### PR TITLE
NO SNOW: Fix DecFloat schema nullability when SQL simplifier is disabled

### DIFF
--- a/src/snowflake/snowpark/_internal/analyzer/datatype_mapper.py
+++ b/src/snowflake/snowpark/_internal/analyzer/datatype_mapper.py
@@ -518,8 +518,6 @@ def schema_expression(data_type: DataType, is_nullable: bool) -> str:
             return "PARSE_JSON('NULL') :: VARIANT"
         return "NULL :: " + convert_sp_to_sf_type(data_type)
 
-    if isinstance(data_type, DecFloatType):
-        return "0 :: " + convert_sp_to_sf_type(data_type)
     if isinstance(data_type, _NumericType):
         return "0 :: " + convert_sp_to_sf_type(data_type)
     if isinstance(data_type, StringType):

--- a/src/snowflake/snowpark/_internal/analyzer/datatype_mapper.py
+++ b/src/snowflake/snowpark/_internal/analyzer/datatype_mapper.py
@@ -519,7 +519,7 @@ def schema_expression(data_type: DataType, is_nullable: bool) -> str:
         return "NULL :: " + convert_sp_to_sf_type(data_type)
 
     if isinstance(data_type, DecFloatType):
-        return "DECFLOAT '0'"
+        return "0 :: " + convert_sp_to_sf_type(data_type)
     if isinstance(data_type, _NumericType):
         return "0 :: " + convert_sp_to_sf_type(data_type)
     if isinstance(data_type, StringType):

--- a/tests/unit/test_datatype_mapper.py
+++ b/tests/unit/test_datatype_mapper.py
@@ -770,6 +770,7 @@ def test_schema_expression():
     assert schema_expression(LongType(), False) == "0 :: BIGINT"
     assert schema_expression(FloatType(), False) == "0 :: FLOAT"
     assert schema_expression(DoubleType(), False) == "0 :: DOUBLE"
+    assert schema_expression(DecFloatType(), False) == "0 :: DECFLOAT"
     assert schema_expression(StringType(), False) == "'a' :: STRING"
     assert schema_expression(StringType(19), False) == "'a' ::  STRING (19)"
     assert schema_expression(BooleanType(), False) == "true"


### PR DESCRIPTION
<!---
Please answer these questions before creating your pull request. Thanks!
--->

1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes SNOW-NNNNNNN

2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.
   - [x] I acknowledge that I have ensured my changes to be thread-safe. Follow the link for more information: [Thread-safe Developer Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#thread-safe-development)
   - [x] If adding any arguments to public Snowpark APIs or creating new public Snowpark APIs, I acknowledge that I have ensured my changes include AST support. Follow the link for more information: [AST Support Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#ast-abstract-syntax-tree-support-in-snowpark)

3. Please describe how your code solves the related issue.

   When SQL simplifier is disabled, Snowpark builds synthetic schema queries via `schema_expression()`. For non-null `DecFloatType` columns, that path used `DECFLOAT '0'`, which Snowflake describes as nullable. That caused DecFloat arithmetic result columns (for example `NEW_E` in `test_plus_basic`) to be reported as `nullable=True`.

   This change uses `0 :: DECFLOAT` for non-null DecFloat schema placeholders instead, matching other numeric types and preserving NOT NULL metadata in describe queries.