### PR TITLE
docs: clarify JDBC driver source for DataFrameReader.jdbc imports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Release History
 
+## Unreleased
+
+### Snowpark Python API Updates
+
+#### Documentation
+
+- Clarified that the JDBC driver JAR referenced via `udtf_configs.imports` in `DataFrameReader.jdbc()` must be downloaded from the database vendor and uploaded to a Snowflake stage.
+
 ## 1.51.0 (2026-05-18)
 
 ### Snowpark Python API Updates

--- a/src/snowflake/snowpark/dataframe_reader.py
+++ b/src/snowflake/snowpark/dataframe_reader.py
@@ -1894,6 +1894,8 @@ class DataFrameReader:
 
                 - imports (List[str], required): A list of stage file names to import into the UDTF.
                     Please include Jar file of jdbc driver to establish connection to external data source.
+                    Download the driver JAR from the database vendor and upload it to a Snowflake stage
+                    before referencing it here.
 
                 - java_version (int, optional): A integer that indicate the java runtime version of udtf.
                     By default, we use java 17.


### PR DESCRIPTION
Note that the JDBC driver JAR must be downloaded from the database vendor and uploaded to a Snowflake stage before being referenced via udtf_configs.imports.

1. Which Jira issue is this PR addressing?

   N/A — documentation-only clarification (docstring change).

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.
   - [x] I acknowledge that I have ensured my changes to be thread-safe. Follow the link for more information: [Thread-safe Developer Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#thread-safe-development)
   - [x] If adding any arguments to public Snowpark APIs or creating new public Snowpark APIs, I acknowledge that I have ensured my changes include AST support. Follow the link for more information: [AST Support Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#ast-abstract-syntax-tree-support-in-snowpark)

3. Please describe how your code solves the related issue.

   Docstring-only change to the `udtf_configs.imports` parameter description on `DataFrameReader.jdbc()`. Adds a sentence telling users that the JDBC driver JAR is sourced from the database vendor and uploaded by the user to a Snowflake stage. No code-path change; no AST or thread-safety implications.
