### PR TITLE
SNOW-3309660: Fix XML tests to run in Snowfort

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 #### Bug Fixes
 
 - Fixed a bug where using parameter bindings for `CALL` queries issued through `session.sql` would raise an error.
+- Fixed a bug where `StringType` columns from Iceberg tables were not recognized as max-size strings.
 
 ## 1.50.0 (2026-04-23)
 

--- a/src/snowflake/snowpark/_internal/type_utils.py
+++ b/src/snowflake/snowpark/_internal/type_utils.py
@@ -278,7 +278,10 @@ def convert_sf_to_sp_type(
             )
     if column_type_name == "TEXT":
         if internal_size > 0:
-            return StringType(internal_size, internal_size == max_string_size)
+            return StringType(
+                internal_size,
+                internal_size == max_string_size or internal_size == _MAX_ICEBERG_STRING_SIZE,
+            )
         elif internal_size == 0:
             return StringType()
         raise ValueError("Negative value is not a valid input for StringType")

--- a/tests/integ/test_xml_reader_row_tag.py
+++ b/tests/integ/test_xml_reader_row_tag.py
@@ -232,9 +232,11 @@ def test_read_xml_row_tag(
     session, file, row_tag, expected_row_count, expected_column_count
 ):
     df = session.read.option("rowTag", row_tag).xml(f"@{tmp_stage_name}/{file}")
-    result = df.collect()
-    assert len(result) == expected_row_count
-    assert len(result[0]) == expected_column_count
+    # Use count() + len(df.columns) instead of collect() to avoid materializing
+    # large result sets (e.g. 740 rows) that trigger paginated download URLs
+    # unsupported by StoredProcRestfulSession inside a stored procedure.
+    assert df.count() == expected_row_count
+    assert len(df.columns) == expected_column_count
 
 
 def test_read_xml_no_xxe(session):

--- a/tests/unit/test_types.py
+++ b/tests/unit/test_types.py
@@ -53,6 +53,7 @@ from snowflake.snowpark._internal.type_utils import (
     split_top_level_comma_fields,
     type_string_to_type_object,
     find_top_level_colon,
+    _MAX_ICEBERG_STRING_SIZE,
 )
 from snowflake.snowpark.types import (
     ArrayType,
@@ -1042,6 +1043,19 @@ def test_convert_sf_to_sp_type_internal_size():
     snowpark_type = convert_sf_to_sp_type("TEXT", 0, 0, 16777216, 16777216)
     assert isinstance(snowpark_type, StringType)
     assert snowpark_type.length == 16777216
+    assert snowpark_type._is_max_size
+
+    # Iceberg deployments report internal_size=134217728 for max-length strings,
+    # which differs from the regular max_string_size (16777216). This must still
+    # be recognized as a max-size string so that StringType(134217728) == StringType().
+    snowpark_type = convert_sf_to_sp_type("TEXT", 0, 0, _MAX_ICEBERG_STRING_SIZE, 16777216)
+    assert isinstance(snowpark_type, StringType)
+    assert snowpark_type.length == _MAX_ICEBERG_STRING_SIZE
+    assert snowpark_type._is_max_size
+
+    snowpark_type = convert_sf_to_sp_type("TEXT", 0, 0, _MAX_ICEBERG_STRING_SIZE, _MAX_ICEBERG_STRING_SIZE)
+    assert isinstance(snowpark_type, StringType)
+    assert snowpark_type.length == _MAX_ICEBERG_STRING_SIZE
     assert snowpark_type._is_max_size
 
     with pytest.raises(

--- a/tests/unit/test_types.py
+++ b/tests/unit/test_types.py
@@ -1054,6 +1054,7 @@ def test_convert_sf_to_sp_type_internal_size():
     assert isinstance(snowpark_type, StringType)
     assert snowpark_type.length == _MAX_ICEBERG_STRING_SIZE
     assert snowpark_type._is_max_size
+    assert snowpark_type == StringType()
 
     snowpark_type = convert_sf_to_sp_type(
         "TEXT", 0, 0, _MAX_ICEBERG_STRING_SIZE, _MAX_ICEBERG_STRING_SIZE
@@ -1061,6 +1062,7 @@ def test_convert_sf_to_sp_type_internal_size():
     assert isinstance(snowpark_type, StringType)
     assert snowpark_type.length == _MAX_ICEBERG_STRING_SIZE
     assert snowpark_type._is_max_size
+    assert snowpark_type == StringType()
 
     with pytest.raises(
         ValueError, match="Negative value is not a valid input for StringType"


### PR DESCRIPTION
<!---
Please answer these questions before creating your pull request. Thanks!
--->

1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   <!---
   In this section, please add a Snowflake Jira issue number.

   Note that if a corresponding GitHub issue exists, you should still include
   the Snowflake Jira issue number. For example, for GitHub issue
   https://github.com/snowflakedb/snowpark-python/issues/1400, you should
   add "SNOW-1335071" here.
    --->

   Fixes SNOW-3309660

2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.
   - [x] I acknowledge that I have ensured my changes to be thread-safe. Follow the link for more information: [Thread-safe Developer Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#thread-safe-development)
   - [x] If adding any arguments to public Snowpark APIs or creating new public Snowpark APIs, I acknowledge that I have ensured my changes include AST support. Follow the link for more information: [AST Support Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#ast-abstract-syntax-tree-support-in-snowpark)

3. Please describe how your code solves the related issue.

   Please write a short description of how your code change solves the related issue.
- Fix StringType for Iceberg tables: Iceberg tables report a max string size of 134217728, which differs from the regular Snowflake max of 16777216. Previously, `convert_sf_to_sp_type` only checked against the regular max, so Iceberg string columns were returned as `StringType(134217728)` with `_is_max_size=False`, breaking equality with `StringType()`
- Fix XML integration test for stored procedure environments: `test_read_xml_row_tag` used `collect()` to materialize full result sets, which fails inside stored procedures when the result is large enough to trigger paginated download URLs (unsupported by `StoredProcRestfulSession`). Replaced with count() + len(df.columns) to validate row/column counts without materializing the data.