### PR TITLE
SNOW-3061745: Propagate parameter bindings in nested CALL operations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Release History
 
+## 1.51.0 (TBD)
+
+### Snowpark Python API Updates
+
+#### New Features
+
+#### Bug Fixes
+
+- Fixed a bug where using parameter bindings for `CALL` queries issued through `session.sql` would raise an error.
+
 ## 1.50.0 (2026-04-23)
 
 ### Snowpark Python API Updates

--- a/src/snowflake/snowpark/_internal/analyzer/select_statement.py
+++ b/src/snowflake/snowpark/_internal/analyzer/select_statement.py
@@ -672,9 +672,12 @@ class SelectableEntity(Selectable):
 
 @SnowflakePlan.Decorator.wrap_exception
 def _analyze_attributes(
-    sql: str, session: "snowflake.snowpark.session.Session", dataframe_uuid: Optional[str] = None  # type: ignore
+    sql: str,
+    session: "snowflake.snowpark.session.Session",
+    dataframe_uuid: Optional[str] = None,  # type: ignore
+    query_params: Optional[Sequence[Any]] = None,
 ) -> List[Attribute]:
-    return analyze_attributes(sql, session, dataframe_uuid)
+    return analyze_attributes(sql, session, dataframe_uuid, query_params)
 
 
 class SelectSQL(Selectable):
@@ -707,7 +710,7 @@ class SelectSQL(Selectable):
                 self.pre_actions[0].query_id_place_holder
             )
             self._schema_query = analyzer_utils.schema_value_statement(
-                _analyze_attributes(sql, self._session, self._uuid)
+                _analyze_attributes(sql, self._session, self._uuid, query_params=params)
             )  # Change to subqueryable schema query so downstream query plan can describe the SQL
             self._query_param = None
         else:

--- a/src/snowflake/snowpark/_internal/analyzer/select_statement.py
+++ b/src/snowflake/snowpark/_internal/analyzer/select_statement.py
@@ -673,8 +673,8 @@ class SelectableEntity(Selectable):
 @SnowflakePlan.Decorator.wrap_exception
 def _analyze_attributes(
     sql: str,
-    session: "snowflake.snowpark.session.Session",
-    dataframe_uuid: Optional[str] = None,  # type: ignore
+    session: "snowflake.snowpark.session.Session",  # type: ignore
+    dataframe_uuid: Optional[str] = None,
     query_params: Optional[Sequence[Any]] = None,
 ) -> List[Attribute]:
     return analyze_attributes(sql, session, dataframe_uuid, query_params)

--- a/tests/integ/test_bind_variable.py
+++ b/tests/integ/test_bind_variable.py
@@ -9,7 +9,7 @@ import os.path
 import pytest
 
 from snowflake.snowpark import Row
-from snowflake.snowpark._internal.utils import is_in_stored_procedure
+from snowflake.snowpark._internal.utils import TempObjectType, is_in_stored_procedure
 from snowflake.snowpark.exceptions import SnowparkSQLException
 from snowflake.snowpark.functions import col, lit, max, table_function
 from snowflake.snowpark.types import (
@@ -457,3 +457,83 @@ def test_explain(session):
         params=[1, "a", 2, "b"],
     )
     df.explain()
+
+
+@pytest.fixture(scope="module")
+def proc_name(session):
+    """Create a trivial stored procedure that echoes its inputs back."""
+    name = f"{session.get_fully_qualified_current_schema()}.{Utils.random_name_for_temp_object(TempObjectType.PROCEDURE)}"
+    session.sql(
+        f"""
+        CREATE OR REPLACE TEMPORARY PROCEDURE {name}(template VARCHAR, args VARCHAR)
+        RETURNS VARCHAR
+        LANGUAGE SQL
+        AS
+        $$
+        BEGIN
+            RETURN template || ' | ' || args;
+        END;
+        $$
+        """
+    ).collect()
+    return name
+
+
+class TestCallIdentifierBinding:
+    """
+    SNOW-3061745: Bindings in CALL previously were not properly transferred through the expression tree.
+    These previously errored out when a chained operation after `session.sql` triggered a call to
+    `to_subqueryable`, which did not properly populate binding parameters.
+    """
+
+    def test_call_collect(self, session, proc_name):
+        result = session.sql(
+            "CALL identifier(?)(?, to_varchar(parse_json(?)))",
+            params=[proc_name, "tmpl", '{"a": 1}'],
+        ).collect()
+        assert result == [Row('tmpl | {"a":1}')]
+
+    def test_call_select(self, session, proc_name):
+        result = (
+            session.sql(
+                "CALL identifier(?)(?, ?)",
+                params=[proc_name, "tmpl", "args"],
+            )
+            .select("*")
+            .collect()
+        )
+        assert result == [Row("tmpl | args")]
+
+    def test_call_filter(self, session, proc_name):
+        result = (
+            session.sql(
+                "CALL identifier(?)(?, ?)",
+                params=[proc_name, "tmpl", "args"],
+            )
+            .filter("1=1")
+            .collect()
+        )
+        assert result == [Row("tmpl | args")]
+
+    def test_call_sort(self, session, proc_name):
+        result = (
+            session.sql(
+                "CALL identifier(?)(?, ?)",
+                params=[proc_name, "tmpl", "args"],
+            )
+            .sort("$1")
+            .collect()
+        )
+        assert result == [Row("tmpl | args")]
+
+    def test_call_union(self, session, proc_name):
+        df1 = session.sql(
+            "CALL identifier(?)(?, ?)",
+            params=[proc_name, "tmpl1", "args1"],
+        )
+        df2 = session.sql(
+            "CALL identifier(?)(?, ?)",
+            params=[proc_name, "tmpl2", "args2"],
+        )
+        result = df1.union_all(df2).collect()
+        assert result == [Row("tmpl1 | args1"), Row("tmpl2 | args2")]


### PR DESCRIPTION
<!---
Please answer these questions before creating your pull request. Thanks!
--->

1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   <!---
   In this section, please add a Snowflake Jira issue number.

   Note that if a corresponding GitHub issue exists, you should still include
   the Snowflake Jira issue number. For example, for GitHub issue
   https://github.com/snowflakedb/snowpark-python/issues/1400, you should
   add "SNOW-1335071" here.
    --->

   Fixes SNOW-3061745

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.
   - [x] I acknowledge that I have ensured my changes to be thread-safe. Follow the link for more information: [Thread-safe Developer Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#thread-safe-development)
   - [x] If adding any arguments to public Snowpark APIs or creating new public Snowpark APIs, I acknowledge that I have ensured my changes include AST support. Follow the link for more information: [AST Support Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#ast-abstract-syntax-tree-support-in-snowpark)

3. Please describe how your code solves the related issue.

Fixes an issue where DESCRIBE queries for CALL queries with parameter bindings were raising an error. This occurred because internal DESCRIBE calls to `analyze_attributes` were not passing query parameters with certain chained operations.

High-level control flow (generated by cursor):
```
df = session.sql("CALL identifier(?)(?, parse_json(?))", params)
df.select("*")
  │
  ├─ self.column_states
  │    └─ SnowflakePlan._analyze_attributes()     [passes query_params ✓]
  │         └─ _describe_internal(sql, params=[...])
  │              → describeOnly:true, but server EXECUTES the CALL to get schema
  │              → Snowhouse type: CALL
  │              → SP runs, hits 'invalid identifier IDT.STATE'
  │              → But returns result metadata OK (schema determined)
  │
  └─ self.from_.to_subqueryable()
       └─ SelectSQL.__init__(convert_to_select=True)
            └─ _analyze_attributes(sql, session, uuid)  [drops query_params ✗]
                 └─ _describe_internal(sql, params=None)
                      → describeOnly:true, server can't compile without bindings
                      → Snowhouse type: DESCRIBE_QUERY
                      → "Bind variable for object '1' not set"
                      → RAISED TO USER
```