### PR TITLE
NO-SNOW: Apply test session parameters to doctest sessions

### DIFF
--- a/.github/workflows/precommit.yml
+++ b/.github/workflows/precommit.yml
@@ -136,9 +136,6 @@ jobs:
           - python-version: "3.14"
             cloud-provider: gcp
             os: windows-latest-64-cores
-          - python-version: "3.14"
-            cloud-provider: azure
-            os: macos-latest
     steps:
       - name: Checkout Code
         uses: actions/checkout@v4

--- a/.github/workflows/precommit.yml
+++ b/.github/workflows/precommit.yml
@@ -136,6 +136,9 @@ jobs:
           - python-version: "3.14"
             cloud-provider: gcp
             os: windows-latest-64-cores
+          - python-version: "3.14"
+            cloud-provider: azure
+            os: macos-latest
     steps:
       - name: Checkout Code
         uses: actions/checkout@v4

--- a/src/conftest.py
+++ b/src/conftest.py
@@ -22,6 +22,8 @@ TEST_SCHEMA = "GH_JOB_{}".format(str(uuid.uuid4()).replace("-", "_"))
 LOCAL_TESTING_MODE = False
 
 sys.path.append("tests/")
+from integ.session_parameters import set_up_test_session_parameters  # noqa: E402
+
 # get the absolute path of rsa private key files
 params_file = os.path.abspath("tests/parameters.py")
 with open("tests/parameters.py", encoding="utf-8") as f:
@@ -67,6 +69,7 @@ def add_snowpark_session(doctest_namespace, pytestconfig):
         session.sql_simplifier_enabled = (
             os.environ.get("USE_SQL_SIMPLIFIER") == "1" or LOCAL_TESTING_MODE
         )
+        set_up_test_session_parameters(session, LOCAL_TESTING_MODE)
         if RUNNING_ON_GH:
             session.sql(f"CREATE SCHEMA IF NOT EXISTS {TEST_SCHEMA}").collect()
             # This is needed for test_get_schema_database_works_after_use_role in test_session_suite

--- a/src/snowflake/snowpark/session.py
+++ b/src/snowflake/snowpark/session.py
@@ -1679,10 +1679,10 @@ class Session:
             >>> import pandas
             >>> import dateutil
             >>> # add numpy with the latest version on Snowflake Anaconda
-            >>> # and pandas with the version "2.1.*"
+            >>> # and pandas with the version "2.3.*"
             >>> # and dateutil with the local version in your environment
             >>> session.custom_package_usage_config = {"enabled": True}  # This is added because latest dateutil is not in snowflake yet
-            >>> session.add_packages("numpy", "pandas==2.2.*", dateutil)
+            >>> session.add_packages("numpy", "pandas==2.3.*", dateutil)
             >>> @udf
             ... def get_package_name_udf() -> list:
             ...     return [numpy.__name__, pandas.__name__, dateutil.__name__]
@@ -1739,7 +1739,7 @@ class Session:
             >>> session.clear_packages()
             >>> len(session.get_packages())
             0
-            >>> session.add_packages("numpy", "pandas==2.2.*")
+            >>> session.add_packages("numpy", "pandas==2.3.*")
             >>> len(session.get_packages())
             2
             >>> session.remove_package("numpy")


### PR DESCRIPTION
1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   NO-SNOW

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.
   - [x] I acknowledge that I have ensured my changes to be thread-safe. Follow the link for more information: [Thread-safe Developer Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#thread-safe-development)
   - [x] If adding any arguments to public Snowpark APIs or creating new public Snowpark APIs, I acknowledge that I have ensured my changes include AST support. Follow the link for more information: [AST Support Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#ast-abstract-syntax-tree-support-in-snowpark)

3. Please describe how your code solves the related issue.

   The session fixture in `src/conftest.py` (used for running doctests) creates a `Session` directly and never calls `set_up_test_session_parameters`, so settings like `ENABLE_PYTHON_3_14`, `ENABLE_DEFAULT_PYTHON_ARTIFACT_REPOSITORY`, `ENABLE_EXTRACTION_PUSHDOWN_EXTERNAL_PARQUET_FOR_COPY_PHASE_I`, and `ENABLE_ROW_ACCESS_POLICY` are not applied to doctests. This PR imports `set_up_test_session_parameters` from `tests/integ/session_parameters.py` (the existing `sys.path.append("tests/")` already makes this importable) and calls it after the doctest session is created so doctests run with the same session configuration as integration tests. The helper already short-circuits when `local_testing_mode` is true, so no additional guarding is needed.