### PR TITLE
NO-SNOW: Fix non-determinism in `TestCallIdentifierBinding::test_call_union` and scoped object naming change

### DIFF
--- a/tests/integ/test_bind_variable.py
+++ b/tests/integ/test_bind_variable.py
@@ -536,4 +536,7 @@ class TestCallIdentifierBinding:
             params=[proc_name, "tmpl2", "args2"],
         )
         result = df1.union_all(df2).collect()
-        assert result == [Row("tmpl1 | args1"), Row("tmpl2 | args2")]
+        assert sorted(result, key=lambda r: r[0]) == [
+            Row("tmpl1 | args1"),
+            Row("tmpl2 | args2"),
+        ]

--- a/tests/integ/test_scoped_temp_objects.py
+++ b/tests/integ/test_scoped_temp_objects.py
@@ -2,6 +2,7 @@
 # Copyright (c) 2012-2025 Snowflake Computing Inc. All rights reserved.
 #
 
+from contextlib import contextmanager
 import pytest
 
 from snowflake.connector.errors import ProgrammingError
@@ -9,6 +10,7 @@ from snowflake.snowpark._internal.utils import (
     TempObjectType,
     random_name_for_temp_object,
 )
+from tests.utils import IS_IN_STORED_PROC
 
 
 @pytest.mark.xfail(
@@ -43,30 +45,37 @@ def test_create_scoped_temp_objects_syntax(session):
         )
     assert "Unsupported feature 'SCOPED_TEMPORARY'." in str(exc)
 
+    # CREATE SCOPED TEMPORARY TABLE previously only worked if the name of the object began with
+    # SNOWPARK_TEMP_. This was changed to only enforce the naming convention if the query is issued
+    # from within a stored procedure.
+
+    @contextmanager
+    def cm():
+        if IS_IN_STORED_PROC:
+            with pytest.raises(ProgrammingError) as exc:
+                yield
+            assert "Unsupported feature 'SCOPED_TEMPORARY'." in str(exc)
+        else:
+            yield
+
     temp_table_name = "temp_table"
-    with pytest.raises(ProgrammingError) as exc:
+    with cm():
         session._run_query(f"create scoped temporary table {temp_table_name} (col int)")
-    assert "Unsupported feature 'SCOPED_TEMPORARY'." in str(exc)
-    with pytest.raises(ProgrammingError) as exc:
+    with cm():
         session._run_query(
             f"create scoped temporary view temp_view as select * from {temp_table_name}"
         )
-    assert "Unsupported feature 'SCOPED_TEMPORARY'." in str(exc)
-    with pytest.raises(ProgrammingError) as exc:
+    with cm():
         session._run_query("create scoped temporary stage temp_stage")
-    assert "Unsupported feature 'SCOPED_TEMPORARY'." in str(exc)
-    with pytest.raises(ProgrammingError) as exc:
+    with cm():
         session._run_query(
             "create scoped temporary function temp_function (arg int) returns int"
         )
-    assert "Unsupported feature 'SCOPED_TEMPORARY'." in str(exc)
-    with pytest.raises(ProgrammingError) as exc:
+    with cm():
         session._run_query(
-            "create scoped temporary function temp_talbe_function (arg int) returns table(col int) as $$ select * from {temp_table_name} $$"
+            f"create scoped temporary function temp_table_function (arg int) returns table(col int) as $$ select col from {temp_table_name} $$"
         )
-    assert "Unsupported feature 'SCOPED_TEMPORARY'." in str(exc)
-    with pytest.raises(ProgrammingError) as exc:
+    with cm():
         session._run_query(
             "create scoped temporary file format temp_file_format type = csv"
         )
-    assert "Unsupported feature 'SCOPED_TEMPORARY'." in str(exc)


### PR DESCRIPTION
<!---
Please answer these questions before creating your pull request. Thanks!
--->

1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   <!---
   In this section, please add a Snowflake Jira issue number.

   Note that if a corresponding GitHub issue exists, you should still include
   the Snowflake Jira issue number. For example, for GitHub issue
   https://github.com/snowflakedb/snowpark-python/issues/1400, you should
   add "SNOW-1335071" here.
    --->

   Fixes SNOW-NNNNNNN

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.
   - [ ] I acknowledge that I have ensured my changes to be thread-safe. Follow the link for more information: [Thread-safe Developer Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#thread-safe-development)
   - [ ] If adding any arguments to public Snowpark APIs or creating new public Snowpark APIs, I acknowledge that I have ensured my changes include AST support. Follow the link for more information: [AST Support Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#ast-abstract-syntax-tree-support-in-snowpark)

3. Please describe how your code solves the related issue.

UNION ALL does not guarantee the ordering of its output, so this test was flaky as a result.

Also fixes `test_scoped_temp_objects.py`, which started failing due to server-side changes relaxing the naming requirements on SCOPED TEMPORARY objects. There is no JIRA associated with this change; use GitHub MCP to search for details if necessary.