### PR TITLE
fix flatten regression

### DIFF
--- a/src/snowflake/snowpark/_internal/analyzer/select_statement.py
+++ b/src/snowflake/snowpark/_internal/analyzer/select_statement.py
@@ -1603,6 +1603,11 @@ class SelectStatement(Selectable):
         self._session._retrieve_aggregation_function_list()
         can_be_flattened = (
             (not self.flatten_disabled)
+            # Disallow flattening when the current SelectStatement has a
+            # limit or offset clause: WHERE cannot be moved across
+            # LIMIT/OFFSET without changing semantics.
+            and (not self.limit_)
+            and (not self.offset)
             and can_clause_dependent_columns_flatten(
                 derive_dependent_columns(col), self.column_states, "filter"
             )
@@ -1614,7 +1619,6 @@ class SelectStatement(Selectable):
                 )
                 and has_aggregation_function_exp(self.projection)
             )  # sum(col) as new_col, new_col can not be flattened in where clause
-            and not (self.order_by and self.limit_ is not None)
         )
         if can_be_flattened:
             new = copy(self)

--- a/src/snowflake/snowpark/_internal/analyzer/select_statement.py
+++ b/src/snowflake/snowpark/_internal/analyzer/select_statement.py
@@ -1603,13 +1603,18 @@ class SelectStatement(Selectable):
         self._session._retrieve_aggregation_function_list()
         can_be_flattened = (
             (not self.flatten_disabled)
-            # Disallow flattening when the current SelectStatement has a
-            # limit or offset clause: WHERE cannot be moved across
-            # LIMIT/OFFSET without changing semantics.
-            and (not self.limit_)
-            and (not self.offset)
             and can_clause_dependent_columns_flatten(
-                derive_dependent_columns(col), self.column_states, "filter"
+                derive_dependent_columns(col),
+                self.column_states,
+                "filter",
+                # In Snowpark Connect compatible mode, the NEW-column branch
+                # below allows flattening through any subquery. Pass
+                # subquery_has_limit so that branch can still reject
+                # flattening across LIMIT/OFFSET, since WHERE cannot cross
+                # LIMIT/OFFSET without changing semantics.
+                subquery_has_limit_or_offset=(
+                    self.limit_ is not None or self.offset is not None
+                ),
             )
             and not has_data_generator_or_window_function_exp(self.projection)
             and not (
@@ -1619,6 +1624,7 @@ class SelectStatement(Selectable):
                 )
                 and has_aggregation_function_exp(self.projection)
             )  # sum(col) as new_col, new_col can not be flattened in where clause
+            and not (self.order_by and self.limit_ is not None)
         )
         if can_be_flattened:
             new = copy(self)
@@ -2179,6 +2185,7 @@ def can_clause_dependent_columns_flatten(
     dependent_columns: Optional[AbstractSet[str]],
     subquery_column_states: ColumnStateDict,
     clause: Literal["filter", "sort"],
+    subquery_has_limit_or_offset: bool = False,
 ) -> bool:
     assert clause in (
         "filter",
@@ -2221,6 +2228,14 @@ def can_clause_dependent_columns_flatten(
                         context._is_snowpark_connect_compatible_mode
                         and context._snowpark_connect_flatten_select_after_sort
                     ):
+                        return False
+                    # Compatible-mode safety: even though we loosened the
+                    # NEW-column flatten rule above, we must not flatten a
+                    # WHERE across LIMIT/OFFSET on a NEW column — that
+                    # would push the filter in front of the limit and
+                    # change the result set. (Sort has its own
+                    # `not self.limit_` guard at the call site.)
+                    if clause == "filter" and subquery_has_limit_or_offset:
                         return False
 
     return True

--- a/tests/integ/test_simplifier_suite.py
+++ b/tests/integ/test_simplifier_suite.py
@@ -2180,6 +2180,67 @@ def test_sort_not_flattened_on_new_column_with_dollar_or_all_dependency(session)
     Utils.check_answer(df_sorted_dollar, [Row(1, 1), Row(3, 3)])
 
 
+@pytest.mark.parametrize("is_snowpark_connect_compatible_mode", [True, False])
+def test_filter_after_limit_not_flattened_on_new_column(
+    session, monkeypatch, is_snowpark_connect_compatible_mode
+):
+    """Filter on a NEW (aliased) column after LIMIT must not be flattened in
+    front of LIMIT, in either legacy or Snowpark Connect compatible mode.
+    Flattening WHERE across LIMIT changes the result set
+    (``LIMIT n ... WHERE c`` != ``WHERE c LIMIT n``).
+
+    Regression test for the bug introduced by the
+    ``_snowpark_connect_flatten_select_after_sort`` loosening, which allowed
+    filter-through-LIMIT flattening on NEW columns in compatible mode."""
+    if is_snowpark_connect_compatible_mode:
+        import snowflake.snowpark.context as context
+
+        monkeypatch.setattr(context, "_is_snowpark_connect_compatible_mode", True)
+
+    df = session.create_dataframe([(i,) for i in range(10)], schema=["ID"])
+    df1 = (
+        df.select(col("ID").alias("id_a"))
+        .select(col("id_a").alias("id_b"))
+        .limit(5)
+        .filter(col("id_b") > 3)
+    )
+
+    # WHERE must remain OUTSIDE the LIMIT subquery. The SQL must nest so that
+    # LIMIT is applied before WHERE.
+    query = df1.queries["queries"][-1]
+    assert query.upper().rfind("WHERE") > query.upper().rfind(
+        "LIMIT"
+    ), f"WHERE flattened across LIMIT on NEW column: {query}"
+    assert (
+        query.count("SELECT") >= 2
+    ), f"Expected nested SELECT when filtering on NEW column after LIMIT: {query}"
+
+
+def test_filter_on_new_column_without_limit_still_flattens_compat_mode(
+    session, monkeypatch
+):
+    """Sanity check: the Snowpark Connect compatible-mode loosening of
+    filter flattening on NEW columns is still active when there is no
+    LIMIT/OFFSET on the subquery. Only the narrow LIMIT/OFFSET case is
+    blocked by the fix."""
+    import snowflake.snowpark.context as context
+
+    monkeypatch.setattr(context, "_is_snowpark_connect_compatible_mode", True)
+
+    df = session.create_dataframe([(i,) for i in range(10)], schema=["ID"])
+    df1 = (
+        df.select(col("ID").alias("id_a"))
+        .select(col("id_a").alias("id_b"))
+        .filter(col("id_b") > 3)
+    )
+
+    # filter flattened into a single level of projection (no nested SELECT
+    # around a standalone subquery for the filter step).
+    query = df1.queries["queries"][-1]
+    assert "LIMIT" not in query.upper()
+    assert "WHERE" in query.upper(), f"Expected filter to be emitted as WHERE: {query}"
+
+
 def test_window_with_filter(session):
     df = session.create_dataframe([[0], [1]], schema=["A"])
     df = (

--- a/tests/integ/test_simplifier_suite.py
+++ b/tests/integ/test_simplifier_suite.py
@@ -2191,7 +2191,14 @@ def test_filter_after_limit_not_flattened_on_new_column(
 
     Regression test for the bug introduced by the
     ``_snowpark_connect_flatten_select_after_sort`` loosening, which allowed
-    filter-through-LIMIT flattening on NEW columns in compatible mode."""
+    filter-through-LIMIT flattening on NEW columns in compatible mode.
+
+    A small inline ``VALUES`` input preserves insertion order in practice for
+    Snowflake's planner, so with the correct (non-flattened) SQL the LIMIT
+    picks IDs 0..4 and only id=4 survives the filter. With the buggy
+    flattened SQL the filter runs first against IDs 0..9, LIMIT then picks 5
+    of the 6 matching rows, and the result is 5 rows. Asserting an exact
+    single row ``[Row(4)]`` therefore catches the regression."""
     if is_snowpark_connect_compatible_mode:
         import snowflake.snowpark.context as context
 
@@ -2205,8 +2212,7 @@ def test_filter_after_limit_not_flattened_on_new_column(
         .filter(col("id_b") > 3)
     )
 
-    # WHERE must remain OUTSIDE the LIMIT subquery. The SQL must nest so that
-    # LIMIT is applied before WHERE.
+    # (a) WHERE must remain OUTSIDE the LIMIT subquery.
     query = df1.queries["queries"][-1]
     assert query.upper().rfind("WHERE") > query.upper().rfind(
         "LIMIT"
@@ -2214,6 +2220,65 @@ def test_filter_after_limit_not_flattened_on_new_column(
     assert (
         query.count("SELECT") >= 2
     ), f"Expected nested SELECT when filtering on NEW column after LIMIT: {query}"
+
+    # (b) Exact row match -- only id=4 is in the first 5 rows AND > 3.
+    Utils.check_answer(df1, [Row(4)])
+
+
+@pytest.mark.parametrize("is_snowpark_connect_compatible_mode", [True, False])
+def test_filter_after_limit_on_range_matches_spark_semantics(
+    session, monkeypatch, is_snowpark_connect_compatible_mode
+):
+    """Mirror of the original Spark SQL regression workload
+    ``SELECT * FROM (SELECT * FROM range(10) LIMIT 5) WHERE id > 3``.
+
+    ``session.range()`` uses Snowflake's ``GENERATOR``, which makes no
+    ordering guarantees without an ``ORDER BY``. So unlike the VALUES-based
+    variant above we cannot assert an exact row set. We can still assert the
+    invariants that distinguish correct from regressed SQL:
+
+    * correct semantics: ``LIMIT 5`` picks 5 of 0..9 then filter keeps those
+      > 3 -> **row count is 0..5**
+    * regressed (flattened) semantics: filter keeps 4..9 (6 rows), ``LIMIT
+      5`` picks 5 of them -> **row count is always exactly 5**
+
+    So ``count < 5`` (with any ordering of generator output) is a positive
+    signal the fix is working; ``count == 5`` plus ``rows == {4..8}`` would
+    indicate the regression. We also assert every row satisfies the filter
+    predicate and LIMIT is respected as additional invariants."""
+    if is_snowpark_connect_compatible_mode:
+        import snowflake.snowpark.context as context
+
+        monkeypatch.setattr(context, "_is_snowpark_connect_compatible_mode", True)
+
+    df = (
+        session.range(10)
+        .select(col("ID").alias("id_a"))
+        .select(col("id_a").alias("id_b"))
+        .limit(5)
+        .select("*")
+        .filter(col("id_b") > 3)
+        .select(col("id_b").alias("id_c"))
+    )
+
+    query = df.queries["queries"][-1]
+    assert query.upper().rfind("WHERE") > query.upper().rfind(
+        "LIMIT"
+    ), f"WHERE flattened across LIMIT on NEW column: {query}"
+
+    rows = df.collect()
+    # Invariants that hold for correct semantics regardless of GENERATOR order.
+    assert len(rows) <= 5, f"LIMIT not respected: got {len(rows)} rows -> {rows}"
+    assert all(r[0] > 3 for r in rows), f"Row failing predicate id > 3 returned: {rows}"
+    # The buggy flattened SQL always returns exactly 5 rows from {4..8}
+    # regardless of generator ordering, which would violate both of the
+    # assertions below.
+    returned = {r[0] for r in rows}
+    assert returned <= set(range(10)), f"Unexpected value: {rows}"
+    assert not (len(rows) == 5 and returned == {4, 5, 6, 7, 8}), (
+        f"Result matches the buggy flattened semantics (filter-before-LIMIT):"
+        f" {rows}"
+    )
 
 
 def test_filter_on_new_column_without_limit_still_flattens_compat_mode(
@@ -2239,6 +2304,9 @@ def test_filter_on_new_column_without_limit_still_flattens_compat_mode(
     query = df1.queries["queries"][-1]
     assert "LIMIT" not in query.upper()
     assert "WHERE" in query.upper(), f"Expected filter to be emitted as WHERE: {query}"
+
+    # Without LIMIT the result is fully deterministic -> exact check.
+    Utils.check_answer(df1, [Row(4), Row(5), Row(6), Row(7), Row(8), Row(9)], sort=True)
 
 
 def test_window_with_filter(session):

--- a/tests/unit/test_selectable_queries.py
+++ b/tests/unit/test_selectable_queries.py
@@ -227,3 +227,44 @@ def test_can_clause_dependent_columns_flatten_sort_new_dollar_or_all(
         frozenset({'"X"'}), col_states, "sort"
     )
     assert result is False
+
+
+@pytest.mark.parametrize(
+    "compat_mode, flatten_flag, subquery_has_limit_or_offset, expected",
+    [
+        # Legacy mode: NEW column + filter is never flattened, regardless of limit.
+        (False, True, True, False),
+        (False, True, False, False),
+        # Compat mode with kill-switch OFF: falls back to legacy behavior.
+        (True, False, True, False),
+        (True, False, False, False),
+        # Compat mode ON: the loosening from SNOW-2203826 applies, except we
+        # must still block flattening across LIMIT/OFFSET (otherwise WHERE
+        # would move in front of LIMIT and change the result set).
+        (True, True, True, False),
+        (True, True, False, True),
+    ],
+)
+def test_can_clause_dependent_columns_flatten_filter_new_limit(
+    compat_mode, flatten_flag, subquery_has_limit_or_offset, expected, monkeypatch
+):
+    """Filter on a NEW column must not flatten across LIMIT/OFFSET, even when
+    the Snowpark Connect compatible-mode loosening is active."""
+    monkeypatch.setattr(context, "_is_snowpark_connect_compatible_mode", compat_mode)
+    monkeypatch.setattr(
+        context, "_snowpark_connect_flatten_select_after_sort", flatten_flag
+    )
+    col_states = ColumnStateDict()
+    col_states['"X"'] = ColumnState(
+        col_name='"X"',
+        change_state=ColumnChangeState.NEW,
+        state_dict=col_states,
+    )
+
+    result = can_clause_dependent_columns_flatten(
+        frozenset({'"X"'}),
+        col_states,
+        "filter",
+        subquery_has_limit_or_offset=subquery_has_limit_or_offset,
+    )
+    assert result is expected


### PR DESCRIPTION
<!---
Please answer these questions before creating your pull request. Thanks!
--->

1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   <!---
   In this section, please add a Snowflake Jira issue number.

   Note that if a corresponding GitHub issue exists, you should still include
   the Snowflake Jira issue number. For example, for GitHub issue
   https://github.com/snowflakedb/snowpark-python/issues/1400, you should
   add "SNOW-1335071" here.
    --->

   Fixes SNOW-NNNNNNN

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.
   - [ ] I acknowledge that I have ensured my changes to be thread-safe. Follow the link for more information: [Thread-safe Developer Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#thread-safe-development)
   - [ ] If adding any arguments to public Snowpark APIs or creating new public Snowpark APIs, I acknowledge that I have ensured my changes include AST support. Follow the link for more information: [AST Support Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#ast-abstract-syntax-tree-support-in-snowpark)

3. Please describe how your code solves the related issue.

Commit 07689e09c ("Loosen flattening rules for sort and filter") loosened can_clause_dependent_columns_flatten so that, when both _is_snowpark_connect_compatible_mode and _snowpark_connect_flatten_select_after_sort are True, a filter depending on a NEW (e.g. aliased) column in a subquery is allowed to be flattened.
That loosening is correct for sort / select / distinct, but it is unsound for filter across LIMIT/OFFSET. Flattening pushes the WHERE in front of the LIMIT, which changes the result set:
```python
-- Input DataFrame (in Snowpark Connect compatible mode):
src.select(col("ID").alias("id_a"))
  .select(col("id_a").alias("id_b"))
  .limit(5)
  .filter(col("id_b") > 3)
-- Before 07689e09c (correct):            -- After 07689e09c (buggy):
SELECT … WHERE "id_b" > 3                 SELECT … WHERE "id_b" > 3 LIMIT 5
FROM (… LIMIT 5)                          --       ^^^^^ WHERE now applied
                                         --             BEFORE LIMIT
```
Repro SQL on Snowpark Connect: SELECT * FROM (SELECT * FROM range(10) LIMIT 5) WHERE id > 3 used to return [4], now returns [4, 5, 6, 7, 8].

Fix
Narrow the loosening that 07689e09c introduced instead of reverting it. Inside the NEW-column branch of can_clause_dependent_columns_flatten — which is only reachable when both compat-mode flags are True — add a single guard that rejects flattening when clause == "filter" and the subquery has LIMIT or OFFSET:

```python
elif dc_state.change_state == ColumnChangeState.NEW:
  ...
  if not (
      context._is_snowpark_connect_compatible_mode
      and context._snowpark_connect_flatten_select_after_sort
  ):
      return False
  # NEW: WHERE cannot cross LIMIT/OFFSET without changing semantics.
  if clause == "filter" and subquery_has_limit_or_offset:
      return False
```

The helper gains one optional kwarg, subquery_has_limit_or_offset: bool = False, passed in from SelectStatement.filter. SelectStatement.sort already short-circuits on not self.limit_ / not self.offset at the call site, so no change is needed there.

Is this a BCR?
No. Existing Snowpark customers (legacy mode) observe no change in generated SQL. The only behavioral delta is for Snowpark Connect / compatible-mode callers on the exact pattern the bad commit newly enabled — where we are restoring pre-commit semantics.
