### PR TITLE
NO-SNOW: Fix python 3.14 artifact repository test failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 #### Bug Fixes
 
 - Fixed a bug where CTE optimization incorrectly deduplicated subtrees containing non-deterministic data generation functions (e.g. `uuid_string()`). 
+- Fixed a bug where vectorized UDFs using non-anaconda package repositories did not specify the pandas package by default.
 
 ## 1.49.0 (TBD)
 

--- a/src/snowflake/snowpark/_internal/udf_utils.py
+++ b/src/snowflake/snowpark/_internal/udf_utils.py
@@ -1253,6 +1253,7 @@ def resolve_imports_and_packages(
                     [],
                     artifact_repository=artifact_repository,
                     existing_packages_dict=existing_packages_dict,
+                    include_pandas=is_pandas_udf,
                 )
             )
         elif packages:

--- a/src/snowflake/snowpark/functions.py
+++ b/src/snowflake/snowpark/functions.py
@@ -11945,7 +11945,7 @@ def regr_sxy(y: ColumnOrName, x: ColumnOrName, _emit_ast: bool = True) -> Column
 
         >>> df = session.create_dataframe([[10, 11], [20, 22], [25, None], [30, 35]], schema=["v", "v2"])
         >>> df = df.filter(df["v2"].is_not_null())
-        >>> df.group_by("v").agg(regr_sxy(df["v"], df["v2"]).alias("regr_sxy")).collect()
+        >>> df.group_by("v").agg(regr_sxy(df["v"], df["v2"]).alias("regr_sxy")).sort("v").collect()
         [Row(V=10, REGR_SXY=0.0), Row(V=20, REGR_SXY=0.0), Row(V=30, REGR_SXY=0.0)]
     """
     y_col = _to_col_if_str(y, "regr_sxy")

--- a/tests/integ/test_packaging.py
+++ b/tests/integ/test_packaging.py
@@ -22,7 +22,7 @@ from snowflake.snowpark._internal.packaging_utils import (
 from snowflake.snowpark.functions import call_udf, col, count_distinct, sproc, udf
 from snowflake.snowpark.context import _ANACONDA_SHARED_REPOSITORY
 from snowflake.snowpark.types import DateType, StringType
-from tests.utils import IS_IN_STORED_PROC, TempObjectType, TestFiles, Utils
+from tests.utils import IS_IN_STORED_PROC, TempObjectType, TestFiles, Utils, IS_PY314
 
 pytestmark = pytest.mark.xfail(
     "config.getoption('local_testing_mode', default=False)",
@@ -347,21 +347,23 @@ def test_add_packages_negative(session, caplog):
     assert "InvalidRequirement" in str(ex_info)
 
     session.custom_package_usage_config = {"enabled": True}
-    with patch.object(session, "_is_anaconda_terms_acknowledged", lambda: True):
-        with pytest.raises(RuntimeError, match="Pip failed with return code 1"):
-            session.add_packages("dateutil")
+    # These errors are not raised with Python 3.14 since it uses the pypi repository by default.
+    if not IS_PY314:
+        with patch.object(session, "_is_anaconda_terms_acknowledged", lambda: True):
+            with pytest.raises(RuntimeError, match="Pip failed with return code 1"):
+                session.add_packages("dateutil")
 
-    with patch.object(session, "_is_anaconda_terms_acknowledged", lambda: False):
-        with pytest.raises(RuntimeError, match="Cannot add package dateutil"):
-            session.add_packages("dateutil")
+        with patch.object(session, "_is_anaconda_terms_acknowledged", lambda: False):
+            with pytest.raises(RuntimeError, match="Cannot add package dateutil"):
+                session.add_packages("dateutil")
 
-    # Verify multiple errors can be raised at once
-    with patch.object(session, "_is_anaconda_terms_acknowledged", lambda: False):
-        with pytest.raises(
-            RuntimeError,
-            match="Cannot add package dateutil.*Cannot add package functools",
-        ):
-            session.add_packages("dateutil", "functools")
+        # Verify multiple errors can be raised at once
+        with patch.object(session, "_is_anaconda_terms_acknowledged", lambda: False):
+            with pytest.raises(
+                RuntimeError,
+                match="Cannot add package dateutil.*Cannot add package functools",
+            ):
+                session.add_packages("dateutil", "functools")
 
     with pytest.raises(ValueError, match="is already added"):
         with caplog.at_level(logging.WARNING):
@@ -464,6 +466,10 @@ def test_add_requirements_twice_should_fail_if_packages_are_different(
     IS_IN_STORED_PROC,
     reason="Subprocess calls are not allowed within stored procedures.",
 )
+@pytest.mark.skipif(
+    IS_PY314,
+    reason="Python 3.14 uses pypi repository",
+)
 def test_add_unsupported_requirements_should_fail_if_custom_packages_upload_enabled_not_switched_on(
     session, resources_path
 ):
@@ -518,6 +524,10 @@ def test_add_requirements_artifact_repository(
 @pytest.mark.skipif(
     IS_IN_STORED_PROC,
     reason="Subprocess calls are not allowed within stored procedures.",
+)
+@pytest.mark.skipif(
+    IS_PY314,
+    reason="Python 3.14 uses pypi repository",
 )
 def test_add_unsupported_packages_should_fail_if_custom_packages_upload_enabled_not_switched_on(
     session,
@@ -990,6 +1000,10 @@ def test_add_requirements_unsupported_with_empty_stage_as_cache_path(
 @pytest.mark.skipif(
     IS_IN_STORED_PROC,
     reason="Subprocess calls are not allowed within stored procedures.",
+)
+@pytest.mark.skipif(
+    IS_PY314,
+    reason="Python 3.14 uses pypi repository",
 )
 def test_add_requirements_unsupported_with_cache_path_negative(
     session, resources_path, temporary_stage

--- a/tests/integ/test_session.py
+++ b/tests/integ/test_session.py
@@ -46,7 +46,6 @@ from snowflake.snowpark.session import (
 from tests.utils import (
     IS_IN_STORED_PROC,
     IS_IN_STORED_PROC_LOCALFS,
-    IS_PY314,
     TestFiles,
     Utils,
 )
@@ -1123,9 +1122,5 @@ def test_default_artifact_repository_with_no_db_schema(
         mock_session_parameters,
     ), caplog.at_level(logging.WARNING):
         result = session._get_default_artifact_repository()
-        assert result == (
-            "snowflake.snowpark.pypi_shared_repository"
-            if (IS_PY314 and not local_testing_mode)
-            else _ANACONDA_SHARED_REPOSITORY
-        )
+        assert result == _ANACONDA_SHARED_REPOSITORY
         assert caplog.text.count("Error getting default artifact repository") == 0

--- a/tests/integ/test_session.py
+++ b/tests/integ/test_session.py
@@ -24,6 +24,7 @@ from snowflake.snowpark.types import (
     TimestampTimeZone,
     StringType,
 )
+from snowflake.snowpark.context import _ANACONDA_SHARED_REPOSITORY
 from snowflake.snowpark._internal.utils import (
     TempObjectType,
     get_version,
@@ -45,9 +46,9 @@ from snowflake.snowpark.session import (
 from tests.utils import (
     IS_IN_STORED_PROC,
     IS_IN_STORED_PROC_LOCALFS,
+    IS_PY314,
     TestFiles,
     Utils,
-    EXPECTED_DEFAULT_ARTIFACT_REPOSITORY,
 )
 
 
@@ -1100,7 +1101,9 @@ def test_get_active_sessions_empty():
         assert session_module._get_active_sessions(require_at_least_one=False) == set()
 
 
-def test_default_artifact_repository_with_no_db_schema(session, caplog):
+def test_default_artifact_repository_with_no_db_schema(
+    session, caplog, local_testing_mode
+):
     # The reported customer issue covered by this test (SNOW-3230493) occurs when no schema/database
     # is set and an account locator is used, so we mock schema/db to be empty for this test.
     # Oddly, getting schema and database appear to be fine (for example, schema comes back with
@@ -1120,5 +1123,9 @@ def test_default_artifact_repository_with_no_db_schema(session, caplog):
         mock_session_parameters,
     ), caplog.at_level(logging.WARNING):
         result = session._get_default_artifact_repository()
-        assert result == EXPECTED_DEFAULT_ARTIFACT_REPOSITORY
+        assert (
+            result == "snowflake.snowpark.pypi_shared_repository"
+            if (IS_PY314 and not local_testing_mode)
+            else _ANACONDA_SHARED_REPOSITORY
+        )
         assert caplog.text.count("Error getting default artifact repository") == 0

--- a/tests/integ/test_session.py
+++ b/tests/integ/test_session.py
@@ -42,8 +42,13 @@ from snowflake.snowpark.session import (
     _get_active_session,
     _get_active_sessions,
 )
-from snowflake.snowpark.context import _ANACONDA_SHARED_REPOSITORY
-from tests.utils import IS_IN_STORED_PROC, IS_IN_STORED_PROC_LOCALFS, TestFiles, Utils
+from tests.utils import (
+    IS_IN_STORED_PROC,
+    IS_IN_STORED_PROC_LOCALFS,
+    TestFiles,
+    Utils,
+    EXPECTED_DEFAULT_ARTIFACT_REPOSITORY,
+)
 
 
 @pytest.mark.skipif(
@@ -1115,5 +1120,5 @@ def test_default_artifact_repository_with_no_db_schema(session, caplog):
         mock_session_parameters,
     ), caplog.at_level(logging.WARNING):
         result = session._get_default_artifact_repository()
-        assert result == _ANACONDA_SHARED_REPOSITORY
+        assert result == EXPECTED_DEFAULT_ARTIFACT_REPOSITORY
         assert caplog.text.count("Error getting default artifact repository") == 0

--- a/tests/integ/test_session.py
+++ b/tests/integ/test_session.py
@@ -24,7 +24,6 @@ from snowflake.snowpark.types import (
     TimestampTimeZone,
     StringType,
 )
-from snowflake.snowpark.context import _ANACONDA_SHARED_REPOSITORY
 from snowflake.snowpark._internal.utils import (
     TempObjectType,
     get_version,
@@ -43,12 +42,8 @@ from snowflake.snowpark.session import (
     _get_active_session,
     _get_active_sessions,
 )
-from tests.utils import (
-    IS_IN_STORED_PROC,
-    IS_IN_STORED_PROC_LOCALFS,
-    TestFiles,
-    Utils,
-)
+from snowflake.snowpark.context import _ANACONDA_SHARED_REPOSITORY
+from tests.utils import IS_IN_STORED_PROC, IS_IN_STORED_PROC_LOCALFS, TestFiles, Utils
 
 
 @pytest.mark.skipif(
@@ -1100,9 +1095,7 @@ def test_get_active_sessions_empty():
         assert session_module._get_active_sessions(require_at_least_one=False) == set()
 
 
-def test_default_artifact_repository_with_no_db_schema(
-    session, caplog, local_testing_mode
-):
+def test_default_artifact_repository_with_no_db_schema(session, caplog):
     # The reported customer issue covered by this test (SNOW-3230493) occurs when no schema/database
     # is set and an account locator is used, so we mock schema/db to be empty for this test.
     # Oddly, getting schema and database appear to be fine (for example, schema comes back with

--- a/tests/integ/test_session.py
+++ b/tests/integ/test_session.py
@@ -1123,8 +1123,8 @@ def test_default_artifact_repository_with_no_db_schema(
         mock_session_parameters,
     ), caplog.at_level(logging.WARNING):
         result = session._get_default_artifact_repository()
-        assert (
-            result == "snowflake.snowpark.pypi_shared_repository"
+        assert result == (
+            "snowflake.snowpark.pypi_shared_repository"
             if (IS_PY314 and not local_testing_mode)
             else _ANACONDA_SHARED_REPOSITORY
         )

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -77,6 +77,7 @@ from snowflake.snowpark.types import (
     TimeType,
     VariantType,
 )
+from snowflake.snowpark.context import _ANACONDA_SHARED_REPOSITORY
 
 IS_WINDOWS = platform.system() == "Windows"
 IS_MACOS = platform.system() == "Darwin"
@@ -104,6 +105,14 @@ STRUCTURED_TYPE_PARAMETERS = {
     "FORCE_ENABLE_STRUCTURED_TYPES_NATIVE_ARROW_FORMAT",
     "IGNORE_CLIENT_VESRION_IN_STRUCTURED_TYPES_RESPONSE",
 }
+
+IS_PY314 = (sys.version_info.major, sys.version_info.minor) == (3, 14)
+
+EXPECTED_DEFAULT_ARTIFACT_REPOSITORY = (
+    "snowflake.snowpark.pypi_shared_repository"
+    if IS_PY314
+    else _ANACONDA_SHARED_REPOSITORY
+)
 
 
 def current_account(session):

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -77,7 +77,6 @@ from snowflake.snowpark.types import (
     TimeType,
     VariantType,
 )
-from snowflake.snowpark.context import _ANACONDA_SHARED_REPOSITORY
 
 IS_WINDOWS = platform.system() == "Windows"
 IS_MACOS = platform.system() == "Darwin"
@@ -107,12 +106,6 @@ STRUCTURED_TYPE_PARAMETERS = {
 }
 
 IS_PY314 = (sys.version_info.major, sys.version_info.minor) == (3, 14)
-
-EXPECTED_DEFAULT_ARTIFACT_REPOSITORY = (
-    "snowflake.snowpark.pypi_shared_repository"
-    if IS_PY314
-    else _ANACONDA_SHARED_REPOSITORY
-)
 
 
 def current_account(session):


### PR DESCRIPTION
<!---
Please answer these questions before creating your pull request. Thanks!
--->

1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   <!---
   In this section, please add a Snowflake Jira issue number.

   Note that if a corresponding GitHub issue exists, you should still include
   the Snowflake Jira issue number. For example, for GitHub issue
   https://github.com/snowflakedb/snowpark-python/issues/1400, you should
   add "SNOW-1335071" here.
    --->

   Fixes NO-SNOW

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.
   - [x] I acknowledge that I have ensured my changes to be thread-safe. Follow the link for more information: [Thread-safe Developer Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#thread-safe-development)
   - [x] If adding any arguments to public Snowpark APIs or creating new public Snowpark APIs, I acknowledge that I have ensured my changes include AST support. Follow the link for more information: [AST Support Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#ast-abstract-syntax-tree-support-in-snowpark)

3. Please describe how your code solves the related issue.

Apparently, the pypi artifact repository is now the default for Python 3.14 UDFs. This PR updates tests to reflect that.

Also fixes a bug where vectorized UDFs (which explicitly use `pandas` for return types) were not automatically including the `pandas` package during UDF registration for non-conda repositories.

Also also fixes a bug where test_regr_sxy's output was not sorted.