### PR TITLE
SNOW-3709941: lift protobuf restriction py314

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@
 - Fixed a bug where UDF default argument values reconstructed from a source file in `register_from_file` were evaluated with `eval()`; they are now evaluated only against the documented set of supported default-value types, and unsupported expressions are ignored.
 - Fixed a bug where `object_name`, `object_domain`, or `object_version` values containing single quotes or backslashes in `session.lineage.trace()` caused incorrect SQL generation. These values are now properly escaped before being embedded in the `SYSTEM$DGQL` call.
 
+#### Dependency Updates
+
+- Lifted `protobuf` restriction for Python 3.14 from `==5.29.3` to `>=5.29.3,<6.34`.
+
 ## 1.52.0 (2026-06-10)
 
 ### Snowpark Python API Updates

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,8 +1,13 @@
 [build-system]
 requires = [
     "setuptools",
-    # py>=3.14: protoc-wheel-0 (protoc 3.21) is incompatible with the protobuf>=7.x runtime available for cp314.
+    # py>=3.14: protoc-wheel-0 has no cp314 wheel on PyPI, so it cannot be installed
+    # in pip's build isolation venv. setup.py falls back to shutil.which("protoc").
     "protoc-wheel-0==21.1; python_version < '3.14'", # Protocol buffer compiler for Snowpark IR
-    "mypy-protobuf", # used in generating typed Python code from protobuf for Snowpark IR
+    # py>=3.14: pin <=3.6.0 so the build isolation venv does not install mypy-protobuf 5.x,
+    # whose extensions_pb2.py was generated with protobuf 6.x gencode and fails at import
+    # time when the isolated venv resolves protobuf 5.x (Snowflake internal channel).
+    "mypy-protobuf<=3.6.0; python_version >= '3.14'",
+    "mypy-protobuf; python_version < '3.14'", # used in generating typed Python code from protobuf for Snowpark IR
 ]
 build-backend = "setuptools.build_meta"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,8 @@
 [build-system]
 requires = [
     "setuptools",
-    "protoc-wheel-0==21.1", # Protocol buffer compiler for Snowpark IR
+    # py>=3.14: protoc-wheel-0 (protoc 3.21) is incompatible with the protobuf>=7.x runtime available for cp314.
+    "protoc-wheel-0==21.1; python_version < '3.14'", # Protocol buffer compiler for Snowpark IR
     "mypy-protobuf", # used in generating typed Python code from protobuf for Snowpark IR
 ]
 build-backend = "setuptools.build_meta"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -40,8 +40,9 @@ requirements:
     - protobuf==4.25.3  # [py>310 and py<314]
     - protobuf==5.29.3  # [py>=314]
     - libprotobuf >=5.29.3 # [py>=314]
-    # mypy-protobuf 3.7.0 requires protobuf >= 5.26
-    - mypy-protobuf <=3.6.0
+    # mypy-protobuf <=3.6.0 requires protobuf<5.0, conflicts with protobuf==5.29.3 for py314
+    - mypy-protobuf <=3.6.0  # [py<314]
+    - mypy-protobuf >=3.7.0  # [py>=314]
   run:
     {% if noarch_build and py == 310 %}
     - python >=3.10,<3.11.0a0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -38,8 +38,8 @@ requirements:
     # Snowpark IR
     - protobuf==3.20.1  # [py<=310]
     - protobuf==4.25.3  # [py>310 and py<314]
-    - protobuf >=5.0,<6.34  # [py>=314]
-    - libprotobuf >=5.0,<6.34  # [py>=314]
+    - protobuf >=5.29.3,<6.34  # [py>=314]
+    - libprotobuf >=5.29.3,<6.34  # [py>=314]
     # mypy-protobuf <=3.6.0 has no ValidateProtobufRuntimeVersion in its pb2 files,
     # safe with protobuf 5.x or 6.x. mypy-protobuf 5.x+ requires protobuf 6.x gencode
     # which conflicts with the internal channel's protobuf 5.x for py314.
@@ -66,8 +66,8 @@ requirements:
     - libffi <=3.4.4
     - pyyaml
     # Snowpark IR
-    - protobuf >=3.20,<6.34  # [py<314]
-    - protobuf >=5.0,<6.34   # [py>=314]
+    - protobuf >=3.20,<6.34    # [py<314]
+    - protobuf >=5.29.3,<6.34  # [py>=314]
     - python-dateutil
     - tzlocal
   run_constrained:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -38,11 +38,12 @@ requirements:
     # Snowpark IR
     - protobuf==3.20.1  # [py<=310]
     - protobuf==4.25.3  # [py>310 and py<314]
-    - protobuf==5.29.3  # [py>=314]
-    - libprotobuf >=5.29.3 # [py>=314]
-    # mypy-protobuf <=3.6.0 requires protobuf<5.0, conflicts with protobuf==5.29.3 for py314
-    - mypy-protobuf <=3.6.0  # [py<314]
-    - mypy-protobuf >=3.7.0  # [py>=314]
+    - protobuf >=5.0,<6.34  # [py>=314]
+    - libprotobuf >=5.0,<6.34  # [py>=314]
+    # mypy-protobuf <=3.6.0 has no ValidateProtobufRuntimeVersion in its pb2 files,
+    # safe with protobuf 5.x or 6.x. mypy-protobuf 5.x+ requires protobuf 6.x gencode
+    # which conflicts with the internal channel's protobuf 5.x for py314.
+    - mypy-protobuf <=3.6.0
   run:
     {% if noarch_build and py == 310 %}
     - python >=3.10,<3.11.0a0
@@ -65,7 +66,8 @@ requirements:
     - libffi <=3.4.4
     - pyyaml
     # Snowpark IR
-    - protobuf >=3.20,<6.34
+    - protobuf >=3.20,<6.34  # [py<314]
+    - protobuf >=5.0,<6.34   # [py>=314]
     - python-dateutil
     - tzlocal
   run_constrained:

--- a/setup.py
+++ b/setup.py
@@ -29,8 +29,9 @@ INSTALL_REQ_LIST = [
     "cloudpickle>=1.6.0,<=3.1.1,!=2.1.0,!=2.2.0",
     # `protoc` < 3.20 is not able to generate protobuf code compatible with protobuf >= 3.20.
     "protobuf>=3.20, <6.34; python_version < '3.14'",  # Snowpark IR
-    # py314: 5.26.0 is the first release forward-compatible with Python 3.14+.
-    "protobuf>=5.26.0; python_version >= '3.14'",  # Snowpark IR
+    # py314: protoc-wheel-0 has no cp314 wheel; setup.py uses libprotobuf's protoc from PATH.
+    # conda-forge provides libprotobuf 6.x for py314; the generated ast_pb2.py requires 6.x.
+    "protobuf>=6.0,<6.34; python_version >= '3.14'",  # Snowpark IR
     "python-dateutil",  # Snowpark IR
     "tzlocal",  # Snowpark IR
 ]

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,9 @@ INSTALL_REQ_LIST = [
     "pyyaml",
     "cloudpickle>=1.6.0,<=3.1.1,!=2.1.0,!=2.2.0",
     # `protoc` < 3.20 is not able to generate protobuf code compatible with protobuf >= 3.20.
-    "protobuf>=3.20, <6.34",  # Snowpark IR
+    "protobuf>=3.20, <6.34; python_version < '3.14'",  # Snowpark IR
+    # py314: 5.26.0 is the first release forward-compatible with Python 3.14+.
+    "protobuf>=5.26.0; python_version >= '3.14'",  # Snowpark IR
     "python-dateutil",  # Snowpark IR
     "tzlocal",  # Snowpark IR
 ]

--- a/setup.py
+++ b/setup.py
@@ -30,8 +30,10 @@ INSTALL_REQ_LIST = [
     # `protoc` < 3.20 is not able to generate protobuf code compatible with protobuf >= 3.20.
     "protobuf>=3.20, <6.34; python_version < '3.14'",  # Snowpark IR
     # py314: protoc-wheel-0 has no cp314 wheel; setup.py uses libprotobuf's protoc from PATH.
-    # conda-forge provides libprotobuf 6.x for py314; the generated ast_pb2.py requires 6.x.
-    "protobuf>=6.0,<6.34; python_version >= '3.14'",  # Snowpark IR
+    # The pre-generated ast_pb2.py in the tarball has no ValidateProtobufRuntimeVersion call
+    # (built with protoc 3.21), so 5.29.0+ is sufficient. Conda recipes may regenerate with
+    # a different protoc version and override this constraint via their run deps.
+    "protobuf>=5.29.0,<6.34; python_version >= '3.14'",  # Snowpark IR
     "python-dateutil",  # Snowpark IR
     "tzlocal",  # Snowpark IR
 ]

--- a/tests/integ/test_udf.py
+++ b/tests/integ/test_udf.py
@@ -3206,24 +3206,25 @@ def test_use_default_artifact_repository(db_parameters):
             "ALTER database set DEFAULT_PYTHON_ARTIFACT_REPOSITORY = snowflake.snowpark.anaconda_shared_repository"
         ).collect()
 
-        def test_art() -> str:
-            import art  # art is not available in the conda channel, but is in pypi
+        def test_turtles() -> str:
+            # turtles is not in Snowflake's anaconda channel, but is in PyPI.
+            import turtles
 
-            _ = art.text2art("test")
-            return "art works!"
+            return f"imported {turtles.__name__}"
 
         temp_func_name = Utils.random_name_for_temp_object(TempObjectType.FUNCTION)
 
-        # should not work in the database where the default is anaconda
+        # turtles is a PyPI-only package never in Snowflake's anaconda channel,
+        # so this reliably exercises the exception path for the anaconda default.
         with pytest.raises(
             Exception,
-            match="Cannot add package art because it is not available in Snowflake",
+            match="Cannot add package turtles because it is not available in Snowflake",
         ):
             udf(
                 session=session,
-                func=test_art,
+                func=test_turtles,
                 name=temp_func_name,
-                packages=["art", "cloudpickle"],
+                packages=["turtles", "cloudpickle"],
             )
 
         session.sql(f"create schema {temp_schema}").collect()
@@ -3231,19 +3232,22 @@ def test_use_default_artifact_repository(db_parameters):
         session.sql(
             "ALTER schema set DEFAULT_PYTHON_ARTIFACT_REPOSITORY = testdb_snowpark_python.testschema_snowpark_python.SNOWPARK_PYTHON_TEST_REPOSITORY"
         ).collect()
-        session.add_packages("art", "cloudpickle")
+        session.add_packages("turtles", "cloudpickle")
 
         try:
             # Test function registration
             udf(
                 session=session,
-                func=test_art,
+                func=test_turtles,
                 name=temp_func_name,
             )
 
             # Test UDF call
             df = session.create_dataframe([1]).to_df(["a"])
-            Utils.check_answer(df.select(call_udf(temp_func_name)), [Row("art works!")])
+            Utils.check_answer(
+                df.select(call_udf(temp_func_name)),
+                [Row("imported turtles")],
+            )
         finally:
             session._run_query(f"drop function if exists {temp_func_name}(int)")
 


### PR DESCRIPTION
<!---
Please answer these questions before creating your pull request. Thanks!
--->

1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   <!---
   In this section, please add a Snowflake Jira issue number.

   Note that if a corresponding GitHub issue exists, you should still include
   the Snowflake Jira issue number. For example, for GitHub issue
   https://github.com/snowflakedb/snowpark-python/issues/1400, you should
   add "SNOW-1335071" here.
    --->

   Fixes SNOW-3709941

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.
   - [ ] I acknowledge that I have ensured my changes to be thread-safe. Follow the link for more information: [Thread-safe Developer Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#thread-safe-development)
   - [ ] If adding any arguments to public Snowpark APIs or creating new public Snowpark APIs, I acknowledge that I have ensured my changes include AST support. Follow the link for more information: [AST Support Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#ast-abstract-syntax-tree-support-in-snowpark)

3. Please describe how your code solves the related issue.

   Please write a short description of how your code change solves the related issue.

Passed Noarch builder: https://snowpark-python-001.jenkinsdev1.us-west-2.aws-dev.app.snowflake.com/job/SnowparkPythonNoarchPackageBuilder/198588/
