### PR TITLE
NO-SNOW: Bump pandas dependency ceiling to <=2.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@
 - Fixed a bug where CTE optimization incorrectly deduplicated subtrees containing non-deterministic data generation functions (e.g. `uuid_string()`). 
 - Fixed a bug where vectorized UDFs using non-anaconda package repositories did not specify the pandas package by default.
 
+### Snowpark pandas API Updates
+
+#### Dependency Updates
+
+- Updated the supported `pandas` versions to <=2.4 (was previously <=2.3.1).
+
 ## 1.49.0 (TBD)
 
 ### Snowpark Python API Updates

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ PANDAS_REQUIREMENTS = [
 MODIN_REQUIREMENTS = [
     *PANDAS_REQUIREMENTS,
     f"modin{MODIN_DEPENDENCY_VERSION}",
-    "pandas<=2.3.1",
+    "pandas<=2.4",
     "tqdm",  # For progress bars during backend switching
     "ipywidgets",  # For enhanced progress bars in Jupyter notebooks
 ]

--- a/tests/integ/modin/frame/test_select_dtypes.py
+++ b/tests/integ/modin/frame/test_select_dtypes.py
@@ -137,36 +137,47 @@ def test_select_dtypes_duplicate_col_names(include, exclude):
     )
 
 
+# Error message differs slightly across pandas patch versions
+STR_DTYPE_ERROR = r"string dtypes are not allowed, use ('str' or )?'object' instead"
+
+SELECT_DTYPES_INVALID_PARAMS = [
+    ([], [], ValueError, "at least one of include or exclude must be nonempty"),
+    (None, None, ValueError, "at least one of include or exclude must be nonempty"),
+    # python `int` is equivalent to any np.int dtype, but it is fine for an type in
+    # `include` to be a strict subtype of a type in `exclude` or vice versa
+    (int, int, ValueError, "include and exclude overlap"),
+    ([int], ["O", int], ValueError, "include and exclude overlap"),
+    (["O", int], [int], ValueError, "include and exclude overlap"),
+    (int, np.int32, ValueError, "include and exclude overlap"),
+    (int, np.int64, ValueError, "include and exclude overlap"),
+    ("datetime", np.datetime64, ValueError, "include and exclude overlap"),
+    ("O", object, ValueError, "include and exclude overlap"),
+    # string dtypes are prohibited by pandas
+    (str, None, TypeError, STR_DTYPE_ERROR),
+    (None, str, TypeError, STR_DTYPE_ERROR),
+    (
+        "timedelta64[s]",
+        None,
+        ValueError,
+        re.escape(
+            "'timedelta64[s]' is too specific of a frequency, try passing 'timedelta64'"
+        ),
+    ),
+    (
+        None,
+        "timedelta64[s]",
+        ValueError,
+        re.escape(
+            "'timedelta64[s]' is too specific of a frequency, try passing 'timedelta64'"
+        ),
+    ),
+]
+
+
 @pytest.mark.parametrize(
     "include, exclude, exc, exc_match",
-    [
-        ([], [], ValueError, "at least one of include or exclude must be nonempty"),
-        (None, None, ValueError, "at least one of include or exclude must be nonempty"),
-        # python `int` is equivalent to any np.int dtype, but it is fine for an type in
-        # `include` to be a strict subtype of a type in `exclude` or vice versa
-        (int, int, ValueError, "include and exclude overlap"),
-        ([int], ["O", int], ValueError, "include and exclude overlap"),
-        (["O", int], [int], ValueError, "include and exclude overlap"),
-        (int, np.int32, ValueError, "include and exclude overlap"),
-        (int, np.int64, ValueError, "include and exclude overlap"),
-        ("datetime", np.datetime64, ValueError, "include and exclude overlap"),
-        ("O", object, ValueError, "include and exclude overlap"),
-        # string dtypes are prohibited by pandas
-        (str, None, TypeError, "string dtypes are not allowed, use 'object' instead"),
-        (None, str, TypeError, "string dtypes are not allowed, use 'object' instead"),
-        (
-            "timedelta64[s]",
-            None,
-            ValueError,
-            "'timedelta64[s]' is too specific of a frequency, try passing 'timedelta64'",
-        ),
-        (
-            None,
-            "timedelta64[s]",
-            ValueError,
-            "'timedelta64[s]' is too specific of a frequency, try passing 'timedelta64'",
-        ),
-    ],
+    SELECT_DTYPES_INVALID_PARAMS,
+    ids=[f"include_{a[0]}-exclude_{a[1]}" for a in SELECT_DTYPES_INVALID_PARAMS],
 )
 @sql_count_checker(query_count=0)
 def test_select_dtypes_invalid_args(include, exclude, exc, exc_match):
@@ -178,6 +189,6 @@ def test_select_dtypes_invalid_args(include, exclude, exc, exc_match):
         lambda df: df.select_dtypes(include, exclude),
         expect_exception=True,
         expect_exception_type=exc,
-        expect_exception_match=re.escape(exc_match),
+        expect_exception_match=exc_match,
         assert_exception_equal=True,
     )


### PR DESCRIPTION
<!---
Please answer these questions before creating your pull request. Thanks!
--->

1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   <!---
   In this section, please add a Snowflake Jira issue number.

   Note that if a corresponding GitHub issue exists, you should still include
   the Snowflake Jira issue number. For example, for GitHub issue
   https://github.com/snowflakedb/snowpark-python/issues/1400, you should
   add "SNOW-1335071" here.
    --->

   Fixes NO-SNOW

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.
   - [ ] I acknowledge that I have ensured my changes to be thread-safe. Follow the link for more information: [Thread-safe Developer Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#thread-safe-development)
   - [ ] If adding any arguments to public Snowpark APIs or creating new public Snowpark APIs, I acknowledge that I have ensured my changes include AST support. Follow the link for more information: [AST Support Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#ast-abstract-syntax-tree-support-in-snowpark)

3. Please describe how your code solves the related issue.

Fixes some daily job failures on Python 3.14: https://github.com/snowflakedb/snowpark-python/actions/runs/24389179381/job/71230883994

This is apparently caused by some recent changes in uv/meson that causes errors when building pandas 2.3.1: https://github.com/pandas-dev/pandas/issues/65213

We previously pinned the pandas version ceiling to 2.3.1 for modin due to constraints with anaconda (#3688). This is no longer relevant since pandas 2.3.3 is now built in the anaconda channel, and new releases of pandas are now in the 3.x series (which modin does not yet support).