### PR TITLE
NO-SNOW: Skip bind variable test with SQL simplifier disabled

### DIFF
--- a/tests/integ/test_bind_variable.py
+++ b/tests/integ/test_bind_variable.py
@@ -483,11 +483,23 @@ def proc_name(session):
     IS_IN_STORED_PROC,
     reason="SNOW-3454682: connector issue in stored procedures breaks this test",
 )
+@pytest.mark.skipif(
+    "config.getoption('disable_sql_simplifier', default=False)",
+    reason="Parameters are not properly propagated when the simplifier is disabled (see comment)",
+)
 class TestCallIdentifierBinding:
     """
     SNOW-3061745: Bindings in CALL previously were not properly transferred through the expression tree.
     These previously errored out when a chained operation after `session.sql` triggered a call to
     `to_subqueryable`, which did not properly populate binding parameters.
+
+    This test fails in stored procedures due to a connector bug (SNOW-3454682).
+
+    This test also fails when the SQL simplifier is disabled. When it is enabled, query parameters are
+    propagated in `SnowflakePlan._analyze_attributes` through the parent `source_plan` field, but this
+    field is `None` for plans constructed from raw SQL when the simplifier is disabled. It is possible
+    to retrieve paramters by checking `self.queries[-1]`, but this approach is too brittle to be reliable,
+    as the final query in the list does not necessarily correspond to the query this plan represents.
     """
 
     def test_call_collect(self, session, proc_name):


### PR DESCRIPTION
<!---
Please answer these questions before creating your pull request. Thanks!
--->

1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   <!---
   In this section, please add a Snowflake Jira issue number.

   Note that if a corresponding GitHub issue exists, you should still include
   the Snowflake Jira issue number. For example, for GitHub issue
   https://github.com/snowflakedb/snowpark-python/issues/1400, you should
   add "SNOW-1335071" here.
    --->

   Fixes SNOW-NNNNNNN

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.
   - [ ] I acknowledge that I have ensured my changes to be thread-safe. Follow the link for more information: [Thread-safe Developer Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#thread-safe-development)
   - [ ] If adding any arguments to public Snowpark APIs or creating new public Snowpark APIs, I acknowledge that I have ensured my changes include AST support. Follow the link for more information: [AST Support Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#ast-abstract-syntax-tree-support-in-snowpark)

3. Please describe how your code solves the related issue.

    `test_bind_variable.py::TestCallIdentifierBinding` fails with the SQL simplifier disabled due to architectural reasons. The only possible fixes are either too fragile or too involved to be worth the effort, so I've elected to skip the test when the simplifier is disabled.