### PR TITLE
SNOW-3654851: escape single quote and backslash in Lineage.trace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ### Snowpark Python API Updates
 
+#### Bug Fixes
+
+- Fixed a bug where `object_name`, `object_domain`, or `object_version` values containing single quotes or backslashes in `session.lineage.trace()` caused incorrect SQL generation. These values are now properly escaped before being embedded in the `SYSTEM$DGQL` call.
+
 ## 1.52.0 (2026-06-10)
 
 ### Snowpark Python API Updates

--- a/src/snowflake/snowpark/lineage.py
+++ b/src/snowflake/snowpark/lineage.py
@@ -209,10 +209,10 @@ class _DGQLQueryBuilder:
                     object_name, object_version
                 )
                 object_version = None
-            object_name = object_name.replace('"', '\\\\"')
+            object_name = object_name.replace('"', '\\"')
             query_object = object_name
             if object_version:
-                object_version = object_version.replace('"', '\\\\"')
+                object_version = object_version.replace('"', '\\"')
                 query_object = object_version
                 parent_param = f', parentName:"{object_name}"'
 
@@ -229,6 +229,13 @@ class _DGQLQueryBuilder:
             parent_param=parent_param,
             edges="".join(parts),
         )
+        # The assembled DGQL body is embedded inside a single-quoted SQL string
+        # literal passed to SYSTEM$DGQL. Backslash must be escaped before the
+        # single quote because Snowflake treats '\' as an escape character in
+        # string literals, so doubling quotes alone is insufficient when the
+        # input contains a backslash. This mirrors str_to_sql() in
+        # _internal/analyzer/datatype_mapper.py.
+        query = query.replace("\\", "\\\\").replace("'", "''")
         return f"select SYSTEM$DGQL('{query}')"
 
     @staticmethod

--- a/tests/integ/test_lineage.py
+++ b/tests/integ/test_lineage.py
@@ -5,10 +5,12 @@
 
 
 import json
+import time
 import uuid
 
 import pytest
 
+from snowflake.snowpark.exceptions import SnowparkSQLException
 from snowflake.snowpark.lineage import LineageDirection
 
 try:
@@ -60,70 +62,259 @@ def remove_created_on_field(df):
     return df
 
 
-@pytest.mark.skipif(not is_pandas_available, reason="pandas is required")
-@pytest.mark.skip(reason="SNOW-3413244 lineage test is flaky")
-def test_lineage_trace(session):
+def assert_lineage_contains(actual_df, expected_data):
+    """Assert that every row in expected_data appears in actual_df.
+
+    Lineage propagation is asynchronous and some environments return more edges
+    than the minimum expected (e.g. additional hops propagate between the poll
+    and the collect). Allowing extra rows avoids spurious failures while still
+    verifying that all the edges we care about are present.
     """
-    Tests lineage.trace API on multiple cases.
+    expected_df = pd.DataFrame(expected_data)
+    assert actual_df.shape[0] >= len(expected_df), (
+        f"Expected at least {len(expected_df)} rows, got {actual_df.shape[0]}.\n"
+        f"Actual:\n{actual_df.to_string()}"
+    )
+    for _, expected_row in expected_df.iterrows():
+        match = actual_df
+        for col in expected_df.columns:
+            match = match[match[col] == expected_row[col]]
+        assert len(match) > 0, (
+            f"Expected row not found in result:\n{dict(expected_row)}\n"
+            f"Actual:\n{actual_df.to_string()}"
+        )
+
+
+def wait_for_lineage(
+    session,
+    object_name,
+    object_domain,
+    direction,
+    distance=5,
+    expected_min_rows=1,
+    timeout=120,
+    interval=2,
+):
+    """Poll lineage.trace() until at least ``expected_min_rows`` rows appear
+    or the timeout (seconds) is exceeded.
+
+    Lineage data is populated asynchronously on Snowflake: the index is built
+    in the background after object creation / DML, so a trace executed
+    immediately after CREATE TABLE/VIEW can return 0 rows even though the
+    objects exist. Polling avoids this race without relying on arbitrary sleeps.
+    """
+    deadline = time.monotonic() + timeout
+    while True:
+        rows = session.lineage.trace(
+            object_name, object_domain, direction=direction, distance=distance
+        ).collect()
+        if len(rows) >= expected_min_rows:
+            return rows
+        if time.monotonic() >= deadline:
+            pytest.xfail(
+                f"Lineage for {object_name!r} ({object_domain}) did not return "
+                f">= {expected_min_rows} row(s) within {timeout}s. "
+                f"Got {len(rows)} row(s)."
+            )
+        time.sleep(interval)
+
+
+@pytest.fixture
+def tmp_lineage_schema(session):
+    """Create a temporary schema and guarantee cleanup even when the test fails.
+
+    Yields (db, schema, primary_role, current_wh) so the test body can use them
+    directly. Teardown restores all session-level state that Case 4 may change
+    (role, secondary roles, warehouse) before dropping the schema, ensuring a
+    clean handoff to the next test on the same xdist worker.
     """
     db = session.get_current_database().replace('"', "")
     schema = ("sch" + str(uuid.uuid4()).replace("-", "")[:10]).upper()
     primary_role = session.get_current_role().replace('"', "")
     current_wh = session.get_current_warehouse().replace('"', "")
     session.sql(f"CREATE SCHEMA {db}.{schema}").collect()
+    yield db, schema, primary_role, current_wh
+    session.sql(f"USE ROLE {primary_role}").collect()
+    try:
+        session.sql("USE SECONDARY ROLES ALL").collect()
+    except Exception:
+        pass
+    session.sql(f"USE WAREHOUSE {current_wh}").collect()
+    session.sql(f"DROP SCHEMA IF EXISTS {db}.{schema}").collect()
+
+
+@pytest.mark.flaky(reruns=0)
+def test_lineage_trace_string_escaping(session):
+    """Regression test for string escaping in Lineage.trace().
+
+    object_domain and object_name values containing single quotes or
+    backslashes must be properly escaped before being embedded in the
+    single-quoted SQL string literal passed to SYSTEM$DGQL. This test runs
+    against a live account and verifies:
+      * a legitimate trace completes without error (no regression), and
+      * values with special characters are handled safely -- a marker table
+        created before each call still exists afterwards, confirming no
+        unintended SQL was executed.
+    """
+    db = session.get_current_database().replace('"', "")
+    schema = ("sch" + str(uuid.uuid4()).replace("-", "")[:10]).upper()
+    session.sql(f"CREATE SCHEMA {db}.{schema}").collect()
+
+    sentinel = f"{db}.{schema}.SENTINEL"
+
+    def sentinel_exists() -> bool:
+        rows = session.sql(
+            f"SHOW TABLES LIKE 'SENTINEL' IN SCHEMA {db}.{schema}"
+        ).collect()
+        return len(rows) > 0
+
+    try:
+        session.sql(f"CREATE OR REPLACE TABLE {db}.{schema}.T1(C1 INT)").collect()
+        session.sql(
+            f"CREATE OR REPLACE VIEW {db}.{schema}.V1 AS SELECT * FROM {db}.{schema}.T1"
+        ).collect()
+        session.sql(f"CREATE OR REPLACE TABLE {sentinel}(C1 INT)").collect()
+
+        # Verify a legitimate trace completes without error. The exact number of
+        # lineage edges can lag object creation (see SNOW-3413244), so we only
+        # assert the call succeeds rather than a specific row count.
+        rows = session.lineage.trace(
+            f"{db}.{schema}.T1",
+            "table",
+            direction=LineageDirection.DOWNSTREAM,
+            distance=1,
+        ).collect()
+        assert isinstance(rows, list)
+
+        # object_domain values with special characters. object_domain is not
+        # validated by _check_valid_object_name, so special characters reach
+        # build_query and must be escaped. Each call should either return a
+        # result or be rejected server-side; in all cases the marker table must
+        # remain untouched.
+        special_domains = [
+            "table' OR 1=1--",
+            f"table'); DROP TABLE {sentinel}; --",
+            f"table\\'); DROP TABLE {sentinel}; --",
+            "table\\' || (select current_user()) --",
+        ]
+        for domain in special_domains:
+            try:
+                session.lineage.trace(
+                    f"{db}.{schema}.T1",
+                    domain,
+                    direction=LineageDirection.DOWNSTREAM,
+                    distance=1,
+                ).collect()
+            except SnowparkSQLException:
+                pass
+            assert (
+                sentinel_exists()
+            ), f"Marker table missing after trace with object_domain={domain!r}"
+
+        # object_name values with special characters via quoted identifiers. The
+        # name must pass _check_valid_object_name (exactly 3 parts), so the
+        # special characters live inside a double-quoted part and reach
+        # build_query. They must be escaped so the marker table is unaffected.
+        special_names = [
+            f'{db}.{schema}."o\'brien"',
+            f'{db}.{schema}."x\'); DROP TABLE {sentinel}; --"',
+            f'{db}.{schema}."x\\\'); DROP TABLE {sentinel}; --"',
+        ]
+        for name in special_names:
+            try:
+                session.lineage.trace(
+                    name, "table", direction=LineageDirection.DOWNSTREAM, distance=1
+                ).collect()
+            except (SnowparkSQLException, ValueError):
+                pass
+            assert (
+                sentinel_exists()
+            ), f"Marker table missing after trace with object_name={name!r}"
+    finally:
+        session.sql(f"DROP SCHEMA IF EXISTS {db}.{schema}").collect()
+
+
+@pytest.mark.skipif(not is_pandas_available, reason="pandas is required")
+@pytest.mark.flaky(reruns=0)
+def test_lineage_trace(session, tmp_lineage_schema):
+    """
+    Tests lineage.trace API on multiple cases.
+    """
+    db, schema, primary_role, current_wh = tmp_lineage_schema
     session.sql(f"use warehouse {current_wh}").collect()
 
     create_objects_for_test(session, db, schema)
 
     # CASE 1 : trace with the role that has VIEW LINEAGE privillege.
-    df = session.lineage.trace(
+    rows = wait_for_lineage(
+        session,
         f"{db}.{schema}.T1",
         "table",
         direction=LineageDirection.DOWNSTREAM,
         distance=4,
+        expected_min_rows=4,
+        timeout=120,
     )
-    df = remove_created_on_field(df.to_pandas())
+    df = remove_created_on_field(
+        pd.DataFrame(
+            [[r[0], r[1], r[2], r[3]] for r in rows],
+            columns=["SOURCE_OBJECT", "TARGET_OBJECT", "DIRECTION", "DISTANCE"],
+        )
+    )
 
-    expected_data = {
-        "SOURCE_OBJECT": [
-            {"domain": "TABLE", "name": f"{db}.{schema}.T1", "status": "ACTIVE"},
-            {"domain": "VIEW", "name": f"{db}.{schema}.V1", "status": "ACTIVE"},
-            {"domain": "VIEW", "name": f"{db}.{schema}.V2", "status": "ACTIVE"},
-            {"domain": "VIEW", "name": f"{db}.{schema}.V3", "status": "ACTIVE"},
-        ],
-        "TARGET_OBJECT": [
-            {"domain": "VIEW", "name": f"{db}.{schema}.V1", "status": "ACTIVE"},
-            {"domain": "VIEW", "name": f"{db}.{schema}.V2", "status": "ACTIVE"},
-            {"domain": "VIEW", "name": f"{db}.{schema}.V3", "status": "ACTIVE"},
-            {"domain": "VIEW", "name": f"{db}.{schema}.V4", "status": "ACTIVE"},
-        ],
-        "DIRECTION": ["Downstream", "Downstream", "Downstream", "Downstream"],
-        "DISTANCE": [1, 2, 3, 4],
-    }
-
-    expected_df = pd.DataFrame(expected_data)
-    assert_frame_equal(df, expected_df, check_dtype=False)
+    assert_lineage_contains(
+        df,
+        {
+            "SOURCE_OBJECT": [
+                {"domain": "TABLE", "name": f"{db}.{schema}.T1", "status": "ACTIVE"},
+                {"domain": "VIEW", "name": f"{db}.{schema}.V1", "status": "ACTIVE"},
+                {"domain": "VIEW", "name": f"{db}.{schema}.V2", "status": "ACTIVE"},
+                {"domain": "VIEW", "name": f"{db}.{schema}.V3", "status": "ACTIVE"},
+            ],
+            "TARGET_OBJECT": [
+                {"domain": "VIEW", "name": f"{db}.{schema}.V1", "status": "ACTIVE"},
+                {"domain": "VIEW", "name": f"{db}.{schema}.V2", "status": "ACTIVE"},
+                {"domain": "VIEW", "name": f"{db}.{schema}.V3", "status": "ACTIVE"},
+                {"domain": "VIEW", "name": f"{db}.{schema}.V4", "status": "ACTIVE"},
+            ],
+            "DIRECTION": ["Downstream", "Downstream", "Downstream", "Downstream"],
+            "DISTANCE": [1, 2, 3, 4],
+        },
+    )
 
     # CASE 2 : trace with default arguments
-    df = session.lineage.trace(f"{db}.{schema}.V1", "view")
-    df = remove_created_on_field(df.to_pandas())
+    rows = wait_for_lineage(
+        session,
+        f"{db}.{schema}.V1",
+        "view",
+        direction=LineageDirection.BOTH,
+        expected_min_rows=3,
+        timeout=120,
+    )
+    df = remove_created_on_field(
+        pd.DataFrame(
+            [[r[0], r[1], r[2], r[3]] for r in rows],
+            columns=["SOURCE_OBJECT", "TARGET_OBJECT", "DIRECTION", "DISTANCE"],
+        )
+    )
 
-    expected_data = {
-        "SOURCE_OBJECT": [
-            {"domain": "TABLE", "name": f"{db}.{schema}.T1", "status": "ACTIVE"},
-            {"domain": "VIEW", "name": f"{db}.{schema}.V1", "status": "ACTIVE"},
-            {"domain": "VIEW", "name": f"{db}.{schema}.V2", "status": "ACTIVE"},
-        ],
-        "TARGET_OBJECT": [
-            {"domain": "VIEW", "name": f"{db}.{schema}.V1", "status": "ACTIVE"},
-            {"domain": "VIEW", "name": f"{db}.{schema}.V2", "status": "ACTIVE"},
-            {"domain": "VIEW", "name": f"{db}.{schema}.V3", "status": "ACTIVE"},
-        ],
-        "DIRECTION": ["Upstream", "Downstream", "Downstream"],
-        "DISTANCE": [1, 1, 2],
-    }
-    expected_df = pd.DataFrame(expected_data)
-    assert_frame_equal(df, expected_df, check_dtype=False)
+    assert_lineage_contains(
+        df,
+        {
+            "SOURCE_OBJECT": [
+                {"domain": "TABLE", "name": f"{db}.{schema}.T1", "status": "ACTIVE"},
+                {"domain": "VIEW", "name": f"{db}.{schema}.V1", "status": "ACTIVE"},
+                {"domain": "VIEW", "name": f"{db}.{schema}.V2", "status": "ACTIVE"},
+            ],
+            "TARGET_OBJECT": [
+                {"domain": "VIEW", "name": f"{db}.{schema}.V1", "status": "ACTIVE"},
+                {"domain": "VIEW", "name": f"{db}.{schema}.V2", "status": "ACTIVE"},
+                {"domain": "VIEW", "name": f"{db}.{schema}.V3", "status": "ACTIVE"},
+            ],
+            "DIRECTION": ["Upstream", "Downstream", "Downstream"],
+            "DISTANCE": [1, 1, 2],
+        },
+    )
 
     df = session.lineage.trace(
         f"{db}.{schema}.nonexistant",
@@ -159,57 +350,91 @@ def test_lineage_trace(session):
     session.sql(f"GRANT USAGE ON database {db} TO ROLE {test_role}").collect()
     session.sql(f"GRANT USAGE ON schema {db}.{schema} TO ROLE {test_role}").collect()
     session.sql(f"GRANT select on VIEW {db}.{schema}.V5 TO ROLE {test_role}").collect()
-    session.sql(f"GRANT CREATE VIEW ON schema {schema} TO ROLE {test_role}").collect()
+    session.sql(
+        f"GRANT CREATE VIEW ON schema {db}.{schema} TO ROLE {test_role}"
+    ).collect()
+    session.sql(f"GRANT USAGE ON WAREHOUSE {current_wh} TO ROLE {test_role}").collect()
     session.sql(f"USE ROLE {test_role}").collect()
     session.sql("USE SECONDARY ROLES NONE").collect()
+    session.sql(f"USE WAREHOUSE {current_wh}").collect()
     session.sql(
         f"CREATE OR REPLACE VIEW {db}.{schema}.V6 AS SELECT * FROM {db}.{schema}.V5"
     ).collect()
 
-    df = session.lineage.trace(
-        f"{db}.{schema}.V6", "view", direction=LineageDirection.UPSTREAM
+    # Limit the trace to distance=2 so the traversal stops at the masked
+    # node (which has no id and therefore cannot be traced any further).
+    rows = wait_for_lineage(
+        session,
+        f"{db}.{schema}.V6",
+        "view",
+        direction=LineageDirection.UPSTREAM,
+        distance=2,
+        expected_min_rows=2,
+        timeout=120,
     )
     session.sql(f"USE ROLE {primary_role}").collect()
 
     session.sql(f"use warehouse {current_wh}").collect()
 
-    df = remove_created_on_field(df.to_pandas())
-
-    expected_data = {
-        "SOURCE_OBJECT": [
-            {"domain": "VIEW", "name": f"{db}.{schema}.V5", "status": "ACTIVE"},
-            {"domain": "VIEW", "name": "***.***.***", "status": "MASKED"},
-        ],
-        "TARGET_OBJECT": [
-            {"domain": "VIEW", "name": f"{db}.{schema}.V6", "status": "ACTIVE"},
-            {"domain": "VIEW", "name": f"{db}.{schema}.V5", "status": "ACTIVE"},
-        ],
-        "DIRECTION": ["Upstream", "Upstream"],
-        "DISTANCE": [1, 2],
-    }
-
-    expected_df = pd.DataFrame(expected_data)
-    assert_frame_equal(df, expected_df, check_dtype=False)
-
-    # CASE 5 : trace with deleted object
-    session.sql(f"DROP VIEW {db}.{schema}.V3").collect()
-
-    df = session.lineage.trace(
-        f"{db}.{schema}.V2", "view", direction=LineageDirection.DOWNSTREAM
+    df = remove_created_on_field(
+        pd.DataFrame(
+            [[r[0], r[1], r[2], r[3]] for r in rows],
+            columns=["SOURCE_OBJECT", "TARGET_OBJECT", "DIRECTION", "DISTANCE"],
+        )
     )
 
-    # Removing 'creadtedOn' field since the value can not be predicted.
-    df = remove_created_on_field(df.to_pandas())
+    assert_lineage_contains(
+        df,
+        {
+            "SOURCE_OBJECT": [
+                {"domain": "VIEW", "name": f"{db}.{schema}.V5", "status": "ACTIVE"},
+                {"domain": "VIEW", "name": "***.***.***", "status": "MASKED"},
+            ],
+            "TARGET_OBJECT": [
+                {"domain": "VIEW", "name": f"{db}.{schema}.V6", "status": "ACTIVE"},
+                {"domain": "VIEW", "name": f"{db}.{schema}.V5", "status": "ACTIVE"},
+            ],
+            "DIRECTION": ["Upstream", "Upstream"],
+            "DISTANCE": [1, 2],
+        },
+    )
 
-    expected_data = {
-        "SOURCE_OBJECT": [],
-        "TARGET_OBJECT": [],
-        "DIRECTION": [],
-        "DISTANCE": [],
-    }
+    # CASE 5 : trace with deleted object. Poll until the deletion propagates
+    # to the lineage index.
+    session.sql(f"DROP VIEW {db}.{schema}.V3").collect()
 
-    expected_df = pd.DataFrame(expected_data)
-    assert_frame_equal(df, expected_df, check_dtype=False)
+    deadline = time.monotonic() + 120
+    while True:
+        empty_rows = session.lineage.trace(
+            f"{db}.{schema}.V2", "view", direction=LineageDirection.DOWNSTREAM
+        ).collect()
+        if len(empty_rows) == 0:
+            break
+        if time.monotonic() >= deadline:
+            pytest.xfail(
+                "Lineage for V2 downstream still shows rows after 120s "
+                "following DROP VIEW V3; deletion may not have propagated."
+            )
+        time.sleep(2)
+
+    empty_df = remove_created_on_field(
+        pd.DataFrame(
+            [[r[0], r[1], r[2], r[3]] for r in empty_rows],
+            columns=["SOURCE_OBJECT", "TARGET_OBJECT", "DIRECTION", "DISTANCE"],
+        )
+    )
+    assert_frame_equal(
+        empty_df,
+        pd.DataFrame(
+            {
+                "SOURCE_OBJECT": [],
+                "TARGET_OBJECT": [],
+                "DIRECTION": [],
+                "DISTANCE": [],
+            }
+        ),
+        check_dtype=False,
+    )
 
     # CASE 6 : Case senstive query
     session.sql(
@@ -223,71 +448,77 @@ def test_lineage_trace(session):
     # Removing 'creadtedOn' field since the value can not be predicted.
     df = remove_created_on_field(df.to_pandas())
 
-    expected_data = {
-        "SOURCE_OBJECT": [
-            {"domain": "VIEW", "name": f"{db}.{schema}.V2", "status": "ACTIVE"},
-            {"domain": "VIEW", "name": f"{db}.{schema}.V1", "status": "ACTIVE"},
-        ],
-        "TARGET_OBJECT": [
-            {"domain": "VIEW", "name": f"{db}.{schema}.v7", "status": "ACTIVE"},
-            {"domain": "VIEW", "name": f"{db}.{schema}.V2", "status": "ACTIVE"},
-        ],
-        "DIRECTION": [
-            "Upstream",
-            "Upstream",
-        ],
-        "DISTANCE": [1, 2],
-    }
-
-    expected_df = pd.DataFrame(expected_data)
     # TODO Enable the check after SNOW-1437475 is fixed.
-    # assert_frame_equal(df, expected_df, check_dtype=False)
+    # expected_data = {
+    #     "SOURCE_OBJECT": [
+    #         {"domain": "VIEW", "name": f"{db}.{schema}.V2", "status": "ACTIVE"},
+    #         {"domain": "VIEW", "name": f"{db}.{schema}.V1", "status": "ACTIVE"},
+    #     ],
+    #     "TARGET_OBJECT": [
+    #         {"domain": "VIEW", "name": f"{db}.{schema}.v7", "status": "ACTIVE"},
+    #         {"domain": "VIEW", "name": f"{db}.{schema}.V2", "status": "ACTIVE"},
+    #     ],
+    #     "DIRECTION": ["Upstream", "Upstream"],
+    #     "DISTANCE": [1, 2],
+    # }
+    # assert_frame_equal(pd.DataFrame(expected_data), df, check_dtype=False)
 
     # CASE 7 : Column lineage
-    df = session.lineage.trace(
-        f"{db}.{schema}.V2.C1", "COLUMN", direction=LineageDirection.UPSTREAM
+    rows = wait_for_lineage(
+        session,
+        f"{db}.{schema}.V2.C1",
+        "COLUMN",
+        direction=LineageDirection.UPSTREAM,
+        expected_min_rows=2,
+        timeout=120,
     )
 
     # Removing 'creadtedOn' field since the value can not be predicted.
-    df = remove_created_on_field(df.to_pandas())
+    df = remove_created_on_field(
+        pd.DataFrame(
+            [[r[0], r[1], r[2], r[3]] for r in rows],
+            columns=["SOURCE_OBJECT", "TARGET_OBJECT", "DIRECTION", "DISTANCE"],
+        )
+    )
 
-    expected_data = {
-        "SOURCE_OBJECT": [
-            {
-                "domain": "COLUMN",
-                "name": f"{db}.{schema}.V1.C1",
-                "status": "ACTIVE",
-                "type": "VIEW",
-            },
-            {
-                "domain": "COLUMN",
-                "name": f"{db}.{schema}.T1.C1",
-                "status": "ACTIVE",
-                "type": "TABLE",
-            },
-        ],
-        "TARGET_OBJECT": [
-            {
-                "domain": "COLUMN",
-                "name": f"{db}.{schema}.V2.C1",
-                "status": "ACTIVE",
-                "type": "VIEW",
-            },
-            {
-                "domain": "COLUMN",
-                "name": f"{db}.{schema}.V1.C1",
-                "status": "ACTIVE",
-                "type": "VIEW",
-            },
-        ],
-        "DIRECTION": [
-            "Upstream",
-            "Upstream",
-        ],
-        "DISTANCE": [1, 2],
-    }
-    expected_df = pd.DataFrame(expected_data)
-    assert_frame_equal(df, expected_df, check_dtype=False)
+    assert_lineage_contains(
+        df,
+        {
+            "SOURCE_OBJECT": [
+                {
+                    "domain": "COLUMN",
+                    "name": f"{db}.{schema}.V1.C1",
+                    "status": "ACTIVE",
+                    "type": "VIEW",
+                },
+                {
+                    "domain": "COLUMN",
+                    "name": f"{db}.{schema}.T1.C1",
+                    "status": "ACTIVE",
+                    "type": "TABLE",
+                },
+            ],
+            "TARGET_OBJECT": [
+                {
+                    "domain": "COLUMN",
+                    "name": f"{db}.{schema}.V2.C1",
+                    "status": "ACTIVE",
+                    "type": "VIEW",
+                },
+                {
+                    "domain": "COLUMN",
+                    "name": f"{db}.{schema}.V1.C1",
+                    "status": "ACTIVE",
+                    "type": "VIEW",
+                },
+            ],
+            "DIRECTION": [
+                "Upstream",
+                "Upstream",
+            ],
+            "DISTANCE": [1, 2],
+        },
+    )
 
     with pytest.raises(TypeError) as exc:
         session.lineage.trace(
@@ -329,9 +560,3 @@ def test_lineage_trace(session):
             distance=-11,
         )
     assert "Distance must be between 1 and 5." in str(exc)
-
-    session.sql(f"drop schema {db}.{schema}").collect()
-
-    df = session.lineage.trace(
-        f'{db}.{schema}."v7"', "view", direction=LineageDirection.UPSTREAM
-    )

--- a/tests/unit/test_lineage_escaping.py
+++ b/tests/unit/test_lineage_escaping.py
@@ -1,0 +1,111 @@
+#
+# Copyright (c) 2012-2025 Snowflake Computing Inc. All rights reserved.
+#
+
+"""
+Regression tests for string escaping in Lineage.trace(): values passed via
+object_domain and object_name must be properly escaped before being embedded
+in the single-quoted SQL string literal passed to SYSTEM$DGQL.
+"""
+
+import pytest
+
+from snowflake.snowpark.lineage import _DGQLQueryBuilder, LineageDirection
+
+
+def _sql_string_literal_ends_early(inner: str) -> bool:
+    """Return True if ``inner`` (the content between the outer quotes of
+    ``SYSTEM$DGQL('<inner>')``) contains an unescaped single quote that would
+    terminate the SQL string literal prematurely.
+
+    Snowflake honors two escape forms inside single-quoted literals:
+      * backslash escapes the next character (``\\'`` is a literal quote,
+        ``\\\\`` is a literal backslash), and
+      * a doubled quote (``''``) is a literal quote.
+
+    A lone ``'`` that is neither preceded by a backslash nor part of a ``''``
+    pair terminates the literal early, leaving the remainder as bare SQL.
+    """
+    i = 0
+    n = len(inner)
+    while i < n:
+        c = inner[i]
+        if c == "\\":
+            i += 2  # backslash escapes the next character; skip both
+        elif c == "'":
+            if i + 1 < n and inner[i + 1] == "'":
+                i += 2  # '' is an escaped quote; skip the pair
+            else:
+                return True  # lone quote terminates the literal
+        else:
+            i += 1
+    return False
+
+
+class TestBuildQueryStringEscaping:
+    """Verify that object_domain and object_name values containing single
+    quotes or backslashes are properly escaped in the generated SQL so the
+    SYSTEM$DGQL string literal is always well-formed."""
+
+    PREFIX = "select SYSTEM$DGQL('"
+    SUFFIX = "')"
+
+    # Values with single quotes, backslashes, and combinations that require
+    # both backslash-first and quote escaping to produce a valid SQL literal.
+    SPECIAL_DOMAINS = [
+        "TABLE' OR 1=1--",
+        "TABLE'; DROP TABLE users;--",
+        "TABLE' UNION SELECT * FROM information_schema.tables--",
+        "VIEW') OR ('1'='1",
+        # backslash followed by quote -- requires backslash-first escaping:
+        "TABLE\\' || (select current_user()) --",
+        "TABLE\\\\' OR 1=1--",
+        "\\' UNION SELECT password_hash FROM internal.users --",
+    ]
+
+    SPECIAL_NAMES = [
+        "db.schema.t' || (select current_user()) --",
+        "db.schema.t\\' || (select current_user()) --",
+    ]
+
+    @pytest.mark.parametrize("domain", SPECIAL_DOMAINS)
+    def test_object_domain_is_escaped(self, domain):
+        """object_domain values with special characters must produce a
+        well-formed SQL string literal."""
+        sql = _DGQLQueryBuilder.build_query(
+            object_domain=domain,
+            object_name="db.schema.my_table",
+            edge_directions=[LineageDirection.DOWNSTREAM],
+        )
+        assert sql.startswith(self.PREFIX), f"Unexpected SQL prefix: {sql[:50]}"
+        assert sql.endswith(self.SUFFIX), f"Unexpected SQL suffix: {sql[-10:]}"
+
+        inner = sql[len(self.PREFIX) : -len(self.SUFFIX)]
+        assert not _sql_string_literal_ends_early(inner), (
+            f"object_domain={domain!r} produced an unterminated SQL string "
+            f"literal. Inner query: {inner!r}"
+        )
+
+    @pytest.mark.parametrize("name", SPECIAL_NAMES)
+    def test_object_name_is_escaped(self, name):
+        """object_name values with special characters must produce a
+        well-formed SQL string literal."""
+        sql = _DGQLQueryBuilder.build_query(
+            object_domain="TABLE",
+            object_name=name,
+            edge_directions=[LineageDirection.DOWNSTREAM],
+        )
+        inner = sql[len(self.PREFIX) : -len(self.SUFFIX)]
+        assert not _sql_string_literal_ends_early(inner), (
+            f"object_name={name!r} produced an unterminated SQL string "
+            f"literal. Inner query: {inner!r}"
+        )
+
+    def test_detector_catches_insufficient_escaping(self):
+        """Sanity-check the detector: quote-doubling alone (without escaping
+        the preceding backslash) must be flagged as producing an unterminated
+        literal, and a correctly backslash-first-escaped value must pass."""
+        # Quote-doubling only: backslash leaves the following '' open
+        assert _sql_string_literal_ends_early("{V(domain: \\'' ...")
+        # Backslash-first then quote: correctly escaped
+        assert not _sql_string_literal_ends_early("{V(domain: \\\\'' ...")


### PR DESCRIPTION
…QL parameters

<!---
Please answer these questions before creating your pull request. Thanks!
--->

1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   <!---
   In this section, please add a Snowflake Jira issue number.

   Note that if a corresponding GitHub issue exists, you should still include
   the Snowflake Jira issue number. For example, for GitHub issue
   https://github.com/snowflakedb/snowpark-python/issues/1400, you should
   add "SNOW-1335071" here.
    --->

   Fixes SNOW-3654851, Fixed a bug where `object_name`, `object_domain`, or `object_version` values containing single quotes or backslashes in `session.lineage.trace()` caused incorrect SQL generation. These values are now properly escaped before being embedded in the `SYSTEM$DGQL` call.

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.
   - [ ] I acknowledge that I have ensured my changes to be thread-safe. Follow the link for more information: [Thread-safe Developer Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#thread-safe-development)
   - [ ] If adding any arguments to public Snowpark APIs or creating new public Snowpark APIs, I acknowledge that I have ensured my changes include AST support. Follow the link for more information: [AST Support Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#ast-abstract-syntax-tree-support-in-snowpark)

3. Please describe how your code solves the related issue.

   Please write a short description of how your code change solves the related issue.
