### PR TITLE
SNOW-3494628: Fix indeterministic error reporting for async job no_result

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 #### Bug Fixes
 
+- Fixed a bug where `AsyncJob.result("no_result")` sometimes silently returned without raising error for failed queries.
+
 #### Improvements
 
 - When `Session.reduce_describe_query_enabled` is enabled, fewer DESCRIBE queries are issued when the outer query only projects or renames columns from an inner subquery whose column types are already known.

--- a/src/snowflake/snowpark/async_job.py
+++ b/src/snowflake/snowpark/async_job.py
@@ -427,6 +427,11 @@ class AsyncJob:
                 # If we can advance in ASYNC_RETRY_PATTERN then do so
                 if retry_pattern_pos < (len(ASYNC_RETRY_PATTERN) - 1):
                     retry_pattern_pos += 1
+            # Without this post-loop check, a failed query would silently return None.
+            # The upstream `get_results_from_sfqid` only catches failures already visible
+            # at that single synchronous status check, and no fetch happens in NO_RESULT mode
+            # to trigger the prefetch hook.
+            self._session.connection.get_query_status_throw_if_error(self.query_id)
             result = None
         elif async_result_type == _AsyncResultType.PANDAS:
             result = self._session._conn._to_data_or_iter(

--- a/tests/integ/scala/test_async_job_suite.py
+++ b/tests/integ/scala/test_async_job_suite.py
@@ -457,6 +457,36 @@ def test_create_async_job_negative(session):
         async_job.result()
 
 
+def test_async_job_no_result_raises_on_failed_query(session):
+    # Warm the warehouse so that subsequent iterations are dominated by the race condition
+    session.sql("select 1").collect()
+    iterations = 30
+    silent_none = 0
+    raised = 0
+    sample_exception_text = ""
+
+    for _ in range(iterations):
+        async_job = session.sql("select 1/0").collect_nowait()
+        try:
+            async_job.result("no_result")
+            silent_none += 1
+        except (DatabaseError, SnowparkSQLException) as exc:
+            raised += 1
+            if not sample_exception_text:
+                sample_exception_text = str(exc)
+
+    assert silent_none == 0, (
+        f"AsyncJob.result('no_result') silently returned None for "
+        f"{silent_none}/{iterations} failed division by zero queries. "
+        "All failures must surface as exceptions"
+    )
+    assert raised == iterations
+    assert (
+        "Division by zero" in sample_exception_text
+        or "FAILED_WITH_ERROR" in sample_exception_text
+    ), f"Unexpected exception text: {sample_exception_text!r}"
+
+
 @pytest.mark.skipif(IS_IN_STORED_PROC, reason="caplog is not supported")
 @pytest.mark.parametrize("create_async_job_from_query_id", [True, False])
 def test_get_query_from_async_job(session, create_async_job_from_query_id, caplog):


### PR DESCRIPTION
<!---
Please answer these questions before creating your pull request. Thanks!
--->

1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   <!---
   In this section, please add a Snowflake Jira issue number.

   Note that if a corresponding GitHub issue exists, you should still include
   the Snowflake Jira issue number. For example, for GitHub issue
   https://github.com/snowflakedb/snowpark-python/issues/1400, you should
   add "SNOW-1335071" here.
    --->

   Fixes SNOW-3494628

2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.
   - [x] I acknowledge that I have ensured my changes to be thread-safe. Follow the link for more information: [Thread-safe Developer Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#thread-safe-development)
   - [x] If adding any arguments to public Snowpark APIs or creating new public Snowpark APIs, I acknowledge that I have ensured my changes include AST support. Follow the link for more information: [AST Support Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#ast-abstract-syntax-tree-support-in-snowpark)

3. Please describe how your code solves the related issue.

   Please write a short description of how your code change solves the related issue.
Fix `AsyncJob.result("no_result")` silently returning None for failed queries. The root cause is a race condition: `is_still_running(status)` returns False for both SUCCESS and every terminal failure state, and `NO_RESULT` is the only result type that doesn't trigger the prefetch hook to surface the failure later, so a failure that wasn't visible at the upfront synchronous status check would silently fall through.

Repro steps:
```
    for i in range(30):
        job = session.sql("select 1/0").collect_nowait()
        try:
            job.result("no_result")
            buckets["silent_none"] += 1
        except Exception:
            buckets["raised"] += 1
```
Without the fix, `silent_none` indeterministically returns 6/30 silent failures, exact number varies from run-to-run.