### PR TITLE
SNOW-3473261: Add Iceberg tag time travel via version_tag

### DIFF
--- a/src/snowflake/snowpark/_internal/utils.py
+++ b/src/snowflake/snowpark/_internal/utils.py
@@ -2102,34 +2102,34 @@ class TimeTravelConfig(NamedTuple):
 
         Note on escaping: string-valued parameters (``statement``,
         ``stream``, ``version_tag``, ``timestamp``) are embedded inside
-        single-quoted SQL literals. We double any embedded ``'`` to the
-        Snowflake-standard ``''`` escape sequence before interpolation
-        so a value like ``release_'s`` produces ``'release_''s'``
-        rather than breaking SQL or opening an injection surface
-        (e.g. ``'); DROP TABLE foo; --``). Numeric parameters
+        single-quoted SQL literals via the existing ``str_to_sql``
+        helper in ``analyzer.datatype_mapper`` so embedded ``'``, ``\\``
+        and newline characters are properly escaped. This keeps the
+        emission consistent with the rest of Snowpark Python's SQL
+        generation and avoids both broken SQL and injection surface
+        (e.g. ``x'); DROP TABLE foo; --``). Numeric parameters
         (``offset``, ``version``) are not quoted and don't need
         escaping.
-        """
 
-        def _quote(value: str) -> str:
-            # Snowflake's SQL string-literal escape is doubled single
-            # quotes; backslashes have no special meaning in
-            # single-quoted literals here, so we don't need to escape
-            # those.
-            return "'" + str(value).replace("'", "''") + "'"
+        ``str_to_sql`` is imported lazily here because
+        ``analyzer.datatype_mapper`` imports from this module at top
+        level — same pattern used elsewhere in this file for analyzer
+        cross-references.
+        """
+        from snowflake.snowpark._internal.analyzer.datatype_mapper import str_to_sql
 
         clause = f" {self.time_travel_mode.upper()} "
 
         if self.statement is not None:
-            clause += f"(STATEMENT => {_quote(self.statement)})"
+            clause += f"(STATEMENT => {str_to_sql(self.statement)})"
         elif self.offset is not None:
             clause += f"(OFFSET => {self.offset})"
         elif self.stream is not None:
-            clause += f"(STREAM => {_quote(self.stream)})"
+            clause += f"(STREAM => {str_to_sql(self.stream)})"
         elif self.version is not None:
             clause += f"(VERSION => {self.version})"
         elif self.version_tag is not None:
-            clause += f"(VERSION_TAG => {_quote(self.version_tag)})"
+            clause += f"(VERSION_TAG => {str_to_sql(self.version_tag)})"
         elif self.timestamp is not None:
             if self.timestamp_type is not None:
                 timestamp_type = self.timestamp_type.upper()
@@ -2141,9 +2141,9 @@ class TimeTravelConfig(NamedTuple):
                     func_name = "TO_TIMESTAMP_TZ"
                 else:
                     func_name = "TO_TIMESTAMP"
-                clause += f"(TIMESTAMP => {func_name}({_quote(self.timestamp)}))"
+                clause += f"(TIMESTAMP => {func_name}({str_to_sql(self.timestamp)}))"
             else:
-                clause += f"(TIMESTAMP => {_quote(self.timestamp)})"
+                clause += f"(TIMESTAMP => {str_to_sql(self.timestamp)})"
 
         return clause
 

--- a/src/snowflake/snowpark/_internal/utils.py
+++ b/src/snowflake/snowpark/_internal/utils.py
@@ -1956,6 +1956,7 @@ class TimeTravelConfig(NamedTuple):
     timestamp_type: Optional[str] = None
     stream: Optional[str] = None
     version: Optional[int] = None
+    version_tag: Optional[str] = None
 
     @staticmethod
     def validate_and_normalize_params(
@@ -1966,6 +1967,7 @@ class TimeTravelConfig(NamedTuple):
         timestamp_type: Optional[Union[str, "TimestampTimeZone"]] = None,
         stream: Optional[str] = None,
         version: Optional[int] = None,
+        version_tag: Optional[str] = None,
     ) -> Optional["TimeTravelConfig"]:
         """
         Validates and normalizes time travel parameters.
@@ -1988,7 +1990,8 @@ class TimeTravelConfig(NamedTuple):
             ValueError: If parameters are invalid.
         """
         time_travel_arg_count = sum(
-            arg is not None for arg in (statement, offset, timestamp, stream, version)
+            arg is not None
+            for arg in (statement, offset, timestamp, stream, version, version_tag)
         )
 
         # Validate mode
@@ -2023,10 +2026,32 @@ class TimeTravelConfig(NamedTuple):
                 f"'version' must be an int Iceberg snapshot id, got {type(version).__name__}."
             )
 
+        # version_tag (Iceberg tag name, mapped to Snowflake's
+        # ``AT(VERSION_TAG => '<name>')`` grammar) only works with 'at' mode —
+        # Iceberg tag reads are positional (bound to a specific snapshot),
+        # not range-of-time, so ``BEFORE`` has no meaning.
+        if version_tag is not None and time_travel_mode.lower() != "at":
+            raise ValueError(
+                "Iceberg version_tag time travel can only be used with "
+                "time_travel_mode='at', not 'before'."
+            )
+
+        # Validate version_tag type — Iceberg tag names are strings. Empty
+        # strings are invalid.
+        if version_tag is not None:
+            if not isinstance(version_tag, str):
+                raise ValueError(
+                    f"'version_tag' must be a string Iceberg tag name, "
+                    f"got {type(version_tag).__name__}."
+                )
+            if not version_tag:
+                raise ValueError("'version_tag' must be a non-empty Iceberg tag name.")
+
         # Validate exactly one parameter is provided
         if time_travel_arg_count != 1:
             raise ValueError(
-                "Exactly one of 'statement', 'offset', 'timestamp', 'stream', or 'version' must be provided."
+                "Exactly one of 'statement', 'offset', 'timestamp', 'stream', "
+                "'version', or 'version_tag' must be provided."
             )
 
         # Normalize timestamp
@@ -2061,6 +2086,7 @@ class TimeTravelConfig(NamedTuple):
             timestamp_type=timestamp_type,
             stream=stream,
             version=version,
+            version_tag=version_tag,
         )
 
     def generate_sql_clause(self) -> str:
@@ -2069,8 +2095,10 @@ class TimeTravelConfig(NamedTuple):
         Args:
             config: Time travel configuration.
         Returns:
-            SQL clause like " AT (TIMESTAMP => TO_TIMESTAMP_NTZ('...'))" or
-            " AT (VERSION => 1234567890)" for Iceberg snapshot id time travel.
+            SQL clause like " AT (TIMESTAMP => TO_TIMESTAMP_NTZ('...'))",
+            " AT (VERSION => 1234567890)" for Iceberg snapshot id time travel,
+            or " AT (VERSION_TAG => 'release_v1')" for Iceberg tag time
+            travel.
         """
         clause = f" {self.time_travel_mode.upper()} "
 
@@ -2082,6 +2110,8 @@ class TimeTravelConfig(NamedTuple):
             clause += f"(STREAM => '{self.stream}')"
         elif self.version is not None:
             clause += f"(VERSION => {self.version})"
+        elif self.version_tag is not None:
+            clause += f"(VERSION_TAG => '{self.version_tag}')"
         elif self.timestamp is not None:
             if self.timestamp_type is not None:
                 timestamp_type = self.timestamp_type.upper()

--- a/src/snowflake/snowpark/_internal/utils.py
+++ b/src/snowflake/snowpark/_internal/utils.py
@@ -2099,19 +2099,37 @@ class TimeTravelConfig(NamedTuple):
             " AT (VERSION => 1234567890)" for Iceberg snapshot id time travel,
             or " AT (VERSION_TAG => 'release_v1')" for Iceberg tag time
             travel.
+
+        Note on escaping: string-valued parameters (``statement``,
+        ``stream``, ``version_tag``, ``timestamp``) are embedded inside
+        single-quoted SQL literals. We double any embedded ``'`` to the
+        Snowflake-standard ``''`` escape sequence before interpolation
+        so a value like ``release_'s`` produces ``'release_''s'``
+        rather than breaking SQL or opening an injection surface
+        (e.g. ``'); DROP TABLE foo; --``). Numeric parameters
+        (``offset``, ``version``) are not quoted and don't need
+        escaping.
         """
+
+        def _quote(value: str) -> str:
+            # Snowflake's SQL string-literal escape is doubled single
+            # quotes; backslashes have no special meaning in
+            # single-quoted literals here, so we don't need to escape
+            # those.
+            return "'" + str(value).replace("'", "''") + "'"
+
         clause = f" {self.time_travel_mode.upper()} "
 
         if self.statement is not None:
-            clause += f"(STATEMENT => '{self.statement}')"
+            clause += f"(STATEMENT => {_quote(self.statement)})"
         elif self.offset is not None:
             clause += f"(OFFSET => {self.offset})"
         elif self.stream is not None:
-            clause += f"(STREAM => '{self.stream}')"
+            clause += f"(STREAM => {_quote(self.stream)})"
         elif self.version is not None:
             clause += f"(VERSION => {self.version})"
         elif self.version_tag is not None:
-            clause += f"(VERSION_TAG => '{self.version_tag}')"
+            clause += f"(VERSION_TAG => {_quote(self.version_tag)})"
         elif self.timestamp is not None:
             if self.timestamp_type is not None:
                 timestamp_type = self.timestamp_type.upper()
@@ -2123,9 +2141,9 @@ class TimeTravelConfig(NamedTuple):
                     func_name = "TO_TIMESTAMP_TZ"
                 else:
                     func_name = "TO_TIMESTAMP"
-                clause += f"(TIMESTAMP => {func_name}('{self.timestamp}'))"
+                clause += f"(TIMESTAMP => {func_name}({_quote(self.timestamp)}))"
             else:
-                clause += f"(TIMESTAMP => '{self.timestamp}')"
+                clause += f"(TIMESTAMP => {_quote(self.timestamp)})"
 
         return clause
 

--- a/src/snowflake/snowpark/dataframe_reader.py
+++ b/src/snowflake/snowpark/dataframe_reader.py
@@ -161,6 +161,15 @@ def _extract_time_travel_from_options(options: dict) -> dict:
     - Automatically set time_travel_mode to 'at'
       (Iceberg snapshot ids only support ``AT(VERSION => N)``, not ``BEFORE``)
     - Cannot be used with time_travel_mode='before' (raises error)
+
+    Special handling for 'VERSION_TAG' / 'VERSION-TAG' (Iceberg tag name) —
+    both aliases map to the internal ``version_tag`` time travel parameter
+    and emit ``AT(VERSION_TAG => '<name>')`` on the Snowflake side (see
+    Spark Iceberg's ``VERSION AS OF '<tag_name>'`` reader path):
+    - Automatically set time_travel_mode to 'at'
+      (tag reads are positional — bound to a specific snapshot — not
+      range-of-time)
+    - Cannot be used with time_travel_mode='before' (raises error)
     """
     result = {}
     excluded_keys = set()
@@ -209,6 +218,27 @@ def _extract_time_travel_from_options(options: dict) -> dict:
                 f"'{snapshot_id_source}' must be a 64-bit integer Iceberg "
                 f"snapshot id, got {snapshot_id_value!r}."
             )
+        result["time_travel_mode"] = "at"
+
+    # Handle Iceberg tag (``version_tag`` / ``version-tag``). Both aliases
+    # route to the internal ``version_tag`` parameter and emit
+    # ``AT(VERSION_TAG => '<name>')`` server-side. Auto-sets mode='at'.
+    version_tag_value = options.get("VERSION_TAG")
+    version_tag_source = "version_tag"
+    if version_tag_value is None:
+        version_tag_value = options.get("VERSION-TAG")
+        version_tag_source = "version-tag"
+    if version_tag_value is not None:
+        if (
+            "TIME_TRAVEL_MODE" in options
+            and options["TIME_TRAVEL_MODE"].lower() == "before"
+        ):
+            raise ValueError(
+                f"Cannot use '{version_tag_source}' option with "
+                "time_travel_mode='before'. Iceberg tag time travel only "
+                "supports time_travel_mode='at'."
+            )
+        result["version_tag"] = str(version_tag_value)
         result["time_travel_mode"] = "at"
 
     for option_key, param_name in _TIME_TRAVEL_OPTIONS_PARAMS_MAP.items():
@@ -634,11 +664,13 @@ class DataFrameReader:
             ...     .option("offset", -60)                 # This will be IGNORED
             ...     .table("my_table", time_travel_mode="at", offset=-3600))  # Only this is used
         """
-        # ``version`` (Iceberg snapshot id) is intentionally not in the public
-        # signature — it's consumed by Snowpark Connect and may be removed
-        # once a first-class API lands. Accept it through **kwargs so direct
-        # callers can still pass it without us advertising it.
+        # ``version`` (Iceberg snapshot id) and ``version_tag`` (Iceberg tag
+        # name) are intentionally not in the public signature — they are
+        # consumed by Snowpark Connect and may be removed once a first-class
+        # API lands. Accept them through **kwargs so direct callers can
+        # still pass them without us advertising the surface.
         version = kwargs.pop("version", None)
+        version_tag = kwargs.pop("version_tag", None)
         if kwargs:
             raise TypeError(
                 f"table() got unexpected keyword arguments: {sorted(kwargs)}"
@@ -664,13 +696,20 @@ class DataFrameReader:
             if stream is not None:
                 ast.stream.value = stream
 
-        if time_travel_mode is not None or version is not None:
-            # If version is provided without mode, default to 'at' (snapshot ids
-            # only make sense with AT — symmetric with iceberg_tag handling).
+        if (
+            time_travel_mode is not None
+            or version is not None
+            or version_tag is not None
+        ):
+            # If version / version_tag is provided without mode, default to
+            # 'at' — snapshot ids and tag reads only make sense with AT
+            # (symmetric with the as-of-timestamp option handling).
             effective_mode = (
                 time_travel_mode
                 if time_travel_mode
-                else ("at" if version is not None else None)
+                else (
+                    "at" if (version is not None or version_tag is not None) else None
+                )
             )
             time_travel_params = {
                 "time_travel_mode": effective_mode,
@@ -680,6 +719,7 @@ class DataFrameReader:
                 "timestamp_type": timestamp_type,
                 "stream": stream,
                 "version": version,
+                "version_tag": version_tag,
             }
         else:
             # if time_travel_mode is not provided, extract time travel config from options

--- a/src/snowflake/snowpark/session.py
+++ b/src/snowflake/snowpark/session.py
@@ -2773,11 +2773,13 @@ class Session:
             # timestamp_type remains "NTZ" (user's explicit choice respected)
             >>> table2 = session.read.table("my_table", time_travel_mode="at", timestamp=tz_aware, timestamp_type="NTZ")  # doctest: +SKIP
         """
-        # ``version`` (Iceberg snapshot id) is intentionally not in the public
-        # signature — it's consumed by Snowpark Connect and may be removed
-        # once a first-class API lands. Accept it through **kwargs so direct
-        # callers can still pass it without us advertising it.
+        # ``version`` (Iceberg snapshot id) and ``version_tag`` (Iceberg tag
+        # name) are intentionally not in the public signature — they are
+        # consumed by Snowpark Connect and may be removed once a first-class
+        # API lands. Accept them through **kwargs so direct callers can
+        # still pass them without us advertising the surface.
         version = kwargs.pop("version", None)
+        version_tag = kwargs.pop("version_tag", None)
         if kwargs:
             raise TypeError(
                 f"table() got unexpected keyword arguments: {sorted(kwargs)}"
@@ -2820,6 +2822,7 @@ class Session:
             timestamp_type=timestamp_type,
             stream=stream,
             version=version,
+            version_tag=version_tag,
         )
         # Replace API call origin for table
         set_api_call_source(t, "Session.table")

--- a/src/snowflake/snowpark/table.py
+++ b/src/snowflake/snowpark/table.py
@@ -296,11 +296,13 @@ class Table(DataFrame):
         stream: Optional[str] = None,
         **kwargs,
     ) -> None:
-        # ``version`` (Iceberg snapshot id) is intentionally not in the public
-        # signature — it's consumed by Snowpark Connect and may be removed
-        # once a first-class API lands. Accept it through **kwargs so direct
-        # callers can still pass it without us advertising it.
+        # ``version`` (Iceberg snapshot id) and ``version_tag`` (Iceberg tag
+        # name) are intentionally not in the public signature — they are
+        # consumed by Snowpark Connect and may be removed once a first-class
+        # API lands. Accept them through **kwargs so direct callers can
+        # still pass them without us advertising the surface.
         version = kwargs.pop("version", None)
+        version_tag = kwargs.pop("version_tag", None)
         if kwargs:
             raise TypeError(
                 f"Table() got unexpected keyword arguments: {sorted(kwargs)}"
@@ -333,6 +335,7 @@ class Table(DataFrame):
             timestamp_type=timestamp_type,
             stream=stream,
             version=version,
+            version_tag=version_tag,
         )
 
         snowflake_table_plan = SnowflakeTable(

--- a/tests/integ/test_dataframe.py
+++ b/tests/integ/test_dataframe.py
@@ -8423,3 +8423,70 @@ def test_iceberg_snapshot_id_time_travel_dataframe_reader_option(session):
         session.read.option("snapshot-id", snapshot_id).table(table_fqn).collect()
     )
     assert via_kwarg == via_option
+
+
+# ----------------------------------------------------------------------
+# Iceberg tag (``version_tag=``) time travel.
+#
+# TODO(SNOW-3473261): Wire these up to a CI test account that has:
+#   * a Catalog-Linked Database (CLD) such as cldUnity / cldglue, AND
+#   * an unmanaged Iceberg table inside it that exposes a named tag
+#     (e.g. created via ``ALTER TABLE ... CREATE TAG <name>`` on the OSS
+#     Iceberg side, or via the catalog's tag API).
+#
+# Snowflake's ``AT(VERSION_TAG => '<name>')`` is the released tag-only
+# Iceberg time-travel clause (Spark Iceberg's
+# ``VERSION AS OF '<tag_name>'`` for tag reads). Like the snapshot-id
+# surface, it currently requires ``FEATURE_ICEBERG_TIME_TRAVEL`` on the
+# account and is scoped to unmanaged Iceberg tables in CLDs, so these
+# tests are skipped by default and exercised manually against
+# ``sfctest0`` (see ``tests/sas_tests/test_iceberg_version_tag_sample.py``
+# in snowflake-eng/sas for the manual reproducer).
+# ----------------------------------------------------------------------
+@pytest.mark.skip(
+    reason=(
+        "Requires a CLD-linked unmanaged Iceberg table with at least one "
+        "named tag and FEATURE_ICEBERG_TIME_TRAVEL enabled on the account. "
+        "Tested manually; see TODO above."
+    )
+)
+def test_iceberg_version_tag_time_travel_session_table(session):
+    """End-to-end: ``Session.table(..., version_tag='<name>')`` returns the
+    table state at the requested Iceberg tag."""
+    table_fqn = "CLDUNITY.scosschema.snapshot_demo"
+    # Demo table is set up with a tag ``first_load`` pointing at the
+    # earliest snapshot (see sas-side reproducer for the setup script).
+    tag_name = "first_load"
+
+    tagged = session.table(
+        table_fqn, time_travel_mode="at", version_tag=tag_name
+    ).collect()
+    latest = session.table(table_fqn).collect()
+    # Tag reads use the snapshot's schema as it existed at the tag —
+    # row count at an earlier tag should be ≤ current row count, since the
+    # tag is bound to a specific (earlier) snapshot.
+    assert len(tagged) <= len(latest)
+
+
+@pytest.mark.skip(
+    reason=(
+        "Requires a CLD-linked unmanaged Iceberg table with at least one "
+        "named tag and FEATURE_ICEBERG_TIME_TRAVEL enabled on the account. "
+        "Tested manually; see TODO above."
+    )
+)
+def test_iceberg_version_tag_time_travel_dataframe_reader_option(session):
+    """End-to-end: ``session.read.option('version_tag', 'name').table(...)``
+    routes through the Iceberg-compat option alias and produces the same
+    result as the explicit ``version_tag=`` kwarg."""
+    table_fqn = "CLDUNITY.scosschema.snapshot_demo"
+    tag_name = "first_load"
+
+    via_kwarg = session.read.table(
+        table_fqn, time_travel_mode="at", version_tag=tag_name
+    ).collect()
+    via_option = session.read.option("version_tag", tag_name).table(table_fqn).collect()
+    via_hyphen_option = (
+        session.read.option("version-tag", tag_name).table(table_fqn).collect()
+    )
+    assert via_kwarg == via_option == via_hyphen_option

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -1076,16 +1076,16 @@ def test_time_travel_version_tag():
 
 def test_time_travel_string_literal_escaping():
     """SQL literals embedded in time-travel clauses (``statement``,
-    ``stream``, ``version_tag``, string-form ``timestamp``) must
-    escape embedded single quotes by doubling them — Snowflake's
-    standard string-literal escape — so neither malicious nor
-    accidental ``'`` characters in the value can break the SQL
-    text or open an injection surface.
+    ``stream``, ``version_tag``, string-form ``timestamp``) are
+    emitted via ``analyzer.datatype_mapper.str_to_sql``, the shared
+    Snowpark Python helper that escapes embedded single quotes
+    (``'`` → ``''``), backslashes (``\\`` → ``\\\\``), and newlines
+    (``\\n`` → literal ``\\n``) before wrapping in single quotes.
 
     Pinned via this test rather than only at the call sites because
-    the four parameters share one code path (``_quote`` in
-    ``generate_sql_clause``); a regression in any one of them would
-    fail here.
+    the four parameters share one code path in ``generate_sql_clause``;
+    a regression in any one of them — or in ``str_to_sql`` itself —
+    would fail here.
     """
     # version_tag — the parameter introduced by this PR.
     config = TimeTravelConfig.validate_and_normalize_params(
@@ -1128,6 +1128,28 @@ def test_time_travel_string_literal_escaping():
     assert (
         ts_typed.generate_sql_clause()
         == " AT (TIMESTAMP => TO_TIMESTAMP_NTZ('2024-01-01''); --'))"
+    )
+
+    # ``str_to_sql`` also escapes backslashes and newlines — pin that
+    # so a future change to the shared helper that affects
+    # time-travel emission fails here rather than silently producing
+    # broken SQL.
+    config_backslash = TimeTravelConfig.validate_and_normalize_params(
+        time_travel_mode="at", version_tag="weird\\name"
+    )
+    # Single backslash in the input → doubled in the SQL.
+    assert (
+        config_backslash.generate_sql_clause() == " AT (VERSION_TAG => 'weird\\\\name')"
+    )
+
+    config_newline = TimeTravelConfig.validate_and_normalize_params(
+        time_travel_mode="at", version_tag="line1\nline2"
+    )
+    # Real newline in the input → literal ``\n`` two-char sequence in
+    # the SQL text (so the literal stays on one line for Snowflake's
+    # parser).
+    assert (
+        config_newline.generate_sql_clause() == " AT (VERSION_TAG => 'line1\\nline2')"
     )
 
 

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -987,3 +987,130 @@ def test_extract_time_travel_snapshot_id_option():
         ValueError, match="'snapshot-id' must be a 64-bit integer Iceberg snapshot id"
     ):
         _extract_time_travel_from_options({"SNAPSHOT-ID": "not-a-number"})
+
+
+def test_time_travel_version_tag():
+    """Test Iceberg tag time travel via ``version_tag`` parameter.
+
+    Covers SQL generation, validation, and the ``mode='at'``-only restriction.
+    Verifies the SQL matches the Snowflake ``AT(VERSION_TAG => '<name>')``
+    grammar — the released tag-only form of Iceberg time travel (Spark
+    Iceberg's ``VERSION AS OF '<tag_name>'`` for tag reads).
+    """
+    # Valid: typical tag name.
+    config = TimeTravelConfig.validate_and_normalize_params(
+        time_travel_mode="at", version_tag="release_v1"
+    )
+    assert config.version_tag == "release_v1"
+    assert config.time_travel_mode == "at"
+    assert config.generate_sql_clause() == " AT (VERSION_TAG => 'release_v1')"
+
+    # Hyphens and dots in tag names round-trip through the SQL clause —
+    # Iceberg allows these in tag names (e.g. ``snapshot-2023-01-01``,
+    # ``v1.2.3``).
+    config_hyphen = TimeTravelConfig.validate_and_normalize_params(
+        time_travel_mode="at", version_tag="audit-tag"
+    )
+    assert config_hyphen.generate_sql_clause() == " AT (VERSION_TAG => 'audit-tag')"
+
+    config_dotted = TimeTravelConfig.validate_and_normalize_params(
+        time_travel_mode="at", version_tag="snapshot-2023-01-01"
+    )
+    assert (
+        config_dotted.generate_sql_clause()
+        == " AT (VERSION_TAG => 'snapshot-2023-01-01')"
+    )
+
+    # Direct construction also generates the right SQL.
+    direct = TimeTravelConfig(time_travel_mode="AT", version_tag="EOM_JULY_2025")
+    assert direct.generate_sql_clause() == " AT (VERSION_TAG => 'EOM_JULY_2025')"
+
+    # version_tag + 'before' is invalid (tag reads are positional — bound
+    # to a specific snapshot — not range-of-time).
+    with pytest.raises(
+        ValueError,
+        match=r"Iceberg version_tag time travel can only be used with time_travel_mode='at'",
+    ):
+        TimeTravelConfig.validate_and_normalize_params(
+            time_travel_mode="before", version_tag="release_v1"
+        )
+
+    # version_tag + another time-travel param is invalid (must pick one).
+    with pytest.raises(ValueError, match="Exactly one of"):
+        TimeTravelConfig.validate_and_normalize_params(
+            time_travel_mode="at", version_tag="release_v1", offset=-3600
+        )
+    with pytest.raises(ValueError, match="Exactly one of"):
+        TimeTravelConfig.validate_and_normalize_params(
+            time_travel_mode="at",
+            version_tag="release_v1",
+            timestamp="2023-01-01 12:00:00",
+        )
+    # version_tag + version (snapshot-id) is invalid — the user must pick
+    # the tag form or the snapshot-id form, not both.
+    with pytest.raises(ValueError, match="Exactly one of"):
+        TimeTravelConfig.validate_and_normalize_params(
+            time_travel_mode="at",
+            version_tag="release_v1",
+            version=5129038471029384756,
+        )
+
+    # Non-string version_tag is rejected.
+    with pytest.raises(
+        ValueError, match="'version_tag' must be a string Iceberg tag name"
+    ):
+        TimeTravelConfig.validate_and_normalize_params(
+            time_travel_mode="at", version_tag=123
+        )
+
+    # Empty version_tag is rejected (Iceberg tag names are non-empty strings).
+    with pytest.raises(ValueError, match="'version_tag' must be a non-empty"):
+        TimeTravelConfig.validate_and_normalize_params(
+            time_travel_mode="at", version_tag=""
+        )
+
+    # version_tag alone (no mode) requires mode (same shape as version=).
+    with pytest.raises(ValueError, match="Must specify time travel mode"):
+        TimeTravelConfig.validate_and_normalize_params(version_tag="release_v1")
+
+
+def test_extract_time_travel_version_tag_option():
+    """Test Iceberg tag option extraction for the reader API.
+
+    Both ``version_tag`` and ``version-tag`` aliases map to the internal
+    ``version_tag`` time-travel parameter and auto-set
+    ``time_travel_mode='at'`` (``AT(VERSION_TAG => '<name>')`` is the only
+    valid form — tag reads are positional).
+    """
+    from snowflake.snowpark.dataframe_reader import _extract_time_travel_from_options
+
+    # Canonical underscore form
+    result = _extract_time_travel_from_options({"VERSION_TAG": "release_v1"})
+    assert result == {"time_travel_mode": "at", "version_tag": "release_v1"}
+
+    # Hyphen form (matches the ``snapshot-id`` style)
+    result = _extract_time_travel_from_options({"VERSION-TAG": "audit-tag"})
+    assert result == {"time_travel_mode": "at", "version_tag": "audit-tag"}
+
+    # Numeric-looking tag names are coerced to string (Iceberg tag names
+    # can be numeric strings).
+    result = _extract_time_travel_from_options({"VERSION_TAG": 42})
+    assert result == {"time_travel_mode": "at", "version_tag": "42"}
+
+    # version_tag + time_travel_mode='before' is rejected
+    with pytest.raises(
+        ValueError,
+        match=r"Cannot use 'version_tag' option with time_travel_mode='before'",
+    ):
+        _extract_time_travel_from_options(
+            {"VERSION_TAG": "release_v1", "TIME_TRAVEL_MODE": "before"}
+        )
+    # Same for the hyphen alias — error message reflects the alias the user
+    # actually typed.
+    with pytest.raises(
+        ValueError,
+        match=r"Cannot use 'version-tag' option with time_travel_mode='before'",
+    ):
+        _extract_time_travel_from_options(
+            {"VERSION-TAG": "release_v1", "TIME_TRAVEL_MODE": "before"}
+        )

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -1074,6 +1074,63 @@ def test_time_travel_version_tag():
         TimeTravelConfig.validate_and_normalize_params(version_tag="release_v1")
 
 
+def test_time_travel_string_literal_escaping():
+    """SQL literals embedded in time-travel clauses (``statement``,
+    ``stream``, ``version_tag``, string-form ``timestamp``) must
+    escape embedded single quotes by doubling them — Snowflake's
+    standard string-literal escape — so neither malicious nor
+    accidental ``'`` characters in the value can break the SQL
+    text or open an injection surface.
+
+    Pinned via this test rather than only at the call sites because
+    the four parameters share one code path (``_quote`` in
+    ``generate_sql_clause``); a regression in any one of them would
+    fail here.
+    """
+    # version_tag — the parameter introduced by this PR.
+    config = TimeTravelConfig.validate_and_normalize_params(
+        time_travel_mode="at", version_tag="release_'s"
+    )
+    assert config.generate_sql_clause() == " AT (VERSION_TAG => 'release_''s')"
+
+    # An attempted injection payload — the closing quote and the
+    # injected DROP must be fully neutralized by the doubled quotes.
+    config_injection = TimeTravelConfig.validate_and_normalize_params(
+        time_travel_mode="at", version_tag="x'); DROP TABLE foo; --"
+    )
+    assert (
+        config_injection.generate_sql_clause()
+        == " AT (VERSION_TAG => 'x''); DROP TABLE foo; --')"
+    )
+
+    # statement — same escape applies (pre-existing pattern hardened
+    # while we're here; raised in PR #4211 review).
+    stmt_config = TimeTravelConfig(time_travel_mode="AT", statement="01a' OR '1'='1")
+    assert (
+        stmt_config.generate_sql_clause() == " AT (STATEMENT => '01a'' OR ''1''=''1')"
+    )
+
+    # stream — same escape applies.
+    stream_config = TimeTravelConfig(time_travel_mode="AT", stream="my_stream'); --")
+    assert stream_config.generate_sql_clause() == " AT (STREAM => 'my_stream''); --')"
+
+    # timestamp (string form, no timestamp_type) — same escape.
+    ts_config = TimeTravelConfig(time_travel_mode="AT", timestamp="2024-01-01'); --")
+    assert ts_config.generate_sql_clause() == " AT (TIMESTAMP => '2024-01-01''); --')"
+
+    # timestamp (with typed TO_TIMESTAMP_*) — same escape inside the
+    # function-call argument.
+    ts_typed = TimeTravelConfig(
+        time_travel_mode="AT",
+        timestamp="2024-01-01'); --",
+        timestamp_type="NTZ",
+    )
+    assert (
+        ts_typed.generate_sql_clause()
+        == " AT (TIMESTAMP => TO_TIMESTAMP_NTZ('2024-01-01''); --'))"
+    )
+
+
 def test_extract_time_travel_version_tag_option():
     """Test Iceberg tag option extraction for the reader API.
 


### PR DESCRIPTION
## Summary

Add Iceberg tag time travel via a ``version_tag=`` parameter that emits
Snowflake's released `AT(VERSION_TAG => '<name>')` clause — the tag-only
form of Iceberg time travel (Spark Iceberg's
`VERSION AS OF '<tag_name>'` for tag reads).

**Scope: tag reads only.** Branch reads are deferred until Snowflake's
unified `VERSION_REF` syntax (which subsumes branch + tag) ships; the
Python kwarg `version_tag` and SQL `VERSION_TAG` keyword match
Snowflake's already-released grammar, so this PR can land independently.

This is the tag-only companion to the merged snapshot-id PR (#4231) and
mirrors that PR's surface decisions point-for-point:

* `version_tag` is **hidden behind `**kwargs`** on `Session.table()`,
  `DataFrameReader.table()`, and `Table.__init__()` — consumed by Snowpark
  Connect, **not** part of the advertised public Snowpark Python surface
  yet. Direct callers can still pass it; the doc page just doesn't list it.
* Reader option aliases `version_tag` and `version-tag` (matching the
  existing `snapshot-id` / `snapshot_id` style). Both auto-set
  `time_travel_mode='at'` since tag reads are positional (bound to a
  specific snapshot), not range-of-time.
* **No AST proto changes.** The field travels through `**kwargs` the
  same way `version=` does — keeps the AST surface minimal and lets the
  monorepo generate any AST coverage later if/when this becomes a
  first-class API.
* **No CHANGELOG entry** — internal kwargs surface, not customer-visible
  (matches PR #4231).

## Validation

* `time_travel_mode='before'` is rejected — tag reads are positional, not
  range-of-time.
* `version_tag` is mutually exclusive with `statement`, `offset`,
  `timestamp`, `stream`, and `version`.
* Non-string and empty `version_tag` values are rejected.
* When provided without a mode, defaults to `'at'` (same shape as
  `version=`).

## Test plan

- [x] Unit tests in `tests/unit/test_utils.py`:
      `test_time_travel_version_tag` (SQL emission, mutual exclusion,
      mode validation, type / empty validation) and
      `test_extract_time_travel_version_tag_option` (canonical +
      hyphen option aliases, before-mode rejection). 17/17 tests in
      `test_utils.py` pass.
- [x] Black 22.3.0 + flake8 + pre-commit clean.
- [ ] Integ tests added under `tests/integ/test_dataframe.py`:
      `test_iceberg_version_tag_time_travel_session_table` and
      `test_iceberg_version_tag_time_travel_dataframe_reader_option`.
      Both are `pytest.mark.skip`'d pending a CI account with a
      CLD-linked unmanaged Iceberg table that has named tags and
      `FEATURE_ICEBERG_TIME_TRAVEL` enabled — same posture as the
      merged snapshot-id integ tests. Manual reproducer lives in
      `snowflake-eng/sas` (`tests/sas_tests/test_iceberg_version_tag_sample.py`).

## Future work

* Add `version_ref=` (or equivalent) once Snowflake ships the unified
  `AT(VERSION_REF => '<name>')` clause that handles both branches and
  tags. At that point `version_tag` can either alias to `version_ref` or
  remain as a tag-specific spelling for clarity.
* Promote both `version=` and `version_tag=` to the public surface once
  the Snowpark Connect consumer is stable.

## Related

* JIRA: [SNOW-3473261](https://snowflakecomputing.atlassian.net/browse/SNOW-3473261)
* Companion PR (merged): #4231 (`version=` for snapshot ids)


[SNOW-3473261]: https://snowflakecomputing.atlassian.net/browse/SNOW-3473261?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ