### PR TITLE
fix(types): handle connector >=4.3.0 interval year-month display format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 #### Bug Fixes
 
 - Fixed a bug where `AsyncJob.result("no_result")` sometimes silently returned without raising error for failed queries.
+- Fixed a bug where `INTERVAL YEAR TO MONTH` values with zero months were displayed incorrectly (e.g. `INTERVAL '0-4' YEAR TO MONTH` instead of `INTERVAL '4-0' YEAR TO MONTH`) when using `snowflake-connector-python>=4.3.0`.
 
 #### Improvements
 

--- a/src/snowflake/snowpark/_internal/type_utils.py
+++ b/src/snowflake/snowpark/_internal/type_utils.py
@@ -1764,11 +1764,11 @@ def format_year_month_interval_for_display(
             years = str(int(parts[0]))
             months = str(int(parts[1]))
     else:
-        # Format like "+2" or "-3"
-        if (
-            start_field == YearMonthIntervalType.YEAR
-            and end_field == YearMonthIntervalType.YEAR
-        ):
+        # Format like "+2" or "-3" — a single number without a year-month dash.
+        # When start_field is YEAR the value represents years (connector >=4.3.0
+        # omits the "-0" suffix when months=0). Only treat as months when the
+        # interval type starts at MONTH.
+        if start_field == YearMonthIntervalType.YEAR:
             years = str(int(remaining))
         else:
             months = str(int(remaining))

--- a/tests/unit/test_datatype_mapper.py
+++ b/tests/unit/test_datatype_mapper.py
@@ -16,6 +16,9 @@ from snowflake.snowpark._internal.analyzer.datatype_mapper import (
     to_sql,
     to_sql_no_cast,
 )
+from snowflake.snowpark._internal.type_utils import (
+    format_year_month_interval_for_display,
+)
 from snowflake.snowpark._internal.udf_utils import generate_call_python_sp_sql
 from snowflake.snowpark.types import (
     ArrayType,
@@ -811,102 +814,84 @@ def test_schema_expression():
     )
 
 
-class TestFormatYearMonthIntervalForDisplay:
-    """Tests for format_year_month_interval_for_display.
-
-    Validates correct behavior with both old connector format ('+Y-M' compound)
-    and new connector >=4.3.0 format ('+N' when months=0 or years=0).
-    """
-
-    @pytest.mark.parametrize(
-        "cell, start_field, end_field, expected",
-        [
-            # Compound format (both old and new connector use this when months != 0)
-            (
-                "+1-6",
-                YearMonthIntervalType.YEAR,
-                YearMonthIntervalType.MONTH,
-                "INTERVAL '1-6' YEAR TO MONTH",
-            ),
-            (
-                "-2-3",
-                YearMonthIntervalType.YEAR,
-                YearMonthIntervalType.MONTH,
-                "INTERVAL '-2-3' YEAR TO MONTH",
-            ),
-            (
-                "+0-5",
-                YearMonthIntervalType.YEAR,
-                YearMonthIntervalType.MONTH,
-                "INTERVAL '0-5' YEAR TO MONTH",
-            ),
-            # New connector format: '+N' with no dash when months=0 for YEAR TO MONTH type
-            (
-                "+4",
-                YearMonthIntervalType.YEAR,
-                YearMonthIntervalType.MONTH,
-                "INTERVAL '4-0' YEAR TO MONTH",
-            ),
-            (
-                "-7",
-                YearMonthIntervalType.YEAR,
-                YearMonthIntervalType.MONTH,
-                "INTERVAL '-7-0' YEAR TO MONTH",
-            ),
-            (
-                "+12",
-                YearMonthIntervalType.YEAR,
-                YearMonthIntervalType.MONTH,
-                "INTERVAL '12-0' YEAR TO MONTH",
-            ),
-            # YEAR-only type (both connector versions use '+N' format)
-            (
-                "+4",
-                YearMonthIntervalType.YEAR,
-                YearMonthIntervalType.YEAR,
-                "INTERVAL '4' YEAR",
-            ),
-            (
-                "-1",
-                YearMonthIntervalType.YEAR,
-                YearMonthIntervalType.YEAR,
-                "INTERVAL '-1' YEAR",
-            ),
-            # MONTH-only type (both connector versions use '+N' format)
-            (
-                "+5",
-                YearMonthIntervalType.MONTH,
-                YearMonthIntervalType.MONTH,
-                "INTERVAL '5' MONTH",
-            ),
-            (
-                "-12",
-                YearMonthIntervalType.MONTH,
-                YearMonthIntervalType.MONTH,
-                "INTERVAL '-12' MONTH",
-            ),
-            # Compound format with YEAR-only output (connector returns '+5-0')
-            (
-                "+5-0",
-                YearMonthIntervalType.YEAR,
-                YearMonthIntervalType.YEAR,
-                "INTERVAL '5' YEAR",
-            ),
-            # Compound format with MONTH-only output (connector returns '+0-3')
-            (
-                "+0-3",
-                YearMonthIntervalType.MONTH,
-                YearMonthIntervalType.MONTH,
-                "INTERVAL '3' MONTH",
-            ),
-        ],
+@pytest.mark.parametrize(
+    "cell, start_field, end_field, expected",
+    [
+        (
+            "+1-6",
+            YearMonthIntervalType.YEAR,
+            YearMonthIntervalType.MONTH,
+            "INTERVAL '1-6' YEAR TO MONTH",
+        ),
+        (
+            "-2-3",
+            YearMonthIntervalType.YEAR,
+            YearMonthIntervalType.MONTH,
+            "INTERVAL '-2-3' YEAR TO MONTH",
+        ),
+        (
+            "+0-5",
+            YearMonthIntervalType.YEAR,
+            YearMonthIntervalType.MONTH,
+            "INTERVAL '0-5' YEAR TO MONTH",
+        ),
+        (
+            "+4",
+            YearMonthIntervalType.YEAR,
+            YearMonthIntervalType.MONTH,
+            "INTERVAL '4-0' YEAR TO MONTH",
+        ),
+        (
+            "-7",
+            YearMonthIntervalType.YEAR,
+            YearMonthIntervalType.MONTH,
+            "INTERVAL '-7-0' YEAR TO MONTH",
+        ),
+        (
+            "+12",
+            YearMonthIntervalType.YEAR,
+            YearMonthIntervalType.MONTH,
+            "INTERVAL '12-0' YEAR TO MONTH",
+        ),
+        (
+            "+4",
+            YearMonthIntervalType.YEAR,
+            YearMonthIntervalType.YEAR,
+            "INTERVAL '4' YEAR",
+        ),
+        (
+            "-1",
+            YearMonthIntervalType.YEAR,
+            YearMonthIntervalType.YEAR,
+            "INTERVAL '-1' YEAR",
+        ),
+        (
+            "+5",
+            YearMonthIntervalType.MONTH,
+            YearMonthIntervalType.MONTH,
+            "INTERVAL '5' MONTH",
+        ),
+        (
+            "-12",
+            YearMonthIntervalType.MONTH,
+            YearMonthIntervalType.MONTH,
+            "INTERVAL '-12' MONTH",
+        ),
+        (
+            "+5-0",
+            YearMonthIntervalType.YEAR,
+            YearMonthIntervalType.YEAR,
+            "INTERVAL '5' YEAR",
+        ),
+        (
+            "+0-3",
+            YearMonthIntervalType.MONTH,
+            YearMonthIntervalType.MONTH,
+            "INTERVAL '3' MONTH",
+        ),
+    ],
+)
+def test_format_year_month_interval_for_display(cell, start_field, end_field, expected):
+    assert (
+        format_year_month_interval_for_display(cell, start_field, end_field) == expected
     )
-    def test_format_year_month_interval(self, cell, start_field, end_field, expected):
-        from snowflake.snowpark._internal.type_utils import (
-            format_year_month_interval_for_display,
-        )
-
-        assert (
-            format_year_month_interval_for_display(cell, start_field, end_field)
-            == expected
-        )

--- a/tests/unit/test_datatype_mapper.py
+++ b/tests/unit/test_datatype_mapper.py
@@ -809,3 +809,104 @@ def test_schema_expression():
         schema_expression(DayTimeIntervalType(), False)
         == "INTERVAL '1 01:01:01.0001' DAY TO SECOND"
     )
+
+
+class TestFormatYearMonthIntervalForDisplay:
+    """Tests for format_year_month_interval_for_display.
+
+    Validates correct behavior with both old connector format ('+Y-M' compound)
+    and new connector >=4.3.0 format ('+N' when months=0 or years=0).
+    """
+
+    @pytest.mark.parametrize(
+        "cell, start_field, end_field, expected",
+        [
+            # Compound format (both old and new connector use this when months != 0)
+            (
+                "+1-6",
+                YearMonthIntervalType.YEAR,
+                YearMonthIntervalType.MONTH,
+                "INTERVAL '1-6' YEAR TO MONTH",
+            ),
+            (
+                "-2-3",
+                YearMonthIntervalType.YEAR,
+                YearMonthIntervalType.MONTH,
+                "INTERVAL '-2-3' YEAR TO MONTH",
+            ),
+            (
+                "+0-5",
+                YearMonthIntervalType.YEAR,
+                YearMonthIntervalType.MONTH,
+                "INTERVAL '0-5' YEAR TO MONTH",
+            ),
+            # New connector format: '+N' with no dash when months=0 for YEAR TO MONTH type
+            (
+                "+4",
+                YearMonthIntervalType.YEAR,
+                YearMonthIntervalType.MONTH,
+                "INTERVAL '4-0' YEAR TO MONTH",
+            ),
+            (
+                "-7",
+                YearMonthIntervalType.YEAR,
+                YearMonthIntervalType.MONTH,
+                "INTERVAL '-7-0' YEAR TO MONTH",
+            ),
+            (
+                "+12",
+                YearMonthIntervalType.YEAR,
+                YearMonthIntervalType.MONTH,
+                "INTERVAL '12-0' YEAR TO MONTH",
+            ),
+            # YEAR-only type (both connector versions use '+N' format)
+            (
+                "+4",
+                YearMonthIntervalType.YEAR,
+                YearMonthIntervalType.YEAR,
+                "INTERVAL '4' YEAR",
+            ),
+            (
+                "-1",
+                YearMonthIntervalType.YEAR,
+                YearMonthIntervalType.YEAR,
+                "INTERVAL '-1' YEAR",
+            ),
+            # MONTH-only type (both connector versions use '+N' format)
+            (
+                "+5",
+                YearMonthIntervalType.MONTH,
+                YearMonthIntervalType.MONTH,
+                "INTERVAL '5' MONTH",
+            ),
+            (
+                "-12",
+                YearMonthIntervalType.MONTH,
+                YearMonthIntervalType.MONTH,
+                "INTERVAL '-12' MONTH",
+            ),
+            # Compound format with YEAR-only output (connector returns '+5-0')
+            (
+                "+5-0",
+                YearMonthIntervalType.YEAR,
+                YearMonthIntervalType.YEAR,
+                "INTERVAL '5' YEAR",
+            ),
+            # Compound format with MONTH-only output (connector returns '+0-3')
+            (
+                "+0-3",
+                YearMonthIntervalType.MONTH,
+                YearMonthIntervalType.MONTH,
+                "INTERVAL '3' MONTH",
+            ),
+        ],
+    )
+    def test_format_year_month_interval(self, cell, start_field, end_field, expected):
+        from snowflake.snowpark._internal.type_utils import (
+            format_year_month_interval_for_display,
+        )
+
+        assert (
+            format_year_month_interval_for_display(cell, start_field, end_field)
+            == expected
+        )


### PR DESCRIPTION
## Summary

Fixes incorrect display of YEAR TO MONTH interval values when using `snowflake-connector-python>=4.3.0`.

### Root Cause

`snowflake-connector-python` v4.3.0 changed the string representation of INTERVAL YEAR and INTERVAL MONTH types (see [connector changelog](https://github.com/snowflakedb/snowflake-connector-python/blob/main/DESCRIPTION.md#v430february-122026): "Fix string representation of INTERVAL YEAR and INTERVAL MONTH types").

Previously, the connector always returned compound year-month format (e.g., `+4-0` for 4 years, 0 months). Starting with v4.3.0, when the months component is zero, the connector returns just `+4` (omitting the `-0` suffix).

`format_year_month_interval_for_display` in `type_utils.py` only interpreted a simple `+N` value as years when the type was exactly `INTERVAL YEAR` (`start_field=YEAR, end_field=YEAR`). For `INTERVAL YEAR TO MONTH` (`start_field=YEAR, end_field=MONTH`), the simple `+N` value was incorrectly treated as months, producing:

```
INTERVAL '0-4' YEAR TO MONTH   (wrong: 0 years, 4 months)
```

instead of:

```
INTERVAL '4-0' YEAR TO MONTH   (correct: 4 years, 0 months)
```

### Fix

When `start_field` is `YEAR`, always interpret a simple `+N` value (no dash) as years, regardless of `end_field`. This is correct for:

- **Old connector (<4.3.0)**: always uses compound format `+Y-M`, so the simple-value branch is never reached for YEAR TO MONTH types — no behavioral change.
- **New connector (>=4.3.0)**: uses `+N` when months=0 — now correctly interpreted as years.

### Reproduction

```python
from snowflake.snowpark._internal.type_utils import format_year_month_interval_for_display
from snowflake.snowpark.types import YearMonthIntervalType

# Bug: '+4' with YEAR TO MONTH type treated as 4 months instead of 4 years
result = format_year_month_interval_for_display('+4', YearMonthIntervalType.YEAR, YearMonthIntervalType.MONTH)
# Before: "INTERVAL '0-4' YEAR TO MONTH" (wrong)
# After:  "INTERVAL '4-0' YEAR TO MONTH" (correct)
```

This was discovered via Snowpark Connect (SCOS) CI where `try_multiply(4, INTERVAL '1' YEAR)` produced incorrect output after widening the connector version cap to `<5.0.0`.

## Test plan

- [x] Added parametrized unit tests covering both old compound format and new simple format for all interval subtypes (YEAR, MONTH, YEAR TO MONTH)
- [x] All existing `tests/unit/test_datatype_mapper.py` tests pass

Made with [Cursor](https://cursor.com)