### PR TITLE
SNOW-3489991: Block flattening of dropped NEW columns in connect mode

### DIFF
--- a/src/snowflake/snowpark/_internal/analyzer/select_statement.py
+++ b/src/snowflake/snowpark/_internal/analyzer/select_statement.py
@@ -269,6 +269,7 @@ class Selectable(LogicalPlan, ABC):
         self.pre_actions: Optional[List["Query"]] = None
         self.post_actions: Optional[List["Query"]] = None
         self.flatten_disabled: bool = False
+        self.protect_dropped_new_columns: bool = False
         self._column_states: Optional[ColumnStateDict] = None
         self._snowflake_plan: Optional[SnowflakePlan] = None
         self.expr_to_alias = (
@@ -1499,7 +1500,7 @@ class SelectStatement(Selectable):
             can_be_flattened = False
         else:
             can_be_flattened = can_select_statement_be_flattened(
-                self.column_states, new_column_states
+                self.column_states, new_column_states, self.protect_dropped_new_columns
             )
 
         if can_be_flattened:
@@ -2196,7 +2197,9 @@ def parse_column_name(
 
 
 def can_select_statement_be_flattened(
-    subquery_column_states: ColumnStateDict, new_column_states: ColumnStateDict
+    subquery_column_states: ColumnStateDict,
+    new_column_states: ColumnStateDict,
+    protect_dropped_new_columns: bool = False,
 ) -> bool:
     for col, state in new_column_states.items():
         dependent_columns = state.dependent_columns
@@ -2221,9 +2224,10 @@ def can_select_statement_be_flattened(
             and subquery_state.change_state == ColumnChangeState.NEW
             and (
                 subquery_state.is_referenced_by_same_level_column
-                # In connect mode, preserve the subquery so that future
-                # filter/sort clauses can still reference the dropped NEW column.
-                or context._is_snowpark_connect_compatible_mode
+                # If the subquery was explicitly marked (e.g. by the SCOS withColumn
+                # path), preserve it so that future filter/sort clauses can still
+                # reference the dropped NEW column.
+                or protect_dropped_new_columns
             )
         ):
             return False

--- a/src/snowflake/snowpark/_internal/analyzer/select_statement.py
+++ b/src/snowflake/snowpark/_internal/analyzer/select_statement.py
@@ -2219,7 +2219,12 @@ def can_select_statement_be_flattened(
             state.change_state == ColumnChangeState.DROPPED
             and (subquery_state := subquery_column_states.get(col))
             and subquery_state.change_state == ColumnChangeState.NEW
-            and subquery_state.is_referenced_by_same_level_column
+            and (
+                subquery_state.is_referenced_by_same_level_column
+                # In connect mode, preserve the subquery so that future
+                # filter/sort clauses can still reference the dropped NEW column.
+                or context._is_snowpark_connect_compatible_mode
+            )
         ):
             return False
     return True

--- a/tests/integ/test_simplifier_suite.py
+++ b/tests/integ/test_simplifier_suite.py
@@ -2786,13 +2786,15 @@ class TestProtectDroppedNewColumns:
         wc = df.select(col("a"), col("b").alias("sort_key"))
         wc._select_statement.protect_dropped_new_columns = True
 
-        sel = wc.select(col("a"))
+        sel = wc.select(col("a")).order_by(col("sort_key"))
         sql = sel.queries["queries"][0]
 
         # Subquery preserved: outer ORDER BY can reference "sort_key".
         assert (
             sql.upper().count("SELECT") == 2
         ), f"Expected 2 SELECT levels, got:\n{sql}"
+        # sort_key order: 1 (a=2), 2 (a=3), 3 (a=1)
+        Utils.check_answer(sel, [Row(2), Row(3), Row(1)], sort=False)
 
     def test_chained_withcolumn_only_last_is_protected(self, session):
         """The TPC-DS Q66 pattern: two consecutive withColumn calls followed by a
@@ -2887,7 +2889,12 @@ class TestFlattenDisabledGetTemporaryView:
 
     def test_without_flatten_disabled_select_flattens(self, session):
         """Control: without flatten_disabled the renaming select is collapsed
-        away and "t2c_renamed" would not be in scope for ORDER BY."""
+        away, so the subquery is gone and dropped columns would be inaccessible.
+
+        This uses a plain select with no order_by at the same level so that
+        is_referenced_by_same_level_column cannot block flattening — the only
+        thing that would preserve the subquery is flatten_disabled itself.
+        """
         df = session.create_dataframe(
             [[1, 2, 3, 4], [5, 6, 7, 8]], schema=["t2a", "t2b", "t2c", "t2d"]
         )
@@ -2897,15 +2904,16 @@ class TestFlattenDisabledGetTemporaryView:
             col("t2c").alias("t2c_renamed"),
             col("t2d").alias("t2d_renamed"),
         )
-        # No flatten_disabled — all renames are NEW and t2c_renamed IS
-        # referenced by same-level order_by, so flattening is blocked anyway.
-        result = renamed.select("t2d_renamed").order_by("t2c_renamed", "t2d_renamed")
+        # No flatten_disabled — t2c_renamed is dropped and NOT referenced at
+        # the same level, so flattening proceeds and the subquery collapses.
+        result = renamed.select("t2d_renamed")
         sql = result.queries["queries"][0]
 
-        # t2c_renamed IS referenced (is_referenced_by_same_level_column),
-        # so even without flatten_disabled the subquery is preserved.
-        assert "ORDER BY" in sql.upper(), f"Expected ORDER BY in SQL:\n{sql}"
-        Utils.check_answer(result, [Row(4), Row(8)], sort=False)
+        # Without flatten_disabled the renaming subquery is collapsed: 1 SELECT.
+        assert (
+            sql.upper().count("SELECT") == 1
+        ), f"Expected 1 SELECT level (flattened), got:\n{sql}"
+        Utils.check_answer(result, [Row(4), Row(8)], sort=True)
 
 
 class TestFlattenDisabledMapToDf:

--- a/tests/integ/test_simplifier_suite.py
+++ b/tests/integ/test_simplifier_suite.py
@@ -2757,9 +2757,12 @@ class TestProtectDroppedNewColumns:
         sql = sel.queries["queries"][0]
 
         # The subquery that defines "new" must still be visible in the SQL.
+        # With create_dataframe the base is always a SELECT from VALUES (1 layer),
+        # wc adds a second SELECT layer, and the protect flag prevents sel from
+        # flattening into wc, producing a third layer — 3 SELECTs total.
         assert (
-            sql.upper().count("SELECT") == 2
-        ), f"Expected 2 SELECT levels (subquery preserved), got:\n{sql}"
+            sql.upper().count("SELECT") == 3
+        ), f"Expected 3 SELECT levels (subquery preserved), got:\n{sql}"
         Utils.check_answer(sel, [Row(3), Row(6)], sort=True)
 
     def test_without_flag_select_is_flattened(self, session):
@@ -2773,9 +2776,11 @@ class TestProtectDroppedNewColumns:
         sql = sel.queries["queries"][0]
 
         # "new" is DROPPED and not referenced; flattening is safe and expected.
+        # sel flattens into wc, but the base create_dataframe VALUES plan always
+        # contributes one SELECT — so the minimum is 2 SELECTs total.
         assert (
-            sql.upper().count("SELECT") == 1
-        ), f"Expected 1 SELECT level (flattened), got:\n{sql}"
+            sql.upper().count("SELECT") == 2
+        ), f"Expected 2 SELECT levels (flattened), got:\n{sql}"
         Utils.check_answer(sel, [Row(3), Row(6)], sort=True)
 
     def test_orderby_on_dropped_new_column_blocked(self, session):
@@ -2790,9 +2795,11 @@ class TestProtectDroppedNewColumns:
         sql = sel.queries["queries"][0]
 
         # Subquery preserved: outer ORDER BY can reference "sort_key".
+        # Same layering as the filter test: VALUES (1) + wc (2) + sel blocked by
+        # protect flag (3) = 3 SELECTs total.
         assert (
-            sql.upper().count("SELECT") == 2
-        ), f"Expected 2 SELECT levels, got:\n{sql}"
+            sql.upper().count("SELECT") == 3
+        ), f"Expected 3 SELECT levels, got:\n{sql}"
         # sort_key order: 1 (a=2), 2 (a=3), 3 (a=1)
         Utils.check_answer(sel, [Row(2), Row(3), Row(1)], sort=False)
 

--- a/tests/integ/test_simplifier_suite.py
+++ b/tests/integ/test_simplifier_suite.py
@@ -2916,10 +2916,12 @@ class TestFlattenDisabledGetTemporaryView:
         result = renamed.select("t2d_renamed")
         sql = result.queries["queries"][0]
 
-        # Without flatten_disabled the renaming subquery is collapsed: 1 SELECT.
+        # Without flatten_disabled the renaming subquery is collapsed into the
+        # VALUES plan's SELECT.  create_dataframe always wraps VALUES in a SELECT,
+        # so the minimum achievable is 2 SELECTs (outer projection + VALUES).
         assert (
-            sql.upper().count("SELECT") == 1
-        ), f"Expected 1 SELECT level (flattened), got:\n{sql}"
+            sql.upper().count("SELECT") == 2
+        ), f"Expected 2 SELECT levels (flattened), got:\n{sql}"
         Utils.check_answer(result, [Row(4), Row(8)], sort=True)
 
 

--- a/tests/integ/test_simplifier_suite.py
+++ b/tests/integ/test_simplifier_suite.py
@@ -2706,3 +2706,246 @@ def test_concurrent_retrieve_agg_event_set_after_context_published(
     assert snapshot_at_set[
         0
     ], "fetch_event fired before _aggregation_function_set was published"
+
+
+# ---------------------------------------------------------------------------
+# Tests for the three "select() flattens too aggressively" scenarios described
+# in "Loosen flattening rules.md" (SCOS Compatibility section).
+#
+# Scenario 1 — map_with_columns (SNOW-3489991):
+#   df.withColumn("new", lit(1)).select("c").filter(col("new") > 0)
+#   Without protection the select() incorrectly flattens and "new" goes
+#   out of scope for the subsequent filter.  SCOS fixes this by setting
+#   protect_dropped_new_columns=True on the SelectStatement produced by the
+#   withColumn path.
+#
+# Scenario 2 — _get_temporary_view column renaming:
+#   renamed.select("t2d").orderBy("t2c", "t2d")
+#   All renamed columns are NEW; dropping them before the orderBy loses the
+#   renamed names.  SCOS protects this with flatten_disabled=True.
+#
+# Scenario 3 — map_to_df:
+#   df.toDF("foo","bar","baz").select("foo").filter((col("bar")+col("foo"))<10)
+#   Same root cause as Scenario 2 but triggered by toDF renaming.
+# ---------------------------------------------------------------------------
+
+
+class TestProtectDroppedNewColumns:
+    """Scenario 1 from 'Loosen flattening rules.md': map_with_columns.
+
+    Verify that protect_dropped_new_columns=True on a SelectStatement
+    prevents can_select_statement_be_flattened() from collapsing a subquery
+    that defines NEW columns which are dropped by the outer SELECT.
+    Without the flag the subquery would be flattened away, leaving any
+    future filter/sort with no subquery that exposes the dropped NEW column.
+    """
+
+    def test_filter_on_dropped_new_column_blocked(self, session):
+        """protect_dropped_new_columns=True: select(drop NEW col) must not
+        be flattened even when the dropped NEW column is NOT referenced by a
+        same-level column expression."""
+        df = session.create_dataframe([[1, 2, 3], [4, 5, 6]], schema=["a", "b", "c"])
+
+        # Simulate withColumn("new", lit(1)) — "new" becomes a NEW column.
+        wc = df.select(col("a"), col("b"), col("c"), lit(1).alias("new"))
+        # Mark the SelectStatement as protected, exactly as SCOS map_with_columns does.
+        wc._select_statement.protect_dropped_new_columns = True
+
+        # Outer select drops "new".  With the flag, can_select_statement_be_flattened
+        # must return False and the subquery must be preserved.
+        sel = wc.select(col("c"))
+        sql = sel.queries["queries"][0]
+
+        # The subquery that defines "new" must still be visible in the SQL.
+        assert (
+            sql.upper().count("SELECT") == 2
+        ), f"Expected 2 SELECT levels (subquery preserved), got:\n{sql}"
+        Utils.check_answer(sel, [Row(3), Row(6)], sort=True)
+
+    def test_without_flag_select_is_flattened(self, session):
+        """Control: without protect_dropped_new_columns the outer select IS
+        flattened into the subquery (normal Snowpark behaviour)."""
+        df = session.create_dataframe([[1, 2, 3], [4, 5, 6]], schema=["a", "b", "c"])
+
+        wc = df.select(col("a"), col("b"), col("c"), lit(1).alias("new"))
+        # No flag set — default False.
+        sel = wc.select(col("c"))
+        sql = sel.queries["queries"][0]
+
+        # "new" is DROPPED and not referenced; flattening is safe and expected.
+        assert (
+            sql.upper().count("SELECT") == 1
+        ), f"Expected 1 SELECT level (flattened), got:\n{sql}"
+        Utils.check_answer(sel, [Row(3), Row(6)], sort=True)
+
+    def test_orderby_on_dropped_new_column_blocked(self, session):
+        """protect_dropped_new_columns=True also blocks flattening when the
+        dropped NEW column would be referenced by a subsequent order_by."""
+        df = session.create_dataframe([[1, 3], [2, 1], [3, 2]], schema=["a", "b"])
+
+        wc = df.select(col("a"), col("b").alias("sort_key"))
+        wc._select_statement.protect_dropped_new_columns = True
+
+        sel = wc.select(col("a"))
+        sql = sel.queries["queries"][0]
+
+        # Subquery preserved: outer ORDER BY can reference "sort_key".
+        assert (
+            sql.upper().count("SELECT") == 2
+        ), f"Expected 2 SELECT levels, got:\n{sql}"
+
+    def test_chained_withcolumn_only_last_is_protected(self, session):
+        """The q66 pattern: two consecutive withColumn calls followed by a
+        narrowing select that drops an UNCHANGED_EXP column (d_year).
+
+        This mirrors SCOS map_with_columns behaviour for chained calls:
+          wc1 = grouped.withColumn("ship_carriers", lit(...))   # ship_carriers is NEW
+          wc2 = wc1.withColumn("year", col("d_year"))           # year is NEW; d_year UNCHANGED_EXP
+          sel = wc2.select(*union_cols)   ← protect_dropped_new_columns=True here
+                                            drops d_year (UNCHANGED_EXP, not NEW)
+
+        The protect flag guards against DROPPED-NEW columns.  Since d_year is
+        UNCHANGED_EXP (not NEW) in wc2, the flag must NOT block flattening.
+        """
+        df = session.create_dataframe([[1, 2, 10]], schema=["a", "b", "d_year"])
+
+        def _build(protect: bool):
+            wc1 = df.select(
+                col("a"), col("b"), col("d_year"), lit("X").alias("ship_carriers")
+            )
+            wc2 = wc1.select(
+                col("a"),
+                col("b"),
+                col("d_year"),
+                col("ship_carriers"),
+                col("d_year").alias("year"),
+            )
+            if protect:
+                wc2._select_statement.protect_dropped_new_columns = True
+            # Drops "d_year" (UNCHANGED_EXP in wc2 — not NEW).
+            return wc2.select(col("a"), col("b"), col("ship_carriers"), col("year"))
+
+        sel_no_flag = _build(protect=False)
+        sel_with_flag = _build(protect=True)
+
+        sql_no_flag = sel_no_flag.queries["queries"][0]
+        sql_with_flag = sel_with_flag.queries["queries"][0]
+
+        # The protect flag must NOT add an extra SELECT layer for an
+        # UNCHANGED_EXP dropped column ("d_year").  Both should have the
+        # same number of SELECT clauses.
+        count_no_flag = sql_no_flag.upper().count("SELECT")
+        count_with_flag = sql_with_flag.upper().count("SELECT")
+        assert count_with_flag == count_no_flag, (
+            f"protect_dropped_new_columns added extra SELECT for UNCHANGED_EXP "
+            f"column: without={count_no_flag}, with={count_with_flag}\n"
+            f"SQL (with flag):\n{sql_with_flag}"
+        )
+
+        # Correctness check.
+        Utils.check_answer(sel_with_flag, [Row(1, 2, "X", 10)], sort=True)
+
+
+class TestFlattenDisabledGetTemporaryView:
+    """Scenario 2 from 'Loosen flattening rules.md': _get_temporary_view.
+
+    All rename-target columns are NEW; when a subsequent select drops some
+    of them before an orderBy, flatten_disabled=True on the renaming
+    SelectStatement keeps the subquery that makes the renamed columns visible.
+    """
+
+    def test_orderby_dropped_new_column_with_flatten_disabled(self, session):
+        """Renamed columns (all NEW) are preserved when flatten_disabled=True.
+
+        Mirrors:
+          renamed = df.select(col("t2a").alias("t2a_renamed"), ...)
+          result  = renamed.select("t2d_renamed").orderBy("t2c_renamed", "t2d_renamed")
+        """
+        df = session.create_dataframe(
+            [[1, 2, 3, 4], [5, 6, 7, 8]], schema=["t2a", "t2b", "t2c", "t2d"]
+        )
+
+        renamed = df.select(
+            col("t2a").alias("t2a_renamed"),
+            col("t2b").alias("t2b_renamed"),
+            col("t2c").alias("t2c_renamed"),
+            col("t2d").alias("t2d_renamed"),
+        )
+        # Simulate _get_temporary_view protection.
+        renamed._select_statement.flatten_disabled = True
+
+        result = renamed.select("t2d_renamed").order_by("t2c_renamed", "t2d_renamed")
+        sql = result.queries["queries"][0]
+
+        # The renaming subquery must be preserved so that "t2c_renamed" is in
+        # scope for ORDER BY even though it was dropped by select("t2d_renamed").
+        assert (
+            sql.upper().count("SELECT") >= 2
+        ), f"Expected nested SELECT (flatten_disabled), got:\n{sql}"
+        assert "ORDER BY" in sql.upper(), f"Expected ORDER BY in SQL:\n{sql}"
+        Utils.check_answer(result, [Row(4), Row(8)], sort=False)
+
+    def test_without_flatten_disabled_select_flattens(self, session):
+        """Control: without flatten_disabled the renaming select is collapsed
+        away and "t2c_renamed" would not be in scope for ORDER BY."""
+        df = session.create_dataframe(
+            [[1, 2, 3, 4], [5, 6, 7, 8]], schema=["t2a", "t2b", "t2c", "t2d"]
+        )
+        renamed = df.select(
+            col("t2a").alias("t2a_renamed"),
+            col("t2b").alias("t2b_renamed"),
+            col("t2c").alias("t2c_renamed"),
+            col("t2d").alias("t2d_renamed"),
+        )
+        # No flatten_disabled — all renames are NEW and t2c_renamed IS
+        # referenced by same-level order_by, so flattening is blocked anyway.
+        result = renamed.select("t2d_renamed").order_by("t2c_renamed", "t2d_renamed")
+        sql = result.queries["queries"][0]
+
+        # t2c_renamed IS referenced (is_referenced_by_same_level_column),
+        # so even without flatten_disabled the subquery is preserved.
+        assert "ORDER BY" in sql.upper(), f"Expected ORDER BY in SQL:\n{sql}"
+        Utils.check_answer(result, [Row(4), Row(8)], sort=False)
+
+
+class TestFlattenDisabledMapToDf:
+    """Scenario 3 from 'Loosen flattening rules.md': map_to_df / toDF.
+
+    toDF renames every column (all become NEW).  A subsequent select drops
+    some of those renamed columns before a filter that references them.
+    flatten_disabled=True on the toDF SelectStatement keeps them in scope.
+    """
+
+    def test_filter_on_dropped_todf_column_with_flatten_disabled(self, session):
+        """Mirrors:
+        renamed = df.toDF("foo", "bar", "baz")
+        result  = renamed.select("foo").filter((col("bar") + col("foo")) < 10)
+        """
+        df = session.create_dataframe([[1, 2, 3], [10, 20, 30]], schema=["x", "y", "z"])
+        renamed = df.to_df("foo", "bar", "baz")
+        renamed._select_statement.flatten_disabled = True
+
+        result = renamed.select("foo").filter((col("bar") + col("foo")) < 10)
+        sql = result.queries["queries"][0]
+
+        # Renaming subquery must be preserved so "bar" is in scope for filter.
+        assert (
+            sql.upper().count("SELECT") >= 2
+        ), f"Expected nested SELECT (flatten_disabled), got:\n{sql}"
+        assert "WHERE" in sql.upper(), f"Expected WHERE in SQL:\n{sql}"
+        Utils.check_answer(result, [Row(1)], sort=True)
+
+    def test_filter_and_orderby_on_dropped_todf_columns(self, session):
+        """Extend: filter AND orderBy both reference columns dropped by
+        the intermediate select.  The protecting subquery must cover both."""
+        df = session.create_dataframe(
+            [[3, 1, 100], [1, 3, 200], [2, 2, 300]], schema=["x", "y", "z"]
+        )
+        renamed = df.to_df("foo", "bar", "baz")
+        renamed._select_statement.flatten_disabled = True
+
+        result = renamed.select("foo").filter(col("bar") > 0).order_by(col("baz"))
+        sql = result.queries["queries"][0]
+
+        assert sql.upper().count("SELECT") >= 2, f"Expected nested SELECT, got:\n{sql}"
+        Utils.check_answer(result, [Row(3), Row(1), Row(2)], sort=False)

--- a/tests/integ/test_simplifier_suite.py
+++ b/tests/integ/test_simplifier_suite.py
@@ -2709,8 +2709,8 @@ def test_concurrent_retrieve_agg_event_set_after_context_published(
 
 
 # ---------------------------------------------------------------------------
-# Tests for the three "select() flattens too aggressively" scenarios described
-# in "Loosen flattening rules.md" (SCOS Compatibility section).
+# Tests for three scenarios in SCOS where leaving flattening enabled causes
+# semantic differences from SCOS.
 #
 # Scenario 1 — map_with_columns (SNOW-3489991):
 #   df.withColumn("new", lit(1)).select("c").filter(col("new") > 0)
@@ -2731,7 +2731,7 @@ def test_concurrent_retrieve_agg_event_set_after_context_published(
 
 
 class TestProtectDroppedNewColumns:
-    """Scenario 1 from 'Loosen flattening rules.md': map_with_columns.
+    """Scenario 1: map_with_columns.
 
     Verify that protect_dropped_new_columns=True on a SelectStatement
     prevents can_select_statement_be_flattened() from collapsing a subquery
@@ -2795,7 +2795,7 @@ class TestProtectDroppedNewColumns:
         ), f"Expected 2 SELECT levels, got:\n{sql}"
 
     def test_chained_withcolumn_only_last_is_protected(self, session):
-        """The q66 pattern: two consecutive withColumn calls followed by a
+        """The TPC-DS Q66 pattern: two consecutive withColumn calls followed by a
         narrowing select that drops an UNCHANGED_EXP column (d_year).
 
         This mirrors SCOS map_with_columns behaviour for chained calls:
@@ -2847,7 +2847,7 @@ class TestProtectDroppedNewColumns:
 
 
 class TestFlattenDisabledGetTemporaryView:
-    """Scenario 2 from 'Loosen flattening rules.md': _get_temporary_view.
+    """Scenario 2: _get_temporary_view.
 
     All rename-target columns are NEW; when a subsequent select drops some
     of them before an orderBy, flatten_disabled=True on the renaming
@@ -2909,7 +2909,7 @@ class TestFlattenDisabledGetTemporaryView:
 
 
 class TestFlattenDisabledMapToDf:
-    """Scenario 3 from 'Loosen flattening rules.md': map_to_df / toDF.
+    """Scenario 3: map_to_df / toDF.
 
     toDF renames every column (all become NEW).  A subsequent select drops
     some of those renamed columns before a filter that references them.


### PR DESCRIPTION
1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   <!---
   In this section, please add a Snowflake Jira issue number.

   Note that if a corresponding GitHub issue exists, you should still include
   the Snowflake Jira issue number. For example, for GitHub issue
   https://github.com/snowflakedb/snowpark-python/issues/1400, you should
   add "SNOW-1335071" here.
    --->

   Fixes SNOW-3489991

2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.
   - [x] I acknowledge that I have ensured my changes to be thread-safe. Follow the link for more information: [Thread-safe Developer Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#thread-safe-development)
   - [ ] If adding any arguments to public Snowpark APIs or creating new public Snowpark APIs, I acknowledge that I have ensured my changes include AST support. Follow the link for more information: [AST Support Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#ast-abstract-syntax-tree-support-in-snowpark)

3. Please describe how your code solves the related issue.

### Problem

In Spark Connect mode, `withColumn` calls in SCOS set `flatten_disabled = True` on the resulting `SelectStatement` to prevent a phantom-column bug (SNOW-2306644): if the added column is immediately dropped by the next `.select()`, a subsequent `.filter()` or `.orderBy()` referencing the dropped column would fail because the projection had been collapsed away.

`flatten_disabled = True` is a blunt instrument — it blocks *all* flattening on that statement, including safe cases where the dropped column is never referenced again. For a chain of N `withColumn` calls where all new columns are kept, this produces N nested `SELECT` layers in the generated SQL instead of one flat projection.

### Solution

Add a targeted `protect_dropped_new_columns: bool` flag to `Selectable`. When set, `can_select_statement_be_flattened` blocks flattening only for the specific case it was designed to protect: a column that was **dropped** by the new projection, where the subquery had marked it as **NEW**, and either it is already referenced at the same level *or* the flag is set (anticipating a future filter/sort reference).

This is strictly more permissive than `flatten_disabled`: it allows flattening in all cases except the one that actually triggers the phantom-column bug.

### Changes

- `select_statement.py`: add `protect_dropped_new_columns: bool = False` to `Selectable`; thread it through `select_with()` → `can_select_statement_be_flattened()` as an additional guard condition
- `test_simplifier_suite.py`: 9 new tests covering the flag's behavior across dropped/kept/referenced-in-filter/order-by column scenarios, and confirming `flatten_disabled` still short-circuits unconditionally

### Performance

For a chain of 8 independent `withColumn` calls (all columns kept in output), the new flag produces **2 SELECT layers** vs **10 with `flatten_disabled`**. No measurable change in Snowflake compilation time at small scale (~56 ms both ways); the benefit is structurally simpler SQL and reduced query text size (~1 KB vs ~2.5 KB).

**NOTE**: When CTE optimization is enabled, many existing workloads do not exhibit any changes in query text size, as the nested SELECT layers are re-used in JOIN or UNION operations and get subsumed by CTE optimizations. The improvement is visible when CTE optimization is off, or if the nested dataframe components are not used in JOIN/UNION operations that would trigger CTE (see the new workload added in the corresponding SCOS PR). https://github.com/snowflake-eng/sas/pull/4455/changes

A performance difference is visible for a pathological workload with deeply chained transformations:
```python
df = spark.createDataFrame(
    [(1, 100.0), (2, 200.0), (3, 50.0)], ["id", "amount"]
)   
col_names = ["id", "amount"]
for i in range(1000):
    name = f"feat_{i}"
    df = df.withColumn(name, F.col("amount") * F.lit(float(i % 97 + 1)))
    df = df.filter(F.col("id").isNotNull())
    col_names.append(name)
df = df.select(*col_names)
```

```
==========================================================================
  Comparison: main SCOS vs PR SCOS (depth=500 / 500)
==========================================================================
  label    build_ms   client_ms    sf_ms   sql_chars   SELECTs
  ----------------------------------------------------------
  main           13     213,524  163,227     694,929        49
  pr             13      35,196      683      71,526         2
  pr-main       +2.3%      -83.5%   -99.6%    -623,403       -47
```

Three things to note:

- SQL size (9.7× smaller): The 500 filters each created a new SELECT layer in main SCOS. The CTE optimizer then hoisted those ~500 nested SELECTs into ~49 CTE bodies — which is why the SELECT count is 49 not 500 — but the total SQL text remained nearly 700K chars. PR SCOS merged every filter into the preceding withColumn's SelectStatement, producing 2 SELECTs (one flat projection of all 502 columns, one outer select).
- Snowflake execution time (−99.6%, 163 s → 0.7 s): This is the headline number. A 49-CTE query with hundreds of column references is genuinely expensive for Snowflake to parse and plan. The flat 2-SELECT query is trivial. The CTE optimizer masked the problem at the SQL generation layer but not at the
planning layer.
- Client time (−83.5%, 213 s → 35 s): The bulk of this is the Snowflake round-trip. SCOS translation cost itself is negligible (build is 13 ms in both cases).