### PR TITLE
SNOW-3556267: Fix AttributeError when write_pandas receives list name…

### DIFF
--- a/src/snowflake/snowpark/modin/plugin/extensions/utils.py
+++ b/src/snowflake/snowpark/modin/plugin/extensions/utils.py
@@ -838,7 +838,7 @@ def pandas_to_snowflake(
     )
     database_converted = (
         _convert_to_snowflake_table_name_to_write_pandas_table_name(name_parts[0])
-        if len(name_parts) >= 3
+        if len(name_parts) == 3
         else None
     )
 

--- a/src/snowflake/snowpark/modin/plugin/extensions/utils.py
+++ b/src/snowflake/snowpark/modin/plugin/extensions/utils.py
@@ -824,6 +824,10 @@ def pandas_to_snowflake(
         )
 
     name_parts = [name] if isinstance(name, str) else list(name)
+    if len(name_parts) > 3:
+        raise ValueError(
+            f"name must have at most 3 parts (database, schema, table), got {len(name_parts)}: {name_parts}"
+        )
     table_name_converted = _convert_to_snowflake_table_name_to_write_pandas_table_name(
         name_parts[-1]
     )

--- a/src/snowflake/snowpark/modin/plugin/extensions/utils.py
+++ b/src/snowflake/snowpark/modin/plugin/extensions/utils.py
@@ -823,6 +823,21 @@ def pandas_to_snowflake(
             "to_snowflake", ", ".join(type(t).__name__ for t in unsupported_types)
         )
 
+    name_parts = [name] if isinstance(name, str) else list(name)
+    table_name_converted = _convert_to_snowflake_table_name_to_write_pandas_table_name(
+        name_parts[-1]
+    )
+    schema_converted = (
+        _convert_to_snowflake_table_name_to_write_pandas_table_name(name_parts[-2])
+        if len(name_parts) >= 2
+        else None
+    )
+    database_converted = (
+        _convert_to_snowflake_table_name_to_write_pandas_table_name(name_parts[0])
+        if len(name_parts) >= 3
+        else None
+    )
+
     pd.session.write_pandas(
         # use set_axis() this way so that we can also flatten the tuple column
         # labels of a column multi-index, e.g. if `pandas_frame` has columns
@@ -836,7 +851,9 @@ def pandas_to_snowflake(
         # column identifiers ourselves, we get the correct column names and we
         # don't have to modify the table name, but the snowflake connector seems
         # to incorrectly insert null data.
-        table_name=_convert_to_snowflake_table_name_to_write_pandas_table_name(name),
+        table_name=table_name_converted,
+        database=database_converted,
+        schema=schema_converted,
         auto_create_table=True,
         overwrite=if_exists != "append",
         table_type=table_type,

--- a/tests/integ/modin/frame/test_to_snowflake.py
+++ b/tests/integ/modin/frame/test_to_snowflake.py
@@ -389,57 +389,50 @@ class TestTableName:
         )
 
 
-class TestListNameParquetPath:
+class TestWritePandasParquetPath:
     @pytest.fixture(autouse=True)
     def use_starting_backend_and_parquet_threshold(self):
         with config_context(Backend="Pandas", PandasToSnowflakeParquetThresholdBytes=0):
             yield
 
-    def test_one_part_list(self, test_table_name):
+    def test_table_name_only(self, session, test_table_name):
         native_df = native_pd.DataFrame({"a": [1]})
         df = pd.DataFrame(native_df)
-        if_exists = "replace"
-        with to_snowflake_counter(dataset=df, if_exists=if_exists):
-            df.to_snowflake([test_table_name], if_exists=if_exists, index=False)
-        written = pd.read_snowflake(test_table_name)
-        assert_snowpark_pandas_equals_to_pandas_without_dtypecheck(
-            written, native_df.rename(str, axis=1)
-        )
-
-    def test_two_part_list(self, session, test_table_name):
-        native_df = native_pd.DataFrame({"a": [1]})
-        df = pd.DataFrame(native_df)
-        if_exists = "replace"
-        schema = session.get_current_schema().strip('"')
-        with to_snowflake_counter(dataset=df, if_exists=if_exists):
-            df.to_snowflake([schema, test_table_name], if_exists=if_exists, index=False)
-        written = pd.read_snowflake(test_table_name)
-        assert_snowpark_pandas_equals_to_pandas_without_dtypecheck(
-            written, native_df.rename(str, axis=1)
-        )
-
-    def test_three_part_list(self, session, test_table_name):
-        native_df = native_pd.DataFrame({"a": [1]})
-        df = pd.DataFrame(native_df)
-        if_exists = "replace"
-        database = session.get_current_database().strip('"')
-        schema = session.get_current_schema().strip('"')
-        with to_snowflake_counter(dataset=df, if_exists=if_exists):
-            df.to_snowflake(
-                [database, schema, test_table_name], if_exists=if_exists, index=False
+        with to_snowflake_counter(dataset=df, if_exists="replace"):
+            session.write_pandas(
+                df, test_table_name, auto_create_table=True, overwrite=True
             )
         written = pd.read_snowflake(test_table_name)
         assert_snowpark_pandas_equals_to_pandas_without_dtypecheck(
             written, native_df.rename(str, axis=1)
         )
 
-    def test_quoted_identifier_list(self, test_table_name):
+    def test_table_name_with_schema(self, session, test_table_name):
         native_df = native_pd.DataFrame({"a": [1]})
         df = pd.DataFrame(native_df)
-        if_exists = "replace"
-        with to_snowflake_counter(dataset=df, if_exists=if_exists):
-            df.to_snowflake(
-                [f'"{test_table_name}"'], if_exists=if_exists, index=False
+        schema = session.get_current_schema().strip('"')
+        with to_snowflake_counter(dataset=df, if_exists="replace"):
+            session.write_pandas(
+                df, test_table_name, schema=schema, auto_create_table=True, overwrite=True
+            )
+        written = pd.read_snowflake(test_table_name)
+        assert_snowpark_pandas_equals_to_pandas_without_dtypecheck(
+            written, native_df.rename(str, axis=1)
+        )
+
+    def test_table_name_with_database_and_schema(self, session, test_table_name):
+        native_df = native_pd.DataFrame({"a": [1]})
+        df = pd.DataFrame(native_df)
+        database = session.get_current_database().strip('"')
+        schema = session.get_current_schema().strip('"')
+        with to_snowflake_counter(dataset=df, if_exists="replace"):
+            session.write_pandas(
+                df,
+                test_table_name,
+                database=database,
+                schema=schema,
+                auto_create_table=True,
+                overwrite=True,
             )
         written = pd.read_snowflake(test_table_name)
         assert_snowpark_pandas_equals_to_pandas_without_dtypecheck(
@@ -456,14 +449,3 @@ class TestListNameParquetPath:
                     if_exists="replace",
                     index=False,
                 )
-
-    def test_str_name_parquet_path(self, test_table_name):
-        native_df = native_pd.DataFrame({"a": [1]})
-        df = pd.DataFrame(native_df)
-        if_exists = "replace"
-        with to_snowflake_counter(dataset=df, if_exists=if_exists):
-            df.to_snowflake(test_table_name, if_exists=if_exists, index=False)
-        written = pd.read_snowflake(test_table_name)
-        assert_snowpark_pandas_equals_to_pandas_without_dtypecheck(
-            written, native_df.rename(str, axis=1)
-        )

--- a/tests/integ/modin/frame/test_to_snowflake.py
+++ b/tests/integ/modin/frame/test_to_snowflake.py
@@ -8,6 +8,7 @@ import re
 import modin.pandas as pd
 import pandas as native_pd
 import pytest
+from modin.config import context as config_context
 
 import snowflake.snowpark.modin.plugin  # noqa: F401
 from tests.integ.modin.utils import (
@@ -383,6 +384,75 @@ class TestTableName:
                 valid_unquoted_identifier_table_name, if_exists=if_exists, index=False
             )
         written = pd.read_snowflake(valid_unquoted_identifier_table_name)
+        assert_snowpark_pandas_equals_to_pandas_without_dtypecheck(
+            written, native_df.rename(str, axis=1)
+        )
+
+
+class TestListNameParquetPath:
+    @pytest.fixture(autouse=True)
+    def use_starting_backend_and_parquet_threshold(self):
+        with config_context(Backend="Pandas", PandasToSnowflakeParquetThresholdBytes=0):
+            yield
+
+    def test_one_part_list(self, test_table_name):
+        native_df = native_pd.DataFrame({"a": [1]})
+        df = pd.DataFrame(native_df)
+        if_exists = "replace"
+        with to_snowflake_counter(dataset=df, if_exists=if_exists):
+            df.to_snowflake([test_table_name], if_exists=if_exists, index=False)
+        written = pd.read_snowflake(test_table_name)
+        assert_snowpark_pandas_equals_to_pandas_without_dtypecheck(
+            written, native_df.rename(str, axis=1)
+        )
+
+    def test_two_part_list(self, session, test_table_name):
+        native_df = native_pd.DataFrame({"a": [1]})
+        df = pd.DataFrame(native_df)
+        if_exists = "replace"
+        schema = session.get_current_schema().strip('"')
+        with to_snowflake_counter(dataset=df, if_exists=if_exists):
+            df.to_snowflake([schema, test_table_name], if_exists=if_exists, index=False)
+        written = pd.read_snowflake(test_table_name)
+        assert_snowpark_pandas_equals_to_pandas_without_dtypecheck(
+            written, native_df.rename(str, axis=1)
+        )
+
+    def test_three_part_list(self, session, test_table_name):
+        native_df = native_pd.DataFrame({"a": [1]})
+        df = pd.DataFrame(native_df)
+        if_exists = "replace"
+        database = session.get_current_database().strip('"')
+        schema = session.get_current_schema().strip('"')
+        with to_snowflake_counter(dataset=df, if_exists=if_exists):
+            df.to_snowflake(
+                [database, schema, test_table_name], if_exists=if_exists, index=False
+            )
+        written = pd.read_snowflake(test_table_name)
+        assert_snowpark_pandas_equals_to_pandas_without_dtypecheck(
+            written, native_df.rename(str, axis=1)
+        )
+
+    def test_quoted_identifier_list(self, test_table_name):
+        native_df = native_pd.DataFrame({"a": [1]})
+        df = pd.DataFrame(native_df)
+        if_exists = "replace"
+        with to_snowflake_counter(dataset=df, if_exists=if_exists):
+            df.to_snowflake(
+                [f'"{test_table_name}"'], if_exists=if_exists, index=False
+            )
+        written = pd.read_snowflake(test_table_name)
+        assert_snowpark_pandas_equals_to_pandas_without_dtypecheck(
+            written, native_df.rename(str, axis=1)
+        )
+
+    def test_str_name_parquet_path(self, test_table_name):
+        native_df = native_pd.DataFrame({"a": [1]})
+        df = pd.DataFrame(native_df)
+        if_exists = "replace"
+        with to_snowflake_counter(dataset=df, if_exists=if_exists):
+            df.to_snowflake(test_table_name, if_exists=if_exists, index=False)
+        written = pd.read_snowflake(test_table_name)
         assert_snowpark_pandas_equals_to_pandas_without_dtypecheck(
             written, native_df.rename(str, axis=1)
         )

--- a/tests/integ/modin/frame/test_to_snowflake.py
+++ b/tests/integ/modin/frame/test_to_snowflake.py
@@ -446,6 +446,17 @@ class TestListNameParquetPath:
             written, native_df.rename(str, axis=1)
         )
 
+    def test_too_many_parts_raises(self, test_table_name):
+        native_df = native_pd.DataFrame({"a": [1]})
+        df = pd.DataFrame(native_df)
+        with SqlCounter(query_count=0):
+            with pytest.raises(ValueError, match="at most 3 parts"):
+                df.to_snowflake(
+                    ["extra", "db", "schema", test_table_name],
+                    if_exists="replace",
+                    index=False,
+                )
+
     def test_str_name_parquet_path(self, test_table_name):
         native_df = native_pd.DataFrame({"a": [1]})
         df = pd.DataFrame(native_df)


### PR DESCRIPTION
1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.
   Fixes SNOW-3556267

2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.
   - [x] I acknowledge that I have ensured my changes to be thread-safe. Follow the link for more information: [Thread-safe Developer Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#thread-safe-development)
   - [ ] If adding any arguments to public Snowpark APIs or creating new public Snowpark APIs, I acknowledge that I have ensured my changes include AST support. Follow the link for more information: [AST Support Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#ast-abstract-syntax-tree-support-in-snowpark)

3. Please describe how your code solves the related issue.

When Session.write_pandas is called with database= and schema= kwargs, _write_modin_pandas_helper builds a list like ["MY_DB",  "MY_SCHEMA", "MY_TABLE"] and passes it as name to to_snowflake. The below-threshold path re-routes to the Snowflake backend which unpacks that list correctly. The Parquet path passed the whole list to a function that called .upper() on it.

write_pandas already accepts table_name, schema, and database as separate string arguments. So the  #fix splits the list before calling it: last element is always the table name, second-to-last is the schema (if present), first is the database (if 3 parts). Each part is individually converted from Snowflake identifier format to the plain string write_pandas expects.