### PR TITLE
SNOW-3654858: fix UDF default values eval

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ### Snowpark Python API Updates
 
+#### Bug Fixes
+
+- Fixed a bug where UDF default argument values reconstructed from a source file in `register_from_file` were evaluated with `eval()`; they are now evaluated only against the documented set of supported default-value types, and unsupported expressions are ignored.
+
 ## 1.52.0 (2026-06-10)
 
 ### Snowpark Python API Updates

--- a/src/snowflake/snowpark/_internal/type_utils.py
+++ b/src/snowflake/snowpark/_internal/type_utils.py
@@ -634,6 +634,123 @@ def merge_type(a: DataType, b: DataType, name: Optional[str] = None) -> DataType
         return a
 
 
+# Default values of UDF arguments are statically reconstructed into strings from
+# the source file passed to ``register_from_file``. ``safe_eval_default_value``
+# below evaluates such a string by walking its AST and computing the result
+# directly, instead of using a bare ``eval`` (which would evaluate arbitrary
+# expressions rather than just the documented default-value forms).
+#
+# A UDF argument value can only be one of the documented SQL<->Python types (see
+# https://docs.snowflake.com/en/developer-guide/udf-stored-procedure-data-type-mapping
+# #sql-python-data-type-mappings): int, float, bool, str, list, dict plus
+# decimal.Decimal, datetime.date/time/datetime and bytes/bytearray. The collections
+# below permit those values written either as literals (handled directly by
+# ``evaluate``) or via their constructors (e.g. ``int('5')``, ``decimal.Decimal(...)``,
+# ``datetime.date(...)``); anything else raises ``TypeError`` instead of being
+# evaluated.
+#
+# Everything the evaluator supports is derived from these two collections:
+#
+# 1. ``_SAFE_BUILTINS`` -- builtin value constructors. Their literal forms are
+#    handled directly by ``evaluate``; listing them here also allows the explicit
+#    spelling (``int('5')``, ``list((1, 2))``).
+# 2. ``_SAFE_TYPES`` -- the documented non-literal default types. They are
+#    constructible (``datetime.date(...)``) and expose only pure date/decimal
+#    helpers, so their methods may be called too (``datetime.datetime.now()``,
+#    ``decimal.Decimal('1').sqrt()``) and instances of them may be referenced
+#    (``datetime.timezone.utc``).
+#
+# ``pandas``/``numpy``/other modules are intentionally absent: they are not part of
+# the documented default-value type mapping.
+_SAFE_BUILTINS = (int, float, bool, str, bytes, bytearray, tuple, list, dict)
+_SAFE_TYPES = (
+    decimal.Decimal,
+    datetime.date,
+    datetime.datetime,
+    datetime.time,
+    datetime.timezone,
+    datetime.timedelta,
+)
+# Root identifiers ``resolve`` may start from: the ``datetime``/``decimal`` modules
+# and the builtin constructors. Everything else is reached via attribute access.
+_SAFE_DEFAULT_VALUE_NAMES: Dict[str, Any] = {
+    "datetime": datetime,
+    "decimal": decimal,
+    **{builtin.__name__: builtin for builtin in _SAFE_BUILTINS},
+}
+
+
+def safe_eval_default_value(value: str) -> Any:
+    """Safely evaluate a UDF default-value expression reconstructed from source.
+
+    Only literals, containers, the builtin value constructors (``int``, ``str``,
+    ``list``, ...), the documented non-literal constructors (``decimal``/
+    ``datetime`` types and ``bytes``/``bytearray``) and non-dunder methods of those
+    ``datetime``/``decimal`` types (e.g. ``datetime.datetime.now()``,
+    ``decimal.Decimal('1').sqrt()``) are permitted. Any other expression raises
+    ``TypeError`` instead of being evaluated.
+    """
+
+    def resolve(node: ast.expr) -> Any:
+        # Best-effort value of a reference/expression, or ``None`` if it is not
+        # reachable from the safe namespace. A ``name`` is looked up in the safe
+        # namespace; ``base.attr`` reads a (non-dunder) attribute of the resolved
+        # base; anything else (e.g. a nested call receiver) is evaluated.
+        if isinstance(node, ast.Name):
+            return _SAFE_DEFAULT_VALUE_NAMES.get(node.id)
+        if isinstance(node, ast.Attribute):
+            if node.attr.startswith("_"):
+                return None
+            base = resolve(node.value)
+            return None if base is None else getattr(base, node.attr, None)
+        return evaluate(node)
+
+    def evaluate(node: ast.expr) -> Any:
+        if isinstance(node, ast.Constant):
+            return node.value
+        if isinstance(node, ast.List):
+            return [evaluate(elt) for elt in node.elts]
+        if isinstance(node, ast.Tuple):
+            return tuple(evaluate(elt) for elt in node.elts)
+        if isinstance(node, ast.Set):
+            return {evaluate(elt) for elt in node.elts}
+        if isinstance(node, ast.Dict):
+            return {evaluate(k): evaluate(v) for k, v in zip(node.keys, node.values)}
+        if isinstance(node, ast.UnaryOp) and isinstance(node.op, (ast.UAdd, ast.USub)):
+            operand = evaluate(node.operand)
+            return +operand if isinstance(node.op, ast.UAdd) else -operand
+        if isinstance(node, ast.Call):
+            args = [evaluate(arg) for arg in node.args]
+            kwargs = {kw.arg: evaluate(kw.value) for kw in node.keywords}
+            # A constructor, e.g. ``int('5')`` or ``datetime.date(...)``.
+            func = resolve(node.func)
+            if func in _SAFE_BUILTINS or func in _SAFE_TYPES:
+                return func(*args, **kwargs)
+            # A non-dunder method on a supported datetime/decimal class or instance,
+            # e.g. ``datetime.datetime.now()`` or ``decimal.Decimal('1').sqrt()``.
+            if isinstance(node.func, ast.Attribute) and not node.func.attr.startswith(
+                "_"
+            ):
+                receiver = resolve(node.func.value)
+                if receiver in _SAFE_TYPES or isinstance(receiver, _SAFE_TYPES):
+                    return getattr(receiver, node.func.attr)(*args, **kwargs)
+            raise TypeError(f"disallowed call in default value: {value!r}")
+        if isinstance(node, (ast.Name, ast.Attribute)):
+            # A bare reference is only allowed if it is an instance of a supported
+            # type, e.g. ``datetime.timezone.utc`` or ``datetime.date.max``.
+            obj = resolve(node)
+            if isinstance(obj, _SAFE_TYPES):
+                return obj
+            raise TypeError(f"disallowed reference in default value: {value!r}")
+        raise TypeError(f"invalid default value: {value!r}")
+
+    try:
+        tree = ast.parse(value, mode="eval")
+    except (ValueError, SyntaxError, RecursionError) as e:
+        raise TypeError(f"invalid default value: {value!r}") from e
+    return evaluate(tree.body)
+
+
 def python_value_str_to_object(value, tp: Optional[DataType]) -> Any:
     if tp is None:
         return None
@@ -653,17 +770,17 @@ def python_value_str_to_object(value, tp: Optional[DataType]) -> Any:
             TimestampType,
         ),
     ):
-        return eval(value)
+        return safe_eval_default_value(value)
 
     if isinstance(tp, ArrayType):
-        curr_list = eval(value)
+        curr_list = safe_eval_default_value(value)
         if curr_list is None:
             return None
         element_tp = tp.element_type or StringType()
         return [python_value_str_to_object(val, element_tp) for val in curr_list]
 
     if isinstance(tp, MapType):
-        curr_dict: dict = eval(value)
+        curr_dict: dict = safe_eval_default_value(value)
         if curr_dict is None:
             return None
         key_tp = tp.key_type or StringType()

--- a/tests/integ/test_udf.py
+++ b/tests/integ/test_udf.py
@@ -1299,7 +1299,11 @@ def test_register_udf_from_file_does_not_evaluate_unsupported_default(
     marker = os.path.join(tmpdir, "marker.txt")
     assert not os.path.exists(marker)
 
-    expr = unsupported_default.format(marker=marker)
+    # Escape backslashes so a Windows path (e.g. C:\\Users\\...) embedded in the
+    # source string literal does not trigger a unicodeescape SyntaxError in
+    # ast.parse before the default value is ever reconstructed.
+    marker_in_source = marker.replace("\\", "\\\\")
+    expr = unsupported_default.format(marker=marker_in_source)
     func_body = f"""
 def sample(x: int = {expr}) -> int:
     return x

--- a/tests/integ/test_udf.py
+++ b/tests/integ/test_udf.py
@@ -1135,6 +1135,18 @@ def return_all_datatypes(
 ) -> str:
     final_str = f"{a}, {b}, {c}, {d}, {e}, {f}, {g}, {h}, {i}, {j}, {k}, {l}, {m}, {n}"
     return final_str
+
+def return_constructor_forms(
+    p: int = int("5"),
+    q: float = float("2.5"),
+    r: datetime.datetime = datetime.datetime(2020, 1, 1, 12, 0, 0).replace(hour=13),
+    s: datetime.date = datetime.date(2020, 1, 1).replace(year=2021),
+    t: decimal.Decimal = decimal.Decimal("4").sqrt(),
+    u: datetime.date = datetime.date.max,
+    v: datetime.datetime = datetime.datetime.now(),
+    w: datetime.date = datetime.date.today(),
+) -> str:
+    return f"{p}, {q}, {r}, {s}, {t}, {u}|{v}|{w}"
 """
     session.add_packages("snowflake-snowpark-python")
     if register_from_file:
@@ -1153,6 +1165,9 @@ def return_all_datatypes(
         return_all_datatypes_udf = session.udf.register_from_file(
             file_path, "return_all_datatypes"
         )
+        return_constructor_forms_udf = session.udf.register_from_file(
+            file_path, "return_constructor_forms"
+        )
     else:
         d = {}
         exec(func_body, {**globals(), **locals()}, d)
@@ -1163,6 +1178,9 @@ def return_all_datatypes(
         return_date_udf = session.udf.register(d["return_date"])
         return_arr_udf = session.udf.register(d["return_arr"])
         return_all_datatypes_udf = session.udf.register(d["return_all_datatypes"])
+        return_constructor_forms_udf = session.udf.register(
+            d["return_constructor_forms"]
+        )
 
     df = session.create_dataframe([[1, 4], [2, 3]]).to_df("a", "b")
     Utils.check_answer(
@@ -1228,6 +1246,79 @@ def return_all_datatypes(
             Row(default_row, custom_row),
             Row(default_row, custom_row),
         ],
+    )
+
+    # Additional default-value forms supported by the default-value evaluator:
+    # builtin-constructor spellings (``int("5")``/``float("2.5")``), non-dunder
+    # methods on datetime/decimal values (``.replace(...)``/``.sqrt()``) and bare
+    # references to type instances (``datetime.date.max``) -- compared by value. The
+    # trailing factory methods (``datetime.datetime.now()`` /
+    # ``datetime.date.today()``) are non-deterministic, so we only assert they
+    # resolve to a non-empty value.
+    expected_deterministic = (
+        "5, 2.5, 2020-01-01 13:00:00, 2021-01-01, 2.000000000000000000, 9999-12-31"
+    )
+    for row in df.select(return_constructor_forms_udf()).collect():
+        deterministic, now_value, today_value = row[0].split("|")
+        assert deterministic == expected_deterministic
+        assert now_value  # datetime.datetime.now() resolved to a value
+        assert today_value  # datetime.date.today() resolved to a value
+
+
+@pytest.mark.xfail(
+    "config.getoption('local_testing_mode', default=False)",
+    reason="SNOW-1412530 to fix bug",
+    run=False,
+)
+@pytest.mark.parametrize(
+    "unsupported_default",
+    [
+        # Expressions with side effects: must never be evaluated during registration.
+        "__import__('os').system('touch {marker}')",
+        "open('{marker}', 'w').write('hi')",
+        # Other unsupported calls: must be rejected, not evaluated.
+        "eval(\"open('{marker}', 'w').write('hi')\")",
+    ],
+)
+def test_register_udf_from_file_does_not_evaluate_unsupported_default(
+    session: Session, tmpdir, unsupported_default
+):
+    """An unsupported default in a source file must not be evaluated on the client.
+
+    Guards the fix end-to-end through ``register_from_file``: reconstructing the
+    default from the source must not evaluate it on the client, and registration
+    must fail open -- the unsupported default is dropped (the argument loses its
+    default) instead of crashing.
+
+    Note: this only covers *client-side* evaluation during registration. The
+    uploaded source is still imported by the server when the UDF runs, where
+    Python evaluates the default at ``def`` time as usual; that is inherent to
+    ``register_from_file`` and outside the scope of this client-side fix, so the
+    UDF is intentionally not invoked here.
+    """
+    marker = os.path.join(tmpdir, "marker.txt")
+    assert not os.path.exists(marker)
+
+    expr = unsupported_default.format(marker=marker)
+    func_body = f"""
+def sample(x: int = {expr}) -> int:
+    return x
+"""
+    file_path = os.path.join(tmpdir, "register_from_file_unsupported.py")
+    with open(file_path, "w") as f:
+        f.write(func_body)
+
+    session.add_packages("snowflake-snowpark-python")
+    # Fail-open: registration succeeds (the unsupported default is dropped) rather
+    # than raising or evaluating the expression.
+    sample_udf = session.udf.register_from_file(file_path, "sample")
+    assert sample_udf is not None
+
+    # The default value expression must not have been evaluated on the client: the
+    # marker file must not be created.
+    assert not os.path.exists(marker), (
+        "An unsupported UDF default value was evaluated on the client during "
+        "register_from_file."
     )
 
 

--- a/tests/unit/test_type_utils_default_values.py
+++ b/tests/unit/test_type_utils_default_values.py
@@ -80,9 +80,13 @@ class TestSafeEvalDefaultValue:
     def test_unsupported_default_in_full_register_flow(self, tmp_path):
         """End-to-end: an unsupported default in a source file must not be evaluated."""
         marker_file = tmp_path / "side_effect_e2e.txt"
+        # Escape backslashes so a Windows path (e.g. C:\\Users\\...) embedded in the
+        # source string literal does not trigger a unicodeescape SyntaxError in
+        # ast.parse before the default value is ever reconstructed.
+        marker_in_source = str(marker_file).replace("\\", "\\\\")
 
         source = f"""
-def sample_udf(x: int = __import__('os').system('touch {marker_file}')) -> int:
+def sample_udf(x: int = __import__('os').system('touch {marker_in_source}')) -> int:
     return x
 """
         # retrieve_func_defaults_from_source parses the AST and reconstructs the

--- a/tests/unit/test_type_utils_default_values.py
+++ b/tests/unit/test_type_utils_default_values.py
@@ -1,0 +1,291 @@
+#
+# Copyright (c) 2012-2025 Snowflake Computing Inc. All rights reserved.
+#
+
+"""Regression tests for evaluating UDF default values reconstructed from source.
+
+When registering a UDF from a source file, default parameter values are statically
+reconstructed into strings by ``retrieve_func_defaults_from_source`` (including
+``ast.Call``/``ast.Attribute``/``ast.Name`` nodes) and then evaluated by
+``python_value_str_to_object``. That evaluation used to call a bare ``eval()``,
+which would evaluate arbitrary expressions instead of just the documented default
+values, so a source file such as::
+
+    def foo(x: int = __import__('os').system('echo hi')) -> int: ...
+
+would run that expression while reading the default during registration.
+
+``safe_eval_default_value`` replaces ``eval`` with an allowlist evaluator that
+supports only literals, containers, and a fixed set of constructors
+(``datetime``/``decimal``/``bytes``/``bytearray``/...). These tests guard two
+properties simultaneously:
+
+1. unsupported expressions are rejected (never evaluated), and
+2. the documented constructor defaults keep working (a naive ``ast.literal_eval``
+   replacement would silently break these).
+"""
+
+import datetime
+import decimal
+
+import pytest
+
+from snowflake.snowpark._internal.type_utils import (
+    python_value_str_to_object,
+    retrieve_func_defaults_from_source,
+    safe_eval_default_value,
+)
+from snowflake.snowpark.types import (
+    BinaryType,
+    DateType,
+    DecimalType,
+    IntegerType,
+    TimestampType,
+    TimeType,
+)
+
+UNSUPPORTED_EXPRESSIONS = [
+    "__import__('os').system('echo hi')",
+    "os.system('id')",
+    "open('/etc/passwd').read()",
+    "eval('1')",
+    "exec('x=1')",
+    "().__class__.__base__",
+    "().__class__",
+    "globals()",
+    "[].__class__",
+]
+
+
+class TestSafeEvalDefaultValue:
+    @pytest.mark.parametrize("expr", UNSUPPORTED_EXPRESSIONS)
+    def test_unsupported_expression_is_rejected(self, expr):
+        """Unsupported expressions must raise instead of being evaluated."""
+        with pytest.raises(TypeError):
+            safe_eval_default_value(expr)
+
+    def test_unsupported_default_value_not_evaluated(self, tmp_path):
+        """An unsupported default value expression must NOT be evaluated."""
+        marker_file = tmp_path / "side_effect.txt"
+        expr = f"__import__('os').system('touch {marker_file}')"
+
+        with pytest.raises(TypeError):
+            python_value_str_to_object(expr, IntegerType())
+
+        assert not marker_file.exists(), (
+            "An unsupported default value expression was evaluated: the marker file "
+            "was created, proving the expression ran instead of being rejected."
+        )
+
+    def test_unsupported_default_in_full_register_flow(self, tmp_path):
+        """End-to-end: an unsupported default in a source file must not be evaluated."""
+        marker_file = tmp_path / "side_effect_e2e.txt"
+
+        source = f"""
+def sample_udf(x: int = __import__('os').system('touch {marker_file}')) -> int:
+    return x
+"""
+        # retrieve_func_defaults_from_source parses the AST and reconstructs the
+        # default value as a string like "__import__('os').system('touch ...')"
+        defaults = retrieve_func_defaults_from_source(
+            "fake.py", "sample_udf", _source=source
+        )
+
+        assert defaults is not None, "Function should be found in source"
+
+        for default_str in defaults:
+            if default_str is not None:
+                with pytest.raises(TypeError):
+                    python_value_str_to_object(default_str, IntegerType())
+
+        assert not marker_file.exists(), (
+            "An unsupported default value expression was evaluated via the "
+            "register_from_file flow: the marker file was created."
+        )
+
+    def test_safe_literal_defaults_still_work(self):
+        """Legitimate literal defaults must continue to parse correctly."""
+        assert python_value_str_to_object("42", IntegerType()) == 42
+        assert python_value_str_to_object("-1", IntegerType()) == -1
+        assert python_value_str_to_object("None", IntegerType()) is None
+
+    def test_legitimate_constructor_defaults_still_work(self):
+        """Constructor-based defaults must keep working.
+
+        These are exactly the cases a naive ``ast.literal_eval`` replacement would
+        silently break, so this is the key non-regression guard for the fix.
+        """
+        assert python_value_str_to_object(
+            "decimal.Decimal('3.14')", DecimalType()
+        ) == decimal.Decimal("3.14")
+        assert python_value_str_to_object(
+            "bytearray('one', 'utf-8')", BinaryType()
+        ) == bytearray("one", "utf-8")
+        assert python_value_str_to_object(
+            "datetime.date(2024, 4, 1)", DateType()
+        ) == datetime.date(2024, 4, 1)
+        assert python_value_str_to_object(
+            "datetime.time(12, 0, second=20, tzinfo=datetime.timezone.utc)", TimeType()
+        ) == datetime.time(12, 0, second=20, tzinfo=datetime.timezone.utc)
+        assert python_value_str_to_object(
+            "datetime.datetime(2024, 4, 1, 12, 0, 20)", TimestampType()
+        ) == datetime.datetime(2024, 4, 1, 12, 0, 20)
+
+    @pytest.mark.parametrize(
+        "expr,expected",
+        [
+            # Literals / containers (int, float, bool, str, list, dict).
+            ("5", 5),
+            ("1.5", 1.5),
+            ("True", True),
+            ("'abc'", "abc"),
+            ("[1, 2, 3]", [1, 2, 3]),
+            ("{'a': 1}", {"a": 1}),
+            ("b'one'", b"one"),
+            # Builtin value constructors (explicit-constructor spelling). Only the
+            # builtins that map to a Snowflake type are allowed.
+            ("int('5')", 5),
+            ("float('1.5')", 1.5),
+            ("bool(1)", True),
+            ("str(3)", "3"),
+            ("list((1, 2))", [1, 2]),
+            ("tuple([1, 2])", (1, 2)),
+            ("dict(a=1)", {"a": 1}),
+            # Non-literal value constructors permitted by the documented type mapping.
+            ("bytes(3)", bytes(3)),
+            ("bytearray('one', 'utf-8')", bytearray("one", "utf-8")),
+            ("decimal.Decimal('3.14')", decimal.Decimal("3.14")),
+            ("datetime.date(2024, 4, 1)", datetime.date(2024, 4, 1)),
+            (
+                "datetime.time(12, 0, second=20, tzinfo=datetime.timezone.utc)",
+                datetime.time(12, 0, second=20, tzinfo=datetime.timezone.utc),
+            ),
+            (
+                "datetime.datetime(2024, 4, 1, 12, 0, 20)",
+                datetime.datetime(2024, 4, 1, 12, 0, 20),
+            ),
+            # Timezone-aware constructors (``datetime.timezone.utc`` as an argument).
+            (
+                "datetime.datetime(2024, 1, 1, tzinfo=datetime.timezone.utc)",
+                datetime.datetime(2024, 1, 1, tzinfo=datetime.timezone.utc),
+            ),
+            # Nested constructor calls (a ``timedelta`` inside a ``timezone``).
+            (
+                "datetime.timezone(datetime.timedelta(hours=5))",
+                datetime.timezone(datetime.timedelta(hours=5)),
+            ),
+            # Unary minus and negative constructor arguments.
+            ("-5", -5),
+            ("datetime.timedelta(days=-1)", datetime.timedelta(days=-1)),
+            # Containers nesting allowed constructor calls.
+            (
+                "[datetime.date(2024, 1, 1), datetime.date(2024, 1, 2)]",
+                [datetime.date(2024, 1, 1), datetime.date(2024, 1, 2)],
+            ),
+            (
+                "{'d': datetime.date(2024, 1, 1)}",
+                {"d": datetime.date(2024, 1, 1)},
+            ),
+        ],
+    )
+    def test_documented_value_forms_allowed(self, expr, expected):
+        """Every documented value form (literals + constructors) evaluates."""
+        assert safe_eval_default_value(expr) == expected
+
+    @pytest.mark.parametrize(
+        "expr,expected",
+        [
+            ("datetime.timezone.utc", datetime.timezone.utc),
+            ("datetime.date.max", datetime.date.max),
+            ("datetime.date.min", datetime.date.min),
+            ("datetime.datetime.min", datetime.datetime.min),
+            ("datetime.datetime.max", datetime.datetime.max),
+        ],
+    )
+    def test_supported_type_instance_references_allowed(self, expr, expected):
+        """Bare references to instances of supported types are permitted."""
+        assert safe_eval_default_value(expr) == expected
+
+    @pytest.mark.parametrize(
+        "expr,expected",
+        [
+            # Deterministic methods on supported datetime/decimal types.
+            ("datetime.datetime.fromtimestamp(0)", datetime.datetime.fromtimestamp(0)),
+            (
+                "datetime.date(2024, 1, 1).replace(year=2025)",
+                datetime.date(2025, 1, 1),
+            ),
+            ("decimal.Decimal('1').sqrt()", decimal.Decimal("1")),
+            ("decimal.Decimal(10).sqrt()", decimal.Decimal(10).sqrt()),
+            (
+                "datetime.timedelta(days=1).total_seconds()",
+                datetime.timedelta(days=1).total_seconds(),
+            ),
+            # Method on a supported-type instance reached via a bare reference.
+            (
+                "datetime.timezone.utc.utcoffset(None)",
+                datetime.timezone.utc.utcoffset(None),
+            ),
+        ],
+    )
+    def test_supported_type_method_calls_allowed(self, expr, expected):
+        """Non-dunder methods on datetime/decimal types are permitted."""
+        assert safe_eval_default_value(expr) == expected
+
+    @pytest.mark.parametrize(
+        "expr,expected_type",
+        [
+            ("datetime.datetime.now()", datetime.datetime),
+            ("datetime.date.today()", datetime.date),
+            # Factory method with a timezone argument.
+            ("datetime.datetime.now(datetime.timezone.utc)", datetime.datetime),
+            ("datetime.datetime.now(tz=datetime.timezone.utc)", datetime.datetime),
+            # Chained: method on the result of a factory method.
+            ("datetime.datetime.now().date()", datetime.date),
+        ],
+    )
+    def test_supported_type_factory_methods_allowed(self, expr, expected_type):
+        """Factory/classmethods (non-deterministic value) on supported types work."""
+        assert isinstance(safe_eval_default_value(expr), expected_type)
+
+    @pytest.mark.parametrize(
+        "expr",
+        [
+            # Module-qualified calls into modules that are not part of the documented
+            # default-value type mapping. Only the documented types are supported, so
+            # the whole module namespace is rejected rather than enumerated.
+            'pandas.Timestamp("2024-01-01")',
+            "numpy.float64(1.5)",
+            'pandas.read_pickle("x")',
+            'numpy.load("x")',
+            "sys.maxsize",  # arbitrary module attribute
+            # Dunder access/calls on a supported-type result are still rejected.
+            "datetime.datetime.now().__class__",
+            "datetime.datetime.now().__class__()",
+            "datetime.datetime.fromtimestamp(0).__reduce__()",
+            # Bare references to a module or class (only *instances* are allowed).
+            "datetime",
+            "datetime.datetime",
+            "datetime.timezone",
+            "decimal.Decimal",
+            # A method referenced but not called is not an instance of a supported type.
+            "datetime.datetime.now",
+            # Unsupported expression node kinds. These never reach
+            # ``safe_eval_default_value`` in practice either: ``parse_default_value``
+            # in ``retrieve_func_defaults_from_source`` only reconstructs
+            # Constant/Name/Attribute/Call/Tuple/List/Dict, so the original code
+            # rejected them at reconstruction too (i.e. they are not regressions).
+            "lambda: 1",  # lambda
+            "1 if True else 2",  # conditional expression (IfExp)
+            "60 * 60",  # arithmetic (BinOp) is not constant-folded
+            "[x for x in (1, 2)]",  # list comprehension (ListComp, not a List literal)
+            # Valid Python values that don't map to a Snowflake type.
+            "complex(1, 2)",
+            "set([1, 2])",
+            "frozenset([1])",
+        ],
+    )
+    def test_non_canonical_forms_rejected(self, expr):
+        """Forms outside the documented type mapping are rejected, not evaluated."""
+        with pytest.raises(TypeError):
+            safe_eval_default_value(expr)


### PR DESCRIPTION
<!---
Please answer these questions before creating your pull request. Thanks!
--->

1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   <!---
   In this section, please add a Snowflake Jira issue number.

   Note that if a corresponding GitHub issue exists, you should still include
   the Snowflake Jira issue number. For example, for GitHub issue
   https://github.com/snowflakedb/snowpark-python/issues/1400, you should
   add "SNOW-1335071" here.
    --->

   Fixes SNOW-3654858, Fixed a bug where UDF default argument values reconstructed from a source file in `register_from_file` were evaluated with `eval()`; they are now evaluated only against the documented set of supported default-value types, and unsupported expressions are ignored.

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.
   - [ ] I acknowledge that I have ensured my changes to be thread-safe. Follow the link for more information: [Thread-safe Developer Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#thread-safe-development)
   - [ ] If adding any arguments to public Snowpark APIs or creating new public Snowpark APIs, I acknowledge that I have ensured my changes include AST support. Follow the link for more information: [AST Support Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#ast-abstract-syntax-tree-support-in-snowpark)

3. Please describe how your code solves the related issue.

   Please write a short description of how your code change solves the related issue.
