### PR TITLE
SNOW-3081273: fix Creating a stored procedure locally results in an unsupported version of cloudpicker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Release History
 
+## 1.52.0 (TBD)
+
+### Snowpark Python API Updates
+
+#### Bug Fixes
+
+- Fixed a bug where `cloudpickle` could not be resolved when registering a Python stored procedure or UDF with `runtime_version='3.13'`.
+
 ## 1.51.0 (2026-05-18)
 
 ### Snowpark Python API Updates

--- a/src/snowflake/snowpark/_internal/udf_utils.py
+++ b/src/snowflake/snowpark/_internal/udf_utils.py
@@ -1276,7 +1276,7 @@ def resolve_imports_and_packages(
                     any(pkg.startswith("cloudpickle") for pkg in packages)
                 )
             resolved_packages = packages + (
-                [f"cloudpickle=={cloudpickle.__version__}"]
+                [f"cloudpickle>={cloudpickle.__version__}"]
                 if not has_cloudpickle
                 else []
             )

--- a/src/snowflake/snowpark/session.py
+++ b/src/snowflake/snowpark/session.py
@@ -2133,7 +2133,7 @@ class Session:
             if isinstance(m, str) and m not in result_dict:
                 res.append(m)
             elif isinstance(m, ModuleType) and m.__name__ not in result_dict:
-                res.append(f"{m.__name__}=={m.__version__}")
+                res.append(f"{m.__name__}>={m.__version__}")
 
         return res
 

--- a/src/snowflake/snowpark/session.py
+++ b/src/snowflake/snowpark/session.py
@@ -2134,7 +2134,10 @@ class Session:
             if isinstance(m, str) and m not in result_dict:
                 res.append(m)
             elif isinstance(m, ModuleType) and m.__name__ not in result_dict:
-                res.append(f"{m.__name__}>={m.__version__}")
+                if m.__name__ == "cloudpickle":
+                    res.append(f"{m.__name__}>={m.__version__}")
+                else:
+                    res.append(f"{m.__name__}=={m.__version__}")
 
         return res
 

--- a/tests/integ/test_stored_procedure.py
+++ b/tests/integ/test_stored_procedure.py
@@ -2736,3 +2736,27 @@ def test_data_source_udtf_ingestion(db_parameters):
             ]
 
         assert normalize(df.collect()) == normalize(oracledb_real_data)
+
+
+@pytest.mark.skipif(IS_IN_STORED_PROC, reason="not supported in stored proc")
+def test_sproc_runtime_313_cloudpickle_ge_spec_compiles_and_executes(session):
+    """Regression test for SNOW-3081273.
+
+    Verifies that a sproc targeting Python 3.13 deploys and executes correctly
+    even when the local cloudpickle version differs from the server-resolved one.
+    The auto-injected cloudpickle>=X spec must satisfy the 3.13 channel.
+    """
+    multiplier = 7
+
+    def multiply(session_: Session, x: int) -> int:
+        return x * multiplier
+
+    sp = session.sproc.register(
+        multiply,
+        return_type=IntegerType(),
+        input_types=[IntegerType()],
+        packages=["snowflake-snowpark-python"],
+        runtime_version="3.13",
+        is_permanent=False,
+    )
+    assert sp(6) == 42

--- a/tests/unit/test_session.py
+++ b/tests/unit/test_session.py
@@ -4,6 +4,7 @@
 import json
 import logging
 import os
+import types
 from typing import Optional
 from unittest import mock
 from unittest.mock import MagicMock
@@ -880,14 +881,16 @@ def test_retrieve_aggregation_function_list_handles_sync_error():
         ctx._aggregation_function_set = original_agg_set
 
 
-def test_get_req_identifiers_list_uses_ge_for_modules(mock_server_connection):
-    """Modules (cloudpickle) are injected with >= not == to allow the server to
-    resolve a compatible version for the target runtime (SNOW-3081273)."""
+def test_get_req_identifiers_list_cloudpickle_only_uses_ge(mock_server_connection):
+    """Only cloudpickle is injected with >= to allow runtime-compatible resolution."""
     import cloudpickle as cp
 
     session = Session(mock_server_connection)
-    result = session._get_req_identifiers_list([cp], {})
-    assert result == [f"cloudpickle>={cp.__version__}"]
+    dummy_module = types.ModuleType("dummy_module")
+    dummy_module.__version__ = "1.2.3"
+
+    result = session._get_req_identifiers_list([cp, dummy_module], {})
+    assert result == [f"cloudpickle>={cp.__version__}", "dummy_module==1.2.3"]
     assert f"cloudpickle=={cp.__version__}" not in result
 
 

--- a/tests/unit/test_session.py
+++ b/tests/unit/test_session.py
@@ -870,6 +870,17 @@ def test_retrieve_aggregation_function_list_handles_system_error():
         ctx._aggregation_function_set = original_agg_set
 
 
+def test_get_req_identifiers_list_uses_ge_for_modules(mock_server_connection):
+    """Modules (cloudpickle) are injected with >= not == to allow the server to
+    resolve a compatible version for the target runtime (SNOW-3081273)."""
+    import cloudpickle as cp
+
+    session = Session(mock_server_connection)
+    result = session._get_req_identifiers_list([cp], {})
+    assert result == [f"cloudpickle>={cp.__version__}"]
+    assert f"cloudpickle=={cp.__version__}" not in result
+
+
 def test_retrieve_aggregation_function_list_handles_both_errors():
     """When both aggregation function queries fail, the hardcoded fallback
     set is still populated."""

--- a/tests/unit/test_udf.py
+++ b/tests/unit/test_udf.py
@@ -96,7 +96,7 @@ def test_do_register_udf_sandbox(session_sandbox, cleanup_registration_patch):
     assert extension_function_properties.all_imports == ""
     # for >= 3.14, we use pypi by default, which auto adds cloudpickle
     assert extension_function_properties.all_packages == (
-        f"'cloudpickle=={cloudpickle.__version__}'"
+        f"'cloudpickle>={cloudpickle.__version__}'"
         if sys.version_info >= (3, 14)
         else ""
     )
@@ -134,7 +134,7 @@ def test_artifact_repository_adds_cloudpickle():
     assert all_packages is not None
     package_list = all_packages.split(",") if all_packages else []
     assert any(
-        pkg.strip().strip("'").startswith("cloudpickle==") for pkg in package_list
+        pkg.strip().strip("'").startswith("cloudpickle>=") for pkg in package_list
     ), f"cloudpickle not found in packages: {all_packages}"
 
     # Test case 2: packages already contains cloudpickle

--- a/tests/unit/test_udf_utils.py
+++ b/tests/unit/test_udf_utils.py
@@ -437,3 +437,24 @@ def test_get_func_arg_names():
     # wrong class type should fallback to default arg names
     arg_names = get_func_arg_names(SumUDAF, TempObjectType.TABLE_FUNCTION, 2, True)
     assert arg_names == ["arg1", "arg2"]
+
+
+def test_resolve_imports_and_packages_non_conda_injects_cloudpickle_ge():
+    """Auto-injected cloudpickle uses >= not == so the server can resolve a
+    compatible version for the target runtime (SNOW-3081273)."""
+    import cloudpickle
+
+    _, _, _, all_packages, _, _ = resolve_imports_and_packages(
+        session=None,
+        object_type=TempObjectType.PROCEDURE,
+        func=lambda: None,
+        arg_names=[],
+        udf_name="test_sp",
+        stage_location=None,
+        imports=None,
+        packages=["snowflake-snowpark-python"],
+        artifact_repository="SNOWPARK_PYTHON_TEST_REPOSITORY",
+    )
+    assert all_packages is not None
+    assert f"cloudpickle>={cloudpickle.__version__}" in all_packages
+    assert f"cloudpickle=={cloudpickle.__version__}" not in all_packages


### PR DESCRIPTION


<!---
Please answer these questions before creating your pull request. Thanks!
--->

1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   <!---
   In this section, please add a Snowflake Jira issue number.

   Note that if a corresponding GitHub issue exists, you should still include
   the Snowflake Jira issue number. For example, for GitHub issue
   https://github.com/snowflakedb/snowpark-python/issues/1400, you should
   add "SNOW-1335071" here.
    --->

   Fixes SNOW-3081273
2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.
   - [x] I acknowledge that I have ensured my changes to be thread-safe. Follow the link for more information: [Thread-safe Developer Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#thread-safe-development)
   - [x] If adding any arguments to public Snowpark APIs or creating new public Snowpark APIs, I acknowledge that I have ensured my changes include AST support. Follow the link for more information: [AST Support Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#ast-abstract-syntax-tree-support-in-snowpark)

3. Please describe how your code solves the related issue.

   This PR fixes a Python 3.13 local-registration issue for Snowpark UDFs/stored procedures by changing auto-injected cloudpickle dependency specs from strict pins (==) to compatible lower bounds (>=), so server-side resolution can choose a supported version instead of failing on an exact local version match.

This change is safe because cloudpickle is backward compatible, meaning higher version can deserialize encoding create by lower version
