### PR TITLE
SNOW-3352686: Support XML inferSchema=False

### DIFF
--- a/src/snowflake/snowpark/_internal/xml_schema_inference.py
+++ b/src/snowflake/snowpark/_internal/xml_schema_inference.py
@@ -126,16 +126,18 @@ def _infer_primitive_type(text: str) -> DataType:
 def infer_type(
     value: Optional[str],
     ignore_surrounding_whitespace: bool = False,
-    null_value: str = "",
+    string_types_only: bool = False,
 ) -> DataType:
     """
     Infer the DataType from a single string value.
-    Normalizes *value*, checks for null / empty / null_value, then delegates
+    Normalizes *value*, checks for null / empty, then delegates
     to :func:`_infer_primitive_type`.
     """
     text = _normalize_text(value, ignore_surrounding_whitespace)
-    if text is None or text == null_value or text == "":
+    if text is None or text == "":
         return NullType()
+    if string_types_only:
+        return StringType()
     return _infer_primitive_type(text)
 
 
@@ -144,10 +146,10 @@ def infer_element_schema(
     attribute_prefix: str = "_",
     exclude_attributes: bool = False,
     value_tag: str = "_VALUE",
-    null_value: str = "",
     ignore_surrounding_whitespace: bool = False,
     ignore_namespace: bool = False,
     is_root: bool = True,
+    string_types_only: bool = False,
 ) -> DataType:
     """
     Infer the schema (DataType) from a parsed XML Element.
@@ -161,13 +163,17 @@ def infer_element_schema(
       Spark treats these differently: at root level, self-closing attribute-only
       elements do NOT get _VALUE. At child level, they always get _VALUE
       (NullType -> StringType after canonicalization).
+
+    string_types_only: When True, all leaf types are StringType (inferSchema=false).
     """
     children = list(element)
     has_attributes = bool(element.attrib) and not exclude_attributes
 
     # Case: leaf element with no attributes -> infer from text content
     if not children and not has_attributes:
-        return infer_type(element.text, ignore_surrounding_whitespace, null_value)
+        return infer_type(
+            element.text, ignore_surrounding_whitespace, string_types_only
+        )
 
     # This element will become a StructType
     # Use a dict to track field names and types (for array detection)
@@ -179,7 +185,9 @@ def infer_element_schema(
         for attr_name, attr_value in element.attrib.items():
             prefixed_name = f"{attribute_prefix}{attr_name}"
             attr_type = infer_type(
-                attr_value, ignore_surrounding_whitespace, null_value
+                attr_value,
+                ignore_surrounding_whitespace,
+                string_types_only,
             )
             if prefixed_name not in name_to_type:
                 field_order.append(prefixed_name)
@@ -203,7 +211,9 @@ def infer_element_schema(
             if not child_children and not child_has_attrs:
                 # Leaf element
                 child_type = infer_type(
-                    child.text, ignore_surrounding_whitespace, null_value
+                    child.text,
+                    ignore_surrounding_whitespace,
+                    string_types_only,
                 )
             else:
                 # Non-leaf element: recurse into inferObject
@@ -212,10 +222,10 @@ def infer_element_schema(
                     attribute_prefix=attribute_prefix,
                     exclude_attributes=exclude_attributes,
                     value_tag=value_tag,
-                    null_value=null_value,
                     ignore_surrounding_whitespace=ignore_surrounding_whitespace,
                     ignore_namespace=ignore_namespace,
                     is_root=False,
+                    string_types_only=string_types_only,
                 )
 
             # When child_has_attrs is True, the recursive infer_element_schema call
@@ -227,8 +237,10 @@ def infer_element_schema(
 
         # Handle mixed content: text + child elements
         text = _normalize_text(element.text, ignore_surrounding_whitespace)
-        if text is not None and text != null_value and text.strip() != "":
-            text_type = _infer_primitive_type(text)
+        if text is not None and text.strip() != "":
+            text_type = (
+                StringType() if string_types_only else _infer_primitive_type(text)
+            )
             if value_tag not in name_to_type:
                 field_order.append(value_tag)
             add_or_update_type(name_to_type, value_tag, text_type, value_tag)
@@ -240,8 +252,10 @@ def infer_element_schema(
         #     to StringType later). This covers cases like self-closing
         #     <edition year="2023" format="Hardcover"/>.
         text = _normalize_text(element.text, ignore_surrounding_whitespace)
-        if text is not None and text != null_value and text != "":
-            text_type = _infer_primitive_type(text)
+        if text is not None and text != "":
+            text_type = (
+                StringType() if string_types_only else _infer_primitive_type(text)
+            )
             if value_tag not in name_to_type:
                 field_order.append(value_tag)
             add_or_update_type(name_to_type, value_tag, text_type, value_tag)
@@ -499,10 +513,10 @@ def infer_schema_for_xml_range(
     attribute_prefix: str,
     exclude_attributes: bool,
     value_tag: str,
-    null_value: str,
     charset: str,
     ignore_surrounding_whitespace: bool,
     chunk_size: int = DEFAULT_CHUNK_SIZE,
+    string_types_only: bool = False,
 ) -> Optional[StructType]:
     """
     Infer the merged XML schema for all records within a byte range.
@@ -596,9 +610,9 @@ def infer_schema_for_xml_range(
                 attribute_prefix=attribute_prefix,
                 exclude_attributes=exclude_attributes,
                 value_tag=value_tag,
-                null_value=null_value,
                 ignore_surrounding_whitespace=ignore_surrounding_whitespace,
                 ignore_namespace=ignore_namespace,
+                string_types_only=string_types_only,
             )
 
             if not isinstance(record_schema, StructType):
@@ -646,10 +660,10 @@ class XMLSchemaInference:
         attribute_prefix: str,
         exclude_attributes: bool,
         value_tag: str,
-        null_value: str,
         charset: str,
         ignore_surrounding_whitespace: bool,
         file_size: int,
+        string_types_only: bool = False,
     ):
         """
         Infer XML schema for a byte-range partition of the file.
@@ -664,10 +678,10 @@ class XMLSchemaInference:
             attribute_prefix: Prefix for attribute names.
             exclude_attributes: Whether to exclude attributes.
             value_tag: Tag name for the value column.
-            null_value: Value to treat as null.
             charset: Character encoding of the XML file.
             ignore_surrounding_whitespace: Whether to strip whitespace from values.
             file_size: Size of the file in bytes (provided by the client via LS).
+            string_types_only: When True, all leaf types inferred as StringType.
         """
         if not file_size or file_size <= 0:
             yield ("",)
@@ -699,9 +713,9 @@ class XMLSchemaInference:
             attribute_prefix=attribute_prefix,
             exclude_attributes=exclude_attributes,
             value_tag=value_tag,
-            null_value=null_value,
             charset=charset,
             ignore_surrounding_whitespace=ignore_surrounding_whitespace,
+            string_types_only=string_types_only,
         )
 
         yield (

--- a/src/snowflake/snowpark/dataframe_reader.py
+++ b/src/snowflake/snowpark/dataframe_reader.py
@@ -1506,7 +1506,9 @@ class DataFrameReader:
             _suppress_local_package_warnings=True,
         )
 
-    def _infer_schema_for_xml(self, path: str) -> Optional[StructType]:
+    def _infer_schema_for_xml(
+        self, path: str, string_types_only: bool = False
+    ) -> Optional[StructType]:
         schema_udtf = self._register_xml_udtf(
             XML_SCHEMA_INFERENCE_FILE_PATH,
             "XMLSchemaInference",
@@ -1535,7 +1537,6 @@ class DataFrameReader:
         attribute_prefix = self._cur_options.get("ATTRIBUTEPREFIX", "_")
         exclude_attributes = self._cur_options.get("EXCLUDEATTRIBUTES", False)
         value_tag = self._cur_options.get("VALUETAG", "_VALUE")
-        null_value = self._cur_options.get("NULL_IF", "")
         charset = self._cur_options.get("CHARSET", "utf-8")
         ignore_surrounding_whitespace = self._cur_options.get(
             "IGNORESURROUNDINGWHITESPACE", False
@@ -1555,10 +1556,10 @@ class DataFrameReader:
                 lit(attribute_prefix),
                 lit(exclude_attributes),
                 lit(value_tag),
-                lit(null_value),
                 lit(charset),
                 lit(ignore_surrounding_whitespace),
                 lit(file_size),
+                lit(string_types_only),
             )
         )
 
@@ -1701,12 +1702,11 @@ class DataFrameReader:
 
         xml_inferred_schema = None
         if format == "XML" and XML_ROW_TAG_STRING in self._cur_options:
-            if (
-                context._is_snowpark_connect_compatible_mode
-                and not self._user_schema
-                and self._cur_options.get("INFER_SCHEMA", True)
-            ):
-                xml_inferred_schema = self._infer_schema_for_xml(path)
+            if context._is_snowpark_connect_compatible_mode and not self._user_schema:
+                string_types_only = not self._cur_options.get("INFER_SCHEMA", True)
+                xml_inferred_schema = self._infer_schema_for_xml(
+                    path, string_types_only
+                )
                 if xml_inferred_schema is not None:
                     self._xml_inferred_schema = xml_inferred_schema
                     schema = [

--- a/tests/integ/test_xml_infer_schema.py
+++ b/tests/integ/test_xml_infer_schema.py
@@ -718,29 +718,6 @@ def test_infer_mixed_content(session):
     assert len(result) == 2
 
 
-# ─── inferSchema=false keeps all strings ────────────────────────────────────
-
-
-@pytest.mark.parametrize(
-    "staged_key, row_tag, expected_count",
-    [
-        ("primitives", "ROW", 1),
-        ("nested_object", "book", 2),
-        ("unbalanced_types", "ROW", 2),
-    ],
-)
-def test_infer_schema_false_all_strings(session, staged_key, row_tag, expected_count):
-    """inferSchema=false → all fields are variant/string columns."""
-    df = (
-        session.read.option("rowTag", row_tag)
-        .option("inferSchema", False)
-        .xml(f"@{tmp_stage_name}/{_staged_files[staged_key]}")
-    )
-    assert df._all_variant_cols is True
-    result = df.collect()
-    assert len(result) == expected_count
-
-
 # ─── Resource file: xml_infer_types.xml ─────────────────────────────────────
 
 
@@ -1070,32 +1047,6 @@ def test_read_xml_attribute_value_infer_schema(session):
     assert pub5 == {"_VALUE": None, "_country": None, "_language": None}
 
 
-# ─── inferSchema vs inferSchema=false comparison ────────────────────────────
-
-
-@pytest.mark.parametrize(
-    "staged_file, row_tag",
-    [
-        ("xml_infer_types.xml", "item"),
-        (RES_BOOKS_XML, "book"),
-        (RES_BOOKS2_XML, "book"),
-    ],
-)
-def test_infer_vs_no_infer_column_count(session, staged_file, row_tag):
-    """inferSchema produces typed columns; no inferSchema produces variant columns."""
-    df_infer = session.read.option("rowTag", row_tag).xml(
-        f"@{tmp_stage_name}/{staged_file}"
-    )
-    df_no_infer = (
-        session.read.option("rowTag", row_tag)
-        .option("inferSchema", False)
-        .xml(f"@{tmp_stage_name}/{staged_file}")
-    )
-    assert df_infer._all_variant_cols is False
-    assert df_no_infer._all_variant_cols is True
-    assert df_infer.count() == df_no_infer.count()
-
-
 # ─── samplingRatio tests ─────────────────────────────────────────────────────
 
 
@@ -1187,3 +1138,102 @@ def test_infer_schema_use_leaf_row_tag(session):
     )
     assert df.count() == 2
     assert "_VALUE" in [f.name for f in df.schema.fields] or len(df.schema.fields) == 1
+
+
+# ─── inferSchema=False ──────────────────────────────
+
+
+def _assert_all_leaves_string(dt):
+    if isinstance(dt, StructType):
+        for f in dt.fields:
+            _assert_all_leaves_string(f.datatype)
+    elif isinstance(dt, ArrayType):
+        _assert_all_leaves_string(dt.element_type)
+    else:
+        assert isinstance(
+            dt, StringType
+        ), f"Expected StringType leaf, got {type(dt).__name__}"
+
+
+@pytest.mark.parametrize(
+    "res_file, row_tag, extra_opts, expected_count, expected_variant_cols",
+    [
+        (RES_BOOKS2_XML, "book", {}, 2, {"editions", "reviews"}),
+        (
+            RES_DK_TRACE_XML,
+            "eqTrace:event",
+            {"ignoreNamespace": False},
+            5,
+            {
+                "eqtrace:equipment-cycle-status-changed",
+                "eqtrace:event-descriptor-list",
+                "eqtrace:interchanged",
+                "eqtrace:location-id",
+                "eqtrace:placement-at-industry-planned",
+                "eqtrace:reporting-detail",
+                "eqtrace:tag-name-list",
+                "eqtrace:waybill-applied",
+            },
+        ),
+        (RES_DBLP_XML, "mastersthesis", {}, 6, {"ee"}),
+        (RES_DBLP_XML, "incollection", {}, 6, {"author", "ee"}),
+        (RES_BOOKS_ATTR_VAL_XML, "book", {}, 5, {"publisher"}),
+        (RES_BOOKS_XML, "book", {}, 12, set()),
+        ("xml_infer_types.xml", "item", {}, 3, {"price", "tags", "specs", "rating"}),
+        ("primitives", "ROW", {}, 1, set()),
+        ("nested_object", "book", {}, 2, {"info"}),
+        ("unbalanced_types", "ROW", {}, 2, set()),
+    ],
+)
+def test_infer_schema_false_resource_files(
+    session, res_file, row_tag, extra_opts, expected_count, expected_variant_cols
+):
+    """inferSchema=False on resource files: complex fields stay VariantType,
+    scalar fields become StringType, all inferred leaves are StringType."""
+    reader_false = session.read.option("rowTag", row_tag).option("inferSchema", False)
+    for k, v in extra_opts.items():
+        reader_false = reader_false.option(k, v)
+    file_name = _staged_files.get(res_file, res_file)
+    path = f"@{tmp_stage_name}/{file_name}"
+
+    df = reader_false.xml(path)
+
+    assert df._all_variant_cols is False
+    assert len(df.collect()) == expected_count
+
+    types = _schema_types(df)
+    for field_name, type_cls in types.items():
+        if field_name in expected_variant_cols:
+            assert (
+                type_cls == VariantType
+            ), f"{field_name}: expected VariantType, got {type_cls.__name__}"
+        else:
+            assert (
+                type_cls == StringType
+            ), f"{field_name}: expected StringType, got {type_cls.__name__}"
+
+    schema_false = reader_false._xml_inferred_schema
+    assert schema_false is not None
+    _assert_all_leaves_string(schema_false)
+
+
+def test_user_schema_takes_precedence_over_infer_schema(session):
+    """User schema overrides inference regardless of inferSchema value."""
+    user_schema = StructType(
+        [
+            StructField("_id", LongType()),
+            StructField("author", StringType()),
+            StructField("title", StringType()),
+        ]
+    )
+    path = f"@{tmp_stage_name}/{RES_BOOKS2_XML}"
+    for infer in (True, False):
+        df = (
+            session.read.option("rowTag", "book")
+            .option("inferSchema", infer)
+            .schema(user_schema)
+            .xml(path)
+        )
+        types = _schema_types(df)
+        assert types == {"_id": LongType, "author": StringType, "title": StringType}
+        assert df.count() == 2

--- a/tests/unit/test_xml_schema_inference.py
+++ b/tests/unit/test_xml_schema_inference.py
@@ -113,12 +113,10 @@ def test_normalize_text(text, strip, expected):
     [
         (None, {}),
         ("", {}),
-        ("NULL", {"null_value": "NULL"}),
-        ("  NULL  ", {"ignore_surrounding_whitespace": True, "null_value": "NULL"}),
     ],
 )
 def test_infer_type_null(value, kwargs):
-    """Null/empty/null_value inputs → NullType."""
+    """Null/empty inputs → NullType."""
     assert isinstance(infer_type(value, **kwargs), NullType)
 
 
@@ -225,7 +223,7 @@ def test_infer_type_whitespace_stripped():
         ("<a>42</a>", LongType, {}),
         ("<a></a>", NullType, {}),
         ("<a/>", NullType, {}),
-        ("<a>N/A</a>", NullType, {"null_value": "N/A"}),
+        ("<a>N/A</a>", StringType, {}),
         ("<a>true</a>", BooleanType, {}),
         ("<a>false</a>", BooleanType, {}),
         ("<a>3.14</a>", DoubleType, {}),
@@ -474,9 +472,7 @@ def test_spark_complex_field_value_type_conflict():
           <struct><field>str</field></struct>
         </ROW>""",
     ]
-    merged = _infer_and_merge(
-        records, ignore_surrounding_whitespace=True, null_value=""
-    )
+    merged = _infer_and_merge(records, ignore_surrounding_whitespace=True)
     fm = {f._name: f.datatype for f in canonicalize_type(merged).fields}
     assert isinstance(fm["array"], ArrayType) and isinstance(
         fm["array"].element_type, LongType
@@ -1388,7 +1384,6 @@ def _mock_xml_range(xml_content, row_tag, **kwargs):
             attribute_prefix=kwargs.get("attribute_prefix", "_"),
             exclude_attributes=kwargs.get("exclude_attributes", False),
             value_tag=kwargs.get("value_tag", "_VALUE"),
-            null_value=kwargs.get("null_value", ""),
             charset="utf-8",
             ignore_surrounding_whitespace=kwargs.get(
                 "ignore_surrounding_whitespace", True
@@ -1532,7 +1527,6 @@ def test_infer_range_sampling_ratio_skips():
             attribute_prefix="_",
             exclude_attributes=False,
             value_tag="_VALUE",
-            null_value="",
             charset="utf-8",
             ignore_surrounding_whitespace=True,
         )
@@ -1556,7 +1550,6 @@ def test_infer_range_truncated_tag_handled():
             attribute_prefix="_",
             exclude_attributes=False,
             value_tag="_VALUE",
-            null_value="",
             charset="utf-8",
             ignore_surrounding_whitespace=True,
         )
@@ -1566,7 +1559,7 @@ def test_infer_range_truncated_tag_handled():
 def test_xml_schema_inference_process_empty_results():
     """Cases where process should yield ("",): empty/None file size, invalid worker id, no records."""
     base = ("test.xml",)
-    tail = (1.0, True, "_", False, "_VALUE", "", "utf-8", True)
+    tail = (1.0, True, "_", False, "_VALUE", "utf-8", True)
 
     # empty file (size 0)
     assert list(XMLSchemaInference().process(*base, 1, "row", 0, *tail, 0)) == [("",)]
@@ -1595,7 +1588,7 @@ def test_xml_schema_inference_process_empty_results():
 def test_xml_schema_inference_process_param_defaults():
     """None num_workers defaults to 1; negative worker id defaults to 0."""
     xml_bytes = b"<r><row><a>42</a></row></r>"
-    tail = (1.0, True, "_", False, "_VALUE", "", "utf-8", True)
+    tail = (1.0, True, "_", False, "_VALUE", "utf-8", True)
 
     for num_workers, i in [(None, 0), (1, -1)]:
         mock_file = io.BytesIO(xml_bytes)
@@ -1631,7 +1624,6 @@ def test_xml_schema_inference_process_with_sampling():
                 "_",
                 False,
                 "_VALUE",
-                "",
                 "utf-8",
                 True,
                 len(xml_bytes),
@@ -1664,7 +1656,6 @@ def test_xml_schema_inference_process_multi_worker():
                     "_",
                     False,
                     "_VALUE",
-                    "",
                     "utf-8",
                     True,
                     len(xml_bytes),
@@ -1874,3 +1865,75 @@ def test_infer_xml_map_type_field_names_cleaned():
     assert result.fields[0]._name == "m"
     assert result.fields[0].datatype.key_type.fields[0]._name == "k"
     assert result.fields[0].datatype.value_type.fields[0]._name == "v"
+
+
+# ===========================================================================
+# string_types_only parameter (inferSchema=False)
+# ===========================================================================
+
+
+def test_infer_type_string_types_only():
+    """string_types_only=True: non-empty text → StringType, null/empty → NullType.
+    Spark's inferField returns NullType for empty/self-closing elements before
+    inferFrom is called.  inferFrom returns StringType unconditionally when
+    inferSchema=false."""
+    for val in ("42", "3.14", "true", "2024-01-15", "hello", "N/A"):
+        assert isinstance(infer_type(val, string_types_only=True), StringType), val
+    for val in (None, ""):
+        assert isinstance(infer_type(val, string_types_only=True), NullType), val
+
+
+def test_infer_element_schema_string_types_only():
+    """One complex XML exercises all infer_element_schema codepaths with string_types_only:
+    attributes, nested struct, repeated children (array), mixed content, empty children.
+    Non-empty leaves → StringType; empty leaves → NullType; structural types preserved."""
+    xml_str = """<book id="1">
+        mixed text
+        <title>Test</title>
+        <price>29.99</price>
+        <empty/>
+        <tag>fiction</tag><tag>classic</tag>
+        <info><publisher>Acme</publisher><year>2020</year></info>
+    </book>"""
+    result = infer_element_schema(_xml(xml_str), string_types_only=True)
+    assert isinstance(result, StructType)
+    fm = {f._name: f.datatype for f in result.fields}
+
+    assert isinstance(fm["_id"], StringType)
+    assert isinstance(fm["_VALUE"], StringType)
+    assert isinstance(fm["title"], StringType)
+    assert isinstance(fm["price"], StringType)
+    assert isinstance(fm["empty"], NullType)
+
+    assert isinstance(fm["tag"], ArrayType)
+    assert isinstance(fm["tag"].element_type, StringType)
+
+    assert isinstance(fm["info"], StructType)
+    info_fm = {f._name: f.datatype for f in fm["info"].fields}
+    assert isinstance(info_fm["publisher"], StringType)
+    assert isinstance(info_fm["year"], StringType)
+
+    # Empty element + struct element across records: struct must survive merge
+    records = [
+        "<row><nested><a>1</a><b>2</b></nested></row>",
+        "<row><nested/></row>",
+    ]
+    merged = canonicalize_type(_infer_and_merge(records, string_types_only=True))
+    nested = {f._name: f.datatype for f in merged.fields}["nested"]
+    assert isinstance(nested, StructType), f"Expected StructType, got {type(nested)}"
+
+
+def test_udtf_process_string_types_only():
+    """End-to-end: XMLSchemaInference.process threads string_types_only through
+    infer_schema_for_xml_range → infer_element_schema → infer_type."""
+    xml_bytes = b"<r><row><a>42</a><b>2024-01-15</b><c>true</c></row></r>"
+    tail = (1.0, True, "_", False, "_VALUE", "utf-8", True)
+    mock_file = io.BytesIO(xml_bytes)
+    with patch("snowflake.snowpark.files.SnowflakeFile.open", return_value=mock_file):
+        schema_str = list(
+            XMLSchemaInference().process(
+                "test.xml", 1, "row", 0, *tail, len(xml_bytes), True
+            )
+        )[0][0]
+    assert "string" in schema_str
+    assert "bigint" not in schema_str and "date" not in schema_str


### PR DESCRIPTION
<!---
Please answer these questions before creating your pull request. Thanks!
--->

1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   <!---
   In this section, please add a Snowflake Jira issue number.

   Note that if a corresponding GitHub issue exists, you should still include
   the Snowflake Jira issue number. For example, for GitHub issue
   https://github.com/snowflakedb/snowpark-python/issues/1400, you should
   add "SNOW-1335071" here.
    --->

   Fixes SNOW-3352686

2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
      - [x] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.
   - [x] I acknowledge that I have ensured my changes to be thread-safe. Follow the link for more information: [Thread-safe Developer Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#thread-safe-development)
   - [x] If adding any arguments to public Snowpark APIs or creating new public Snowpark APIs, I acknowledge that I have ensured my changes include AST support. Follow the link for more information: [AST Support Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#ast-abstract-syntax-tree-support-in-snowpark)

3. Please describe how your code solves the related issue.

   Please write a short description of how your code change solves the related issue.

- Add `inferSchema=False` support for XML reads behind the `_is_snowpark_connect_compatible_mode` flag, matching Spark's behavior: the inferred schema preserves the same nested structure (StructType, ArrayType) as `inferSchema=True`, but all leaf types are StringType.
- Remove the unused `null_value` parameter from the schema inference pipeline since Spark does not consult `nullValue` during inference — it is a read-time option handled only in `xml_reader.py`.

Validated in sproc via stage import that inferSchema=False produces all StringType on leaf tags and VariantType on nested schema:
```
alter session set conda_stage_channel_for_testing = 'ADMINDB_MAYLIU.PUBLIC.xml_stage_import';
CREATE OR REPLACE PROCEDURE xml_read_sproc_148_1()
RETURNS STRING
LANGUAGE PYTHON
RUNTIME_VERSION=3.13
PACKAGES=('snowflake-snowpark-python', 'lxml<6')
HANDLER='run'
AS $$
def run(session):
    import snowflake.snowpark.context as context
    results = []
    test_file = "@admindb_mayliu.public.xml_perf/dblp_6kb.xml"

    try:
        context._is_snowpark_connect_compatible_mode = True
        df = session.read.option("rowTag", "mastersthesis").option("inferSchema", False).xml(test_file)
        count = df.count()
        results.append(f"SUCCESS: count={count}")
        results.append(f"SCHEMA: {df.schema}")
        rows = df.collect()
        for row in rows:
            results.append(str(row.as_dict()))
    except Exception as e:
        results.append(f"FAILED: {e}")

    return "\n".join(results)
$$;
CALL xml_read_sproc_148_1();
```

Output:

> SCHEMA: StructType([StructField('"_key"', **StringType**(134217728), nullable=True), StructField('"_mdate"', **StringType**(134217728), nullable=True), StructField('"author"', **StringType**(134217728), nullable=True), StructField('"ee"', **VariantType**(), nullable=True), StructField('"note"', **StringType**(134217728), nullable=True), StructField('"school"', **StringType**(134217728), nullable=True), StructField('"title"', **StringType**(134217728), nullable=True), StructField('"year"', **StringType**(134217728), nullable=True)])