### PR TITLE
NO-SNOW: Add pyarrow to dev dependencies and fix no-pandas test failures

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -66,6 +66,7 @@ DEVELOPMENT_REQUIREMENTS = [
     "snowflake.core>=1.0.0, <2",  # Catalog
     "psutil",  # testing for telemetry
     "lxml",  # used in XML reader unit tests
+    "pyarrow",  # used in dataframe reader tests
 ]
 MODIN_DEVELOPMENT_REQUIREMENTS = [
     # Snowpark pandas 3rd party library testing. Cap the scipy version because

--- a/tests/integ/compiler/test_query_generator.py
+++ b/tests/integ/compiler/test_query_generator.py
@@ -9,7 +9,13 @@ import tempfile
 import os
 import re
 
-import pandas
+try:
+    import pandas
+
+    is_pandas_available = True
+except ImportError:
+    is_pandas_available = False
+
 import pytest
 
 import snowflake.snowpark._internal.analyzer.snowflake_plan as snowflake_plan
@@ -568,6 +574,7 @@ def test_select_alias_identity(session):
     )
 
 
+@pytest.mark.skipif(not is_pandas_available, reason="pandas is required")
 def test_disambiguate_skips_quoted_alias(session):
     # SNOW-3176017: This tests a previous regression in a SnowML pipeline where alias optimization
     # incorrectly removed an alias from """col_0""" (triple-quoted in SQL) to "col_0" (single-quoted).

--- a/tests/notebooks/modin/TimeSeriesTesting.ipynb
+++ b/tests/notebooks/modin/TimeSeriesTesting.ipynb
@@ -346,7 +346,9 @@
     }
    ],
    "source": [
-    "ts.resample(\"2h\").mean()"
+    "# Skipped due to modin bug with pandas 2.3.3: https://github.com/modin-project/modin/issues/7697",
+    "# Cannot install lower versions of pandas 2.3 due to https://github.com/pandas-dev/pandas/issues/65213",
+    "# ts.resample(\"2h\").mean()"
    ]
   },
   {

--- a/tests/notebooks/test_requirements.txt
+++ b/tests/notebooks/test_requirements.txt
@@ -1,4 +1,4 @@
-numpy==1.23.5
+numpy
 pytest<8.0.0
 nbmake
 matplotlib


### PR DESCRIPTION
<!---
Please answer these questions before creating your pull request. Thanks!
--->

1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   <!---
   In this section, please add a Snowflake Jira issue number.

   Note that if a corresponding GitHub issue exists, you should still include
   the Snowflake Jira issue number. For example, for GitHub issue
   https://github.com/snowflakedb/snowpark-python/issues/1400, you should
   add "SNOW-1335071" here.
    --->

   Fixes SNOW-NNNNNNN

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.
   - [ ] I acknowledge that I have ensured my changes to be thread-safe. Follow the link for more information: [Thread-safe Developer Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#thread-safe-development)
   - [ ] If adding any arguments to public Snowpark APIs or creating new public Snowpark APIs, I acknowledge that I have ensured my changes include AST support. Follow the link for more information: [AST Support Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#ast-abstract-syntax-tree-support-in-snowpark)

3. Please describe how your code solves the related issue.

Resolves a failure in the daily job for installations without the pandas extra: https://github.com/snowflakedb/snowpark-python/actions/runs/24500387346/job/71605865416

`test_dataframe_reader_file.py` imports pyarrow directly, which is normally implicitly installed by installing pandas.

`test_query_generator.py` uses pandas to generate parquet files, and did not guard the import of the library.

Skips a failing test in `TimeSeriesTesting.ipynb` due to a bug with modin on pandas 2.3.3: https://github.com/modin-project/modin/issues/7697. Downgrading the pandas version for the test is not an option due to https://github.com/pandas-dev/pandas/issues/65213, so I've elected to skip the test instead.