### PR TITLE
SNOW-3485482: Eliminate unnecessary SELECT * from joins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 #### Improvements
 
 - Improved CTE optimization to deduplicate identical subtrees in self-joins, which were previously emitted as repeated subqueries.
+- Reduced the size of generated query text for repeated join operations.
 
 #### Deprecations
 

--- a/src/snowflake/snowpark/_internal/analyzer/analyzer_utils.py
+++ b/src/snowflake/snowpark/_internal/analyzer/analyzer_utils.py
@@ -989,24 +989,30 @@ def snowflake_supported_join_statement(
     left_uuid: Optional[str] = None,
     right_uuid: Optional[str] = None,
     directed: bool = False,
+    left_is_join: bool = False,
 ) -> str:
     LEFT_UUID = format_uuid(left_uuid)
     RIGHT_UUID = format_uuid(right_uuid)
 
-    # If left is a simple SELECT * FROM (\n<join_source>\n) wrapper from a
-    # previous join, flatten into a multi-way join by appending the new right
-    # operand directly to the existing join source. This avoids nested
+    # If left is the output of a previous join, flatten into a multi-way join
+    # by unwrapping the SELECT * FROM (...) envelope and appending the new
+    # right operand directly to the existing join source. This avoids nested
     # SELECT * layers that inflate query text without changing semantics.
     #
     # Though it is technically less efficient than constructing the join sub-queries
     # without the SELECT in the first place, the structure of our SQL processing code
-    # top-level projections to be wrapped by a select.
-    unwrapped_left = _unwrap_select_star_from(left)
+    # needs top-level projections to be wrapped by a select to be well-formed, so we
+    # must strip it here instead.
+    #
+    # We only unwrap the left side because it is simpler to deal with than unwrapping
+    # both left and right, and left-deep chains are more common, as they're produced
+    # by calls like df1.join(df2).join(df3) etc.
+    unwrapped_left = _unwrap_select_star_from(left) if left_is_join else None
     right_alias = (
         "SNOWPARK_RIGHT"
+        if use_constant_subquery_alias and unwrapped_left is None
         # Multi-way join: right alias must be unique to avoid collisions
         # with aliases already present in the flattened join source.
-        if use_constant_subquery_alias and unwrapped_left is None
         else random_name_for_temp_object(TempObjectType.TABLE)
     )
 
@@ -1098,6 +1104,7 @@ def join_statement(
     left_uuid: Optional[str] = None,
     right_uuid: Optional[str] = None,
     directed: bool = False,
+    left_is_join: bool = False,
 ) -> str:
     if isinstance(join_type, (LeftSemi, LeftAnti)):
         return left_semi_or_anti_join_statement(
@@ -1125,6 +1132,7 @@ def join_statement(
         left_uuid=left_uuid,
         right_uuid=right_uuid,
         directed=directed,
+        left_is_join=left_is_join,
     )
 
 

--- a/src/snowflake/snowpark/_internal/analyzer/analyzer_utils.py
+++ b/src/snowflake/snowpark/_internal/analyzer/analyzer_utils.py
@@ -992,14 +992,21 @@ def snowflake_supported_join_statement(
 ) -> str:
     LEFT_UUID = format_uuid(left_uuid)
     RIGHT_UUID = format_uuid(right_uuid)
-    left_alias = (
-        "SNOWPARK_LEFT"
-        if use_constant_subquery_alias
-        else random_name_for_temp_object(TempObjectType.TABLE)
-    )
+
+    # If left is a simple SELECT * FROM (\n<join_source>\n) wrapper from a
+    # previous join, flatten into a multi-way join by appending the new right
+    # operand directly to the existing join source. This avoids nested
+    # SELECT * layers that inflate query text without changing semantics.
+    #
+    # Though it is technically less efficient than constructing the join sub-queries
+    # without the SELECT in the first place, the structure of our SQL processing code
+    # top-level projections to be wrapped by a select.
+    unwrapped_left = _unwrap_select_star_from(left)
     right_alias = (
         "SNOWPARK_RIGHT"
-        if use_constant_subquery_alias
+        # Multi-way join: right alias must be unique to avoid collisions
+        # with aliases already present in the flattened join source.
+        if use_constant_subquery_alias and unwrapped_left is None
         else random_name_for_temp_object(TempObjectType.TABLE)
     )
 
@@ -1035,40 +1042,17 @@ def snowflake_supported_join_statement(
 
     maybe_directed_sql = DIRECTED_JOIN if directed else JOIN
 
-    # If left is a simple SELECT * FROM (\n<join_source>\n) wrapper from a
-    # previous join, flatten into a multi-way join by appending the new right
-    # operand directly to the existing join source. This avoids nested
-    # SELECT * layers that inflate query text without changing semantics.
-    unwrapped_left = _unwrap_select_star_from(left)
-
     if unwrapped_left is not None:
-        # Multi-way join: right alias must be unique to avoid collisions
-        # with aliases already present in the flattened join source.
-        multiway_right_alias = random_name_for_temp_object(TempObjectType.TABLE)
-        source = (
-            LEFT_UUID
-            + unwrapped_left
-            + NEW_LINE
-            + LEFT_UUID
-            + join_sql
-            + maybe_directed_sql
-            + NEW_LINE
-            + LEFT_PARENTHESIS
-            + NEW_LINE
-            + RIGHT_UUID
-            + right
-            + NEW_LINE
-            + RIGHT_UUID
-            + RIGHT_PARENTHESIS
-            + AS
-            + multiway_right_alias
-            + NEW_LINE
-            + f"{match_condition if match_condition else EMPTY_STRING}"
-            + f"{using_condition if using_condition else EMPTY_STRING}"
-            + f"{join_condition if join_condition else EMPTY_STRING}"
-        )
+        # No need for additional parentheses around the left expression here, since it
+        # should already be parenthesized
+        left_expr = LEFT_UUID + unwrapped_left + NEW_LINE + LEFT_UUID
     else:
-        source = (
+        left_alias = (
+            "SNOWPARK_LEFT"
+            if use_constant_subquery_alias
+            else random_name_for_temp_object(TempObjectType.TABLE)
+        )
+        left_expr = (
             LEFT_PARENTHESIS
             + NEW_LINE
             + LEFT_UUID
@@ -1080,23 +1064,26 @@ def snowflake_supported_join_statement(
             + left_alias
             + SPACE
             + NEW_LINE
-            + join_sql
-            + maybe_directed_sql
-            + NEW_LINE
-            + LEFT_PARENTHESIS
-            + NEW_LINE
-            + RIGHT_UUID
-            + right
-            + NEW_LINE
-            + RIGHT_UUID
-            + RIGHT_PARENTHESIS
-            + AS
-            + right_alias
-            + NEW_LINE
-            + f"{match_condition if match_condition else EMPTY_STRING}"
-            + f"{using_condition if using_condition else EMPTY_STRING}"
-            + f"{join_condition if join_condition else EMPTY_STRING}"
         )
+    source = (
+        left_expr
+        + join_sql
+        + maybe_directed_sql
+        + NEW_LINE
+        + LEFT_PARENTHESIS
+        + NEW_LINE
+        + RIGHT_UUID
+        + right
+        + NEW_LINE
+        + RIGHT_UUID
+        + RIGHT_PARENTHESIS
+        + AS
+        + right_alias
+        + NEW_LINE
+        + f"{match_condition if match_condition else EMPTY_STRING}"
+        + f"{using_condition if using_condition else EMPTY_STRING}"
+        + f"{join_condition if join_condition else EMPTY_STRING}"
+    )
 
     return project_statement([], source)
 

--- a/src/snowflake/snowpark/_internal/analyzer/analyzer_utils.py
+++ b/src/snowflake/snowpark/_internal/analyzer/analyzer_utils.py
@@ -968,13 +968,22 @@ _SELECT_STAR_FROM_SUFFIX = NEW_LINE + RIGHT_PARENTHESIS
 def _unwrap_select_star_from(sql: str) -> Optional[str]:
     """If sql is a join-produced `SELECT * FROM (\n<join_source>\n)` (the
     output of project_statement([], join_source)), return <join_source>.
-    Only unwraps when the inner content starts with '(' which indicates
-    a parenthesized join operand rather than a wrapped SELECT statement."""
+    Only unwraps when the inner content starts with '(' (possibly preceded
+    by UUID trace comments) which indicates a parenthesized join operand
+    rather than a wrapped SELECT statement."""
     if sql.startswith(_SELECT_STAR_FROM_PREFIX) and sql.endswith(
         _SELECT_STAR_FROM_SUFFIX
     ):
         inner = sql[len(_SELECT_STAR_FROM_PREFIX) : -len(_SELECT_STAR_FROM_SUFFIX)]
-        if inner.startswith(LEFT_PARENTHESIS):
+        # In trace-SQL mode, UUID comments (\n-- <uuid>\n) may precede the
+        # opening parenthesis. Strip them before checking.
+        check = inner.lstrip("\n")
+        if check.startswith("--"):
+            # Skip the comment line and any trailing newline
+            newline_pos = check.find("\n")
+            if newline_pos != -1:
+                check = check[newline_pos + 1 :]
+        if check.startswith(LEFT_PARENTHESIS) or inner.startswith(LEFT_PARENTHESIS):
             return inner
     return None
 

--- a/src/snowflake/snowpark/_internal/analyzer/analyzer_utils.py
+++ b/src/snowflake/snowpark/_internal/analyzer/analyzer_utils.py
@@ -961,6 +961,24 @@ def lateral_join_statement(
     )
 
 
+_SELECT_STAR_FROM_PREFIX = SELECT + STAR + NEW_LINE + FROM + LEFT_PARENTHESIS + NEW_LINE
+_SELECT_STAR_FROM_SUFFIX = NEW_LINE + RIGHT_PARENTHESIS
+
+
+def _unwrap_select_star_from(sql: str) -> Optional[str]:
+    """If sql is a join-produced `SELECT * FROM (\n<join_source>\n)` (the
+    output of project_statement([], join_source)), return <join_source>.
+    Only unwraps when the inner content starts with '(' which indicates
+    a parenthesized join operand rather than a wrapped SELECT statement."""
+    if sql.startswith(_SELECT_STAR_FROM_PREFIX) and sql.endswith(
+        _SELECT_STAR_FROM_SUFFIX
+    ):
+        inner = sql[len(_SELECT_STAR_FROM_PREFIX) : -len(_SELECT_STAR_FROM_SUFFIX)]
+        if inner.startswith(LEFT_PARENTHESIS):
+            return inner
+    return None
+
+
 def snowflake_supported_join_statement(
     left: str,
     right: str,
@@ -1017,35 +1035,68 @@ def snowflake_supported_join_statement(
 
     maybe_directed_sql = DIRECTED_JOIN if directed else JOIN
 
-    source = (
-        LEFT_PARENTHESIS
-        + NEW_LINE
-        + LEFT_UUID
-        + left
-        + NEW_LINE
-        + LEFT_UUID
-        + RIGHT_PARENTHESIS
-        + AS
-        + left_alias
-        + SPACE
-        + NEW_LINE
-        + join_sql
-        + maybe_directed_sql
-        + NEW_LINE
-        + LEFT_PARENTHESIS
-        + NEW_LINE
-        + RIGHT_UUID
-        + right
-        + NEW_LINE
-        + RIGHT_UUID
-        + RIGHT_PARENTHESIS
-        + AS
-        + right_alias
-        + NEW_LINE
-        + f"{match_condition if match_condition else EMPTY_STRING}"
-        + f"{using_condition if using_condition else EMPTY_STRING}"
-        + f"{join_condition if join_condition else EMPTY_STRING}"
-    )
+    # If left is a simple SELECT * FROM (\n<join_source>\n) wrapper from a
+    # previous join, flatten into a multi-way join by appending the new right
+    # operand directly to the existing join source. This avoids nested
+    # SELECT * layers that inflate query text without changing semantics.
+    unwrapped_left = _unwrap_select_star_from(left)
+
+    if unwrapped_left is not None:
+        # Multi-way join: right alias must be unique to avoid collisions
+        # with aliases already present in the flattened join source.
+        multiway_right_alias = random_name_for_temp_object(TempObjectType.TABLE)
+        source = (
+            LEFT_UUID
+            + unwrapped_left
+            + NEW_LINE
+            + LEFT_UUID
+            + join_sql
+            + maybe_directed_sql
+            + NEW_LINE
+            + LEFT_PARENTHESIS
+            + NEW_LINE
+            + RIGHT_UUID
+            + right
+            + NEW_LINE
+            + RIGHT_UUID
+            + RIGHT_PARENTHESIS
+            + AS
+            + multiway_right_alias
+            + NEW_LINE
+            + f"{match_condition if match_condition else EMPTY_STRING}"
+            + f"{using_condition if using_condition else EMPTY_STRING}"
+            + f"{join_condition if join_condition else EMPTY_STRING}"
+        )
+    else:
+        source = (
+            LEFT_PARENTHESIS
+            + NEW_LINE
+            + LEFT_UUID
+            + left
+            + NEW_LINE
+            + LEFT_UUID
+            + RIGHT_PARENTHESIS
+            + AS
+            + left_alias
+            + SPACE
+            + NEW_LINE
+            + join_sql
+            + maybe_directed_sql
+            + NEW_LINE
+            + LEFT_PARENTHESIS
+            + NEW_LINE
+            + RIGHT_UUID
+            + right
+            + NEW_LINE
+            + RIGHT_UUID
+            + RIGHT_PARENTHESIS
+            + AS
+            + right_alias
+            + NEW_LINE
+            + f"{match_condition if match_condition else EMPTY_STRING}"
+            + f"{using_condition if using_condition else EMPTY_STRING}"
+            + f"{join_condition if join_condition else EMPTY_STRING}"
+        )
 
     return project_statement([], source)
 

--- a/src/snowflake/snowpark/_internal/analyzer/select_statement.py
+++ b/src/snowflake/snowpark/_internal/analyzer/select_statement.py
@@ -449,7 +449,7 @@ class Selectable(LogicalPlan, ABC):
             # Only SelectStatement has has_clause/has_projection; other
             # Selectable subclasses (SelectSQL, SetStatement, etc.) skip this.
             if (
-                hasattr(self, "has_clause")
+                isinstance(self, SelectStatement)
                 and not self.has_clause
                 and not self.has_projection
                 and isinstance(self.from_, SelectSnowflakePlan)

--- a/src/snowflake/snowpark/_internal/analyzer/select_statement.py
+++ b/src/snowflake/snowpark/_internal/analyzer/select_statement.py
@@ -444,6 +444,13 @@ class Selectable(LogicalPlan, ABC):
                 # Add the last df ast id to the snowflake plan as the most recent
                 # dataframe operation to create this plan.
                 self._snowflake_plan.df_ast_ids = self.df_ast_ids
+            # Propagate join output flag through passthrough SelectStatements
+            # so chained joins can flatten into multi-way joins.
+            if not self.has_clause and not self.has_projection:
+                if isinstance(self.from_, SelectSnowflakePlan):
+                    self._snowflake_plan._is_join_output = (
+                        self.from_._snowflake_plan._is_join_output
+                    )
         return self._snowflake_plan
 
     @property

--- a/src/snowflake/snowpark/_internal/analyzer/select_statement.py
+++ b/src/snowflake/snowpark/_internal/analyzer/select_statement.py
@@ -446,11 +446,17 @@ class Selectable(LogicalPlan, ABC):
                 self._snowflake_plan.df_ast_ids = self.df_ast_ids
             # Propagate join output flag through passthrough SelectStatements
             # so chained joins can flatten into multi-way joins.
-            if not self.has_clause and not self.has_projection:
-                if isinstance(self.from_, SelectSnowflakePlan):
-                    self._snowflake_plan._is_join_output = (
-                        self.from_._snowflake_plan._is_join_output
-                    )
+            # Only SelectStatement has has_clause/has_projection; other
+            # Selectable subclasses (SelectSQL, SetStatement, etc.) skip this.
+            if (
+                hasattr(self, "has_clause")
+                and not self.has_clause
+                and not self.has_projection
+                and isinstance(self.from_, SelectSnowflakePlan)
+            ):
+                self._snowflake_plan._is_join_output = (
+                    self.from_._snowflake_plan._is_join_output
+                )
         return self._snowflake_plan
 
     @property

--- a/src/snowflake/snowpark/_internal/analyzer/snowflake_plan.py
+++ b/src/snowflake/snowpark/_internal/analyzer/snowflake_plan.py
@@ -770,6 +770,7 @@ class SnowflakePlan(LogicalPlan):
                 referenced_ctes=self.referenced_ctes,
             )
         plan.df_ast_ids = self.df_ast_ids
+        plan._is_join_output = self._is_join_output
         return plan
 
     def __deepcopy__(self, memodict={}) -> "SnowflakePlan":  # noqa: B006
@@ -809,6 +810,7 @@ class SnowflakePlan(LogicalPlan):
         if copied_source_plan:
             copied_source_plan._is_valid_for_replacement = True
         copied_plan.df_ast_ids = self.df_ast_ids
+        copied_plan._is_join_output = self._is_join_output
 
         return copied_plan
 

--- a/src/snowflake/snowpark/_internal/analyzer/snowflake_plan.py
+++ b/src/snowflake/snowpark/_internal/analyzer/snowflake_plan.py
@@ -458,6 +458,7 @@ class SnowflakePlan(LogicalPlan):
         self.session = session
         self.source_plan = source_plan
         self.is_ddl_on_temp_object = is_ddl_on_temp_object
+        self._is_join_output = False
         # We need to copy this list since we don't want to change it for the
         # previous SnowflakePlan objects
         self.api_calls = api_calls.copy() if api_calls else []
@@ -1231,7 +1232,8 @@ class SnowflakePlanBuilder:
         use_constant_subquery_alias: bool,
         directed: bool = False,
     ):
-        return self.build_binary(
+        left_is_join = left._is_join_output
+        result = self.build_binary(
             lambda x, y: join_statement(
                 x,
                 y,
@@ -1248,11 +1250,14 @@ class SnowflakePlanBuilder:
                     else None
                 ),
                 directed=directed,
+                left_is_join=left_is_join,
             ),
             left,
             right,
             source_plan,
         )
+        result._is_join_output = True
+        return result
 
     def save_as_table(
         self,

--- a/tests/unit/compiler/test_replace_child_and_update_node.py
+++ b/tests/unit/compiler/test_replace_child_and_update_node.py
@@ -70,6 +70,7 @@ def mock_snowflake_plan() -> SnowflakePlan:
     fake_snowflake_plan.referenced_ctes = {with_query_block: 1}
     fake_snowflake_plan._cumulative_node_complexity = {}
     fake_snowflake_plan._is_valid_for_replacement = True
+    fake_snowflake_plan._is_join_output = False
     fake_snowflake_plan._metadata = mock.create_autospec(PlanMetadata)
     fake_snowflake_plan._metadata.attributes = {}
     fake_snowflake_plan.query_line_intervals = []

--- a/tests/unit/test_analyzer_util_suite.py
+++ b/tests/unit/test_analyzer_util_suite.py
@@ -465,7 +465,8 @@ def test_join_statement_flattens_chained_joins():
         True,
     )
 
-    # Second join uses first join's output as left operand
+    # Second join uses first join's output as left operand.
+    # left_is_join=True signals that the left operand is a join result.
     second_join = join_statement(
         first_join,
         "SELECT * FROM table_c",
@@ -473,6 +474,7 @@ def test_join_statement_flattens_chained_joins():
         "",
         "",
         True,
+        left_is_join=True,
     )
 
     # Should NOT have nested SELECT * FROM (SELECT * FROM (...))
@@ -483,6 +485,45 @@ def test_join_statement_flattens_chained_joins():
     assert "table_a" in second_join
     assert "table_b" in second_join
     assert "table_c" in second_join
+
+
+def test_join_statement_does_not_flatten_user_generated_select_star():
+    """A user-generated SELECT * that coincidentally matches the internal
+    pattern must NOT be flattened when left_is_join is False (the default)."""
+    join_type = UsingJoin(Inner(), ["key"])
+
+    # Craft a SQL string that matches the internal _SELECT_STAR_FROM_PREFIX/SUFFIX
+    # pattern exactly — this simulates what session.sql("SELECT * FROM (...)") or
+    # a similar user-provided query might produce.
+    user_sql = (
+        " SELECT  * \n FROM (\n"
+        "(SELECT id, key FROM user_table) AS t1"
+        " INNER  JOIN \n(SELECT id, key FROM other_table) AS t2\n"
+        " USING (key)"
+        "\n)"
+    )
+
+    # join_statement with left_is_join=False (default) — should NOT unwrap because
+    # left_is_join is only True when a plan object is constructed from a dataframe
+    # join operation
+    result = join_statement(
+        user_sql,
+        "SELECT * FROM table_c",
+        join_type,
+        "",
+        "",
+        True,
+        left_is_join=False,
+    )
+
+    # The user SQL should be preserved as a nested subquery, producing
+    # two SELECT levels (the outer wrapper + the user's original SELECT *)
+    assert result.count(" SELECT ") >= 2
+
+    # The user's original SQL should appear within the output intact
+    assert "user_table" in result
+    assert "other_table" in result
+    assert "table_c" in result
 
 
 def test_create_iceberg_table_statement():

--- a/tests/unit/test_analyzer_util_suite.py
+++ b/tests/unit/test_analyzer_util_suite.py
@@ -451,6 +451,40 @@ def test_join_statement_negative():
         join_statement("", "", join_type, "cond2", "", False)
 
 
+def test_join_statement_flattens_chained_joins():
+    """Chained joins should produce a flat multi-way join, not nested SELECT * wrappers."""
+    join_type = UsingJoin(Inner(), ["key"])
+
+    # First join: produces SELECT * FROM ((left) AS L JOIN (right) AS R USING (key))
+    first_join = join_statement(
+        "SELECT * FROM table_a",
+        "SELECT * FROM table_b",
+        join_type,
+        "",
+        "",
+        True,
+    )
+
+    # Second join uses first join's output as left operand
+    second_join = join_statement(
+        first_join,
+        "SELECT * FROM table_c",
+        join_type,
+        "",
+        "",
+        True,
+    )
+
+    # Should NOT have nested SELECT * FROM (SELECT * FROM (...))
+    # Count occurrences of "SELECT" — expect exactly one top-level SELECT *
+    assert second_join.count(" SELECT ") == 1
+
+    # The SQL should contain all three table references at the same nesting level
+    assert "table_a" in second_join
+    assert "table_b" in second_join
+    assert "table_c" in second_join
+
+
 def test_create_iceberg_table_statement():
     assert create_table_statement(
         table_name="test_table",

--- a/tests/unit/test_analyzer_util_suite.py
+++ b/tests/unit/test_analyzer_util_suite.py
@@ -487,6 +487,61 @@ def test_join_statement_flattens_chained_joins():
     assert "table_c" in second_join
 
 
+def test_join_statement_flattens_with_uuid_trace_comments():
+    """Flattening must work when UUID trace comments are present (trace-SQL mode)."""
+    join_type = UsingJoin(Inner(), ["key"])
+
+    # First join with UUID trace comments
+    first_join = join_statement(
+        "SELECT * FROM table_a",
+        "SELECT * FROM table_b",
+        join_type,
+        "",
+        "",
+        True,
+        left_uuid="aaaa-bbbb",
+        right_uuid="cccc-dddd",
+    )
+
+    # Second join: flattening with UUIDs
+    second_join = join_statement(
+        first_join,
+        "SELECT * FROM table_c",
+        join_type,
+        "",
+        "",
+        True,
+        left_uuid="eeee-ffff",
+        right_uuid="1111-2222",
+        left_is_join=True,
+    )
+
+    # Should still flatten — only one top-level SELECT *
+    assert second_join.count(" SELECT ") == 1
+    assert "table_a" in second_join
+    assert "table_b" in second_join
+    assert "table_c" in second_join
+
+    # Third join: must also flatten successfully despite accumulated UUID comments
+    third_join = join_statement(
+        second_join,
+        "SELECT * FROM table_d",
+        join_type,
+        "",
+        "",
+        True,
+        left_uuid="3333-4444",
+        right_uuid="5555-6666",
+        left_is_join=True,
+    )
+
+    assert third_join.count(" SELECT ") == 1
+    assert "table_a" in third_join
+    assert "table_b" in third_join
+    assert "table_c" in third_join
+    assert "table_d" in third_join
+
+
 def test_join_statement_does_not_flatten_user_generated_select_star():
     """A user-generated SELECT * that coincidentally matches the internal
     pattern must NOT be flattened when left_is_join is False (the default)."""


### PR DESCRIPTION
<!---
Please answer these questions before creating your pull request. Thanks!
--->

1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   <!---
   In this section, please add a Snowflake Jira issue number.

   Note that if a corresponding GitHub issue exists, you should still include
   the Snowflake Jira issue number. For example, for GitHub issue
   https://github.com/snowflakedb/snowpark-python/issues/1400, you should
   add "SNOW-1335071" here.
    --->

   Fixes SNOW-3485482

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.
   - [x] I acknowledge that I have ensured my changes to be thread-safe. Follow the link for more information: [Thread-safe Developer Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#thread-safe-development)
   - [x] If adding any arguments to public Snowpark APIs or creating new public Snowpark APIs, I acknowledge that I have ensured my changes include AST support. Follow the link for more information: [AST Support Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#ast-abstract-syntax-tree-support-in-snowpark)

3. Please describe how your code solves the related issue.

Removes unnecessary SELECT * layers from repeated join operations. Truncated example SQL from Python code `df1.join(df2.join(df3, on="key", how="inner"), on="key", how="inner")`, edited for readability:

Current main:
```
SELECT * FROM (
  SELECT * FROM (
    (
      SELECT * FROM (
        (
          SELECT "KEY", "VAL_BASE"
          FROM (
            SELECT $1 AS "KEY", $2 AS "VAL_BASE" FROM table_name
        ) AS SNOWPARK_LEFT
        INNER JOIN (
          SELECT "KEY", "VAL_1" FROM (
            SELECT $1 AS "KEY", $2 AS "VAL_1" FROM table_name
        ) AS SNOWPARK_RIGHT
          USING (key)
      )
    ) AS SNOWPARK_LEFT
    INNER JOIN (
      SELECT "KEY", "VAL_2" FROM (
        SELECT $1 AS "KEY", $2 AS "VAL_2" FROM table_name
    ) AS SNOWPARK_RIGHT
      USING (key)
  )
)
WHERE "VAL_BASE" > 100
ORDER BY "VAL_BASE" DESC NULLS LAST
LIMIT 5
```

New:
```
SELECT * FROM (
  SELECT * FROM (
    (
      SELECT "KEY", "VAL_BASE" FROM table_name
    ) AS SNOWPARK_LEFT
    INNER JOIN (
      SELECT "KEY", "VAL_1" FROM table_name
    ) AS SNOWPARK_RIGHT
      USING (key)
    INNER JOIN (
      SELECT "KEY", "VAL_2"FROM table_name
    ) AS SNOWPARK_TEMP_TABLE_Y7YO05WRW5
      USING (key)
  )
)
WHERE "VAL_BASE" > 100
ORDER BY "VAL_BASE" DESC NULLS LAST
LIMIT 5
```

The outer-most layers of SELECT * cannot be removed, but this PR prevents the addition of a new layer of SELECT * wrapping on every additional chained join operatio. For a sequence of 10 joins, this PR reduces the query text from 3752 characters to 3528 (-6%), but does not meaningfully affect SQL compilation time.