### PR TITLE
SNOW-3375781: Preserve 1-pass read for SCOS XML user schema performance

### DIFF
--- a/src/snowflake/snowpark/dataframe_reader.py
+++ b/src/snowflake/snowpark/dataframe_reader.py
@@ -1703,7 +1703,14 @@ class DataFrameReader:
 
         xml_inferred_schema = None
         if format == "XML" and XML_ROW_TAG_STRING in self._cur_options:
-            if context._is_snowpark_connect_compatible_mode and not self._user_schema:
+            # Internal flag set by SCOS to skip the inference pass when a user schema
+            # is already present, maintaining 1-pass reading when user schema is provided.
+            skip_inference = self._cur_options.get("_XML_SKIP_INFERENCE", False)
+            if (
+                context._is_snowpark_connect_compatible_mode
+                and not self._user_schema
+                and not skip_inference
+            ):
                 string_types_only = not self._cur_options.get("INFER_SCHEMA", True)
                 xml_inferred_schema = self._infer_schema_for_xml(
                     path, string_types_only

--- a/tests/unit/test_xml_schema_inference.py
+++ b/tests/unit/test_xml_schema_inference.py
@@ -1944,23 +1944,24 @@ def test_udtf_process_string_types_only():
 # ===========================================================================
 
 
-def test_xml_skip_inference_option_prevents_inference_call():
-    s = mock.MagicMock()
-    reader = DataFrameReader(s, _emit_ast=False)
-
-    # _XML_SKIP_INFERENCE=False, should call _infer_schema_for_xml
+@pytest.mark.parametrize("skip_inference", [True, False])
+def test_xml_skip_inference_option(skip_inference):
+    reader = DataFrameReader(mock.MagicMock(), _emit_ast=False)
     reader._cur_options[_dr_mod.XML_ROW_TAG_STRING] = "row"
-    skip = reader._cur_options.get("_XML_SKIP_INFERENCE", False)
-    assert skip is False
-    assert not reader._user_schema
-    should_infer = (not reader._user_schema) and (not skip)
-    assert should_infer is True
+    if skip_inference:
+        reader._cur_options["_XML_SKIP_INFERENCE"] = True
 
-    # set _XML_SKIP_INFERENCE=True, should not call _infer_schema_for_xml
-    reader._cur_options["_XML_SKIP_INFERENCE"] = True
-    with mock.patch.object(reader, "_infer_schema_for_xml") as mock_infer:
-        skip = reader._cur_options.get("_XML_SKIP_INFERENCE", False)
-        should_infer = (not reader._user_schema) and (not skip)
-        assert skip is True
-        assert should_infer is False
-        mock_infer.assert_not_called()
+    with mock.patch.object(
+        reader, "_infer_schema_for_xml", return_value=None
+    ) as mock_infer, mock.patch.object(
+        _dr_mod.context, "_is_snowpark_connect_compatible_mode", True
+    ):
+        try:
+            reader._read_semi_structured_file("@s/f.xml", "XML")
+        except Exception:
+            pass
+
+        if skip_inference:
+            mock_infer.assert_not_called()
+        else:
+            mock_infer.assert_called_once()

--- a/tests/unit/test_xml_schema_inference.py
+++ b/tests/unit/test_xml_schema_inference.py
@@ -1937,3 +1937,30 @@ def test_udtf_process_string_types_only():
         )[0][0]
     assert "string" in schema_str
     assert "bigint" not in schema_str and "date" not in schema_str
+
+
+# ===========================================================================
+# _XML_SKIP_INFERENCE option
+# ===========================================================================
+
+
+def test_xml_skip_inference_option_prevents_inference_call():
+    s = mock.MagicMock()
+    reader = DataFrameReader(s, _emit_ast=False)
+
+    # _XML_SKIP_INFERENCE=False, should call _infer_schema_for_xml
+    reader._cur_options[_dr_mod.XML_ROW_TAG_STRING] = "row"
+    skip = reader._cur_options.get("_XML_SKIP_INFERENCE", False)
+    assert skip is False
+    assert not reader._user_schema
+    should_infer = (not reader._user_schema) and (not skip)
+    assert should_infer is True
+
+    # set _XML_SKIP_INFERENCE=True, should not call _infer_schema_for_xml
+    reader._cur_options["_XML_SKIP_INFERENCE"] = True
+    with mock.patch.object(reader, "_infer_schema_for_xml") as mock_infer:
+        skip = reader._cur_options.get("_XML_SKIP_INFERENCE", False)
+        should_infer = (not reader._user_schema) and (not skip)
+        assert skip is True
+        assert should_infer is False
+        mock_infer.assert_not_called()


### PR DESCRIPTION

<!---
Please answer these questions before creating your pull request. Thanks!
--->

1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   <!---
   In this section, please add a Snowflake Jira issue number.

   Note that if a corresponding GitHub issue exists, you should still include
   the Snowflake Jira issue number. For example, for GitHub issue
   https://github.com/snowflakedb/snowpark-python/issues/1400, you should
   add "SNOW-1335071" here.
    --->

   Fixes SNOW-3375781

2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.
   - [x] I acknowledge that I have ensured my changes to be thread-safe. Follow the link for more information: [Thread-safe Developer Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#thread-safe-development)
   - [x] If adding any arguments to public Snowpark APIs or creating new public Snowpark APIs, I acknowledge that I have ensured my changes include AST support. Follow the link for more information: [AST Support Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#ast-abstract-syntax-tree-support-in-snowpark)

3. Please describe how your code solves the related issue.

   Please write a short description of how your code change solves the related issue.

Add internal `_XML_SKIP_INFERENCE` option to preserve 1-pass read in SCOS XML with user schema.
Snowpark Python now supports XML `inferSchema=False` to produce all StringType columns for leaf tags while preserving nested structures (to be released in v1.50.0). Since SCOS custom-schema turns off inferSchema flag, a 2-pass read would be triggered in Snowpark after release.

This PR serves to preserve the 1-pass read performance in SCOS XML custom-schema scenarios to adhere to Spark behaviors -- no behavioral changes whatsoever, pure performance improvement. The private `_XML_SKIP_INFERENCE` option in SCOS is an internal contract to preserve performance.
Relevant SCOS PR: https://github.com/snowflake-eng/sas/pull/3687