### PR TITLE
SNOW-3718302: Correctly escape special characters in AI function object literals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Fixed a bug where stage paths and file format names that contain single quotes were not consistently escaped when generating SQL, which could produce malformed statements. This affects `INFER_SCHEMA` (used by `DataFrameReader.csv`/`json`/`parquet`/`orc`/`avro`) and `COPY FILES` (used by `FileOperation.copy_files`).
 - Fixed a bug where UDF default argument values reconstructed from a source file in `register_from_file` were evaluated with `eval()`; they are now evaluated only against the documented set of supported default-value types, and unsupported expressions are ignored.
 - Fixed a bug where `object_name`, `object_domain`, or `object_version` values containing single quotes or backslashes in `session.lineage.trace()` caused incorrect SQL generation. These values are now properly escaped before being embedded in the `SYSTEM$DGQL` call.
+- Fixed a bug where string values in the AI functions (`ai_extract`, `ai_classify`, `ai_similarity`, `ai_parse_document`, `ai_transcribe`, `ai_complete`) configuration and `response_format` were not correctly escaped when generating the SQL object literal, which could produce malformed statements when a value contained single quotes or backslashes (for example, an apostrophe in a natural-language question).
 
 #### Dependency Updates
 

--- a/src/snowflake/snowpark/functions.py
+++ b/src/snowflake/snowpark/functions.py
@@ -160,7 +160,7 @@ The return type is always ``Column``. The input types tell you the acceptable va
 import functools
 import typing
 from functools import reduce
-import json
+import json  # noqa: F401  (only referenced by doctests in this module)
 from random import randint
 from types import ModuleType
 from typing import Callable, Dict, List, Optional, Tuple, Union, overload
@@ -12803,6 +12803,53 @@ def prompt(
     )
 
 
+def _python_obj_to_sql_literal(
+    value: Union[dict, list, str, int, float, bool, None],
+) -> str:
+    """Serialize a Python object into a Snowflake SQL object/array/scalar constant.
+
+    Used by the AI functions (``ai_extract``, ``ai_classify``, ``ai_similarity``,
+    ``ai_parse_document``, ``ai_transcribe``, ``ai_complete``) to embed
+    caller-supplied configuration / response-format structures into the generated
+    SQL. Unlike the previous ``json.dumps(value).replace('"', "'")`` approach,
+    every string key and value is SQL-escaped (single quotes doubled, backslashes
+    escaped), so string keys/values containing single quotes or backslashes
+    (e.g. an apostrophe in a natural-language question) produce valid SQL.
+    """
+    if value is None:
+        return "null"
+    if isinstance(value, bool):
+        # bool must be checked before int since bool is a subclass of int
+        return "true" if value else "false"
+    if isinstance(value, str):
+        escaped = value.replace("\\", "\\\\").replace("'", "''")
+        return f"'{escaped}'"
+    if isinstance(value, int):
+        # bool is handled above; int() normalizes subclasses such as IntEnum
+        return str(int(value))
+    if isinstance(value, float):
+        value = float(value)  # normalize subclasses
+        # Note: do not use builtin abs() here — `abs` is shadowed by the Snowpark
+        # column function defined in this module.
+        if value != value or value == float("inf") or value == float("-inf"):
+            raise TypeError(
+                f"Cannot serialize non-finite float {value!r} to a SQL literal"
+            )
+        return repr(value)
+    if isinstance(value, dict):
+        items = ", ".join(
+            f"{_python_obj_to_sql_literal(str(k))}: {_python_obj_to_sql_literal(v)}"
+            for k, v in value.items()
+        )
+        return f"{{{items}}}"
+    if isinstance(value, (list, tuple)):
+        items = ", ".join(_python_obj_to_sql_literal(v) for v in value)
+        return f"[{items}]"
+    raise TypeError(
+        f"Cannot serialize value of type {type(value).__name__} to a SQL literal"
+    )
+
+
 @publicapi
 def ai_extract(
     input: Union[ColumnOrLiteralStr, Column],
@@ -12951,9 +12998,9 @@ def ai_extract(
     else:
         input_col = input
 
-    # Convert response_format to SQL expression
-    # We use json.dumps and replace double quotes with single quotes as per SQL requirements
-    response_format_col = sql_expr(json.dumps(response_format).replace('"', "'"))
+    # Convert response_format to a SQL object/array literal with every string
+    # key/value SQL-escaped so special characters produce valid SQL.
+    response_format_col = sql_expr(_python_obj_to_sql_literal(response_format))
 
     # Build AST if needed
     ast = (
@@ -13181,8 +13228,9 @@ def ai_classify(
             f"list_of_categories must be a list of str or a Column, got {list_of_categories}"
         )
     if config_dict:
-        # only object constant is supported for now
-        config_col = sql_expr(json.dumps(config_dict).replace('"', "'"))
+        # only object constant is supported for now; keys/values are SQL-escaped
+        # so special characters produce valid SQL.
+        config_col = sql_expr(_python_obj_to_sql_literal(config_dict))
         return _call_function(
             sql_func_name, expr_col, cat_col, config_col, _ast=ast, _emit_ast=_emit_ast
         )
@@ -13372,8 +13420,9 @@ def ai_similarity(
     input2_col = _to_col_if_lit(input2, sql_func_name)
 
     if config_dict:
-        # only object constant is supported for now
-        config_col = sql_expr(json.dumps(config_dict).replace('"', "'"))
+        # only object constant is supported for now; keys/values are SQL-escaped
+        # so special characters produce valid SQL.
+        config_col = sql_expr(_python_obj_to_sql_literal(config_dict))
         return _call_function(
             sql_func_name,
             input1_col,
@@ -13478,8 +13527,9 @@ def ai_parse_document(
             if _emit_ast
             else None
         )
-        # only object constant is supported for now
-        config_col = sql_expr(json.dumps(config_dict).replace('"', "'"))
+        # only object constant is supported for now; keys/values are SQL-escaped
+        # so special characters produce valid SQL.
+        config_col = sql_expr(_python_obj_to_sql_literal(config_dict))
         return _call_function(
             sql_func_name, file, config_col, _ast=ast, _emit_ast=_emit_ast
         )
@@ -13601,8 +13651,9 @@ def ai_transcribe(
             if _emit_ast
             else None
         )
-        # only object constant is supported for now
-        config_col = sql_expr(json.dumps(config_dict).replace('"', "'"))
+        # only object constant is supported for now; keys/values are SQL-escaped
+        # so special characters produce valid SQL.
+        config_col = sql_expr(_python_obj_to_sql_literal(config_dict))
         return _call_function(
             sql_func_name, audio_file, config_col, _ast=ast, _emit_ast=_emit_ast
         )
@@ -13799,16 +13850,12 @@ def ai_complete(
 
     # Add model_parameters if provided
     if model_parameters is not None:
-        model_params_col = sql_expr(
-            json.dumps(model_parameters).replace("'", "''").replace('"', "'")
-        )
+        model_params_col = sql_expr(_python_obj_to_sql_literal(model_parameters))
         call_kwargs["model_parameters"] = model_params_col
 
     # Add response_format if provided
     if response_format is not None:
-        response_format_col = sql_expr(
-            json.dumps(response_format).replace("'", "''").replace('"', "'")
-        )
+        response_format_col = sql_expr(_python_obj_to_sql_literal(response_format))
         call_kwargs["response_format"] = response_format_col
 
     # Add show_details if provided

--- a/src/snowflake/snowpark/functions.py
+++ b/src/snowflake/snowpark/functions.py
@@ -12829,12 +12829,17 @@ def _python_obj_to_sql_literal(
         return str(int(value))
     if isinstance(value, float):
         value = float(value)  # normalize subclasses
-        # Note: do not use builtin abs() here — `abs` is shadowed by the Snowpark
-        # column function defined in this module.
-        if value != value or value == float("inf") or value == float("-inf"):
-            raise TypeError(
-                f"Cannot serialize non-finite float {value!r} to a SQL literal"
-            )
+        # Match json.dumps' handling of non-finite floats: emit NaN / Infinity /
+        # -Infinity (the same tokens the previous json.dumps-based code produced)
+        # and let Snowflake surface any error server-side, rather than raising
+        # client-side. Note: do not use builtin abs() here — `abs` is shadowed by
+        # the Snowpark column function defined in this module.
+        if value != value:
+            return "NaN"
+        if value == float("inf"):
+            return "Infinity"
+        if value == float("-inf"):
+            return "-Infinity"
         return repr(value)
     if isinstance(value, dict):
         items = ", ".join(

--- a/tests/integ/test_dataframe_ai.py
+++ b/tests/integ/test_dataframe_ai.py
@@ -5,11 +5,10 @@
 import datetime
 import json
 import pytest
-from snowflake.snowpark.functions import ai_complete, col, lit, to_file
+from snowflake.snowpark.functions import ai_complete, ai_extract, col, lit, to_file
 from snowflake.snowpark.row import Row
 from tests.utils import TestFiles, Utils
 from snowflake.snowpark.exceptions import SnowparkSQLException
-
 
 pytestmark = [
     pytest.mark.skipif(
@@ -130,7 +129,7 @@ def test_dataframe_ai_complete_error_handling(session):
     ):
         df.ai.complete(
             prompt="Test {text}",
-            input_columns={"text": col("text")}
+            input_columns={"text": col("text")},
             # model parameter missing
         )
 
@@ -1618,3 +1617,81 @@ def test_ai_complete_response_format_with_special_quotes(session):
         ).alias("result")
     )
     assert "name" in json.loads(df.collect()[0][0])
+
+
+def _ai_extract_supported(session):
+    """Return True if the test account can run ai_extract.
+
+    AI functions may not be enabled on every test account. We probe with a
+    trivial call; any failure (feature disabled, role/region restrictions, etc.)
+    means we cannot exercise the live integ path and the caller should skip. The
+    unit-level SQL assertions in tests/unit/test_function.py cover the escaping
+    behavior regardless.
+    """
+    try:
+        session.range(1).select(
+            ai_extract("John lives in Denver", {"city": "What city?"}).alias("r")
+        ).collect(_emit_ast=False)
+        return True
+    except Exception:
+        return False
+
+
+def test_ai_extract_apostrophe_question_runs(session):
+    """A question containing an apostrophe must produce valid SQL and not raise
+    a SQL syntax error (previously the apostrophe was not escaped)."""
+    if not _ai_extract_supported(session):
+        pytest.skip("ai_extract not runnable on this account")
+
+    df = session.create_dataframe(
+        [["John Smith's contract was signed in Paris"]], schema=["text"]
+    )
+    result_df = df.select(
+        ai_extract(
+            col("text"),
+            {"name": "What is the employee's last name?"},
+        ).alias("extracted")
+    )
+    # The key assertion: the query plans and executes without a SQL syntax error.
+    results = result_df.collect(_emit_ast=False)
+    assert len(results) == 1
+    assert results[0]["EXTRACTED"] is not None
+    data = json.loads(results[0]["EXTRACTED"])
+    assert isinstance(data, dict) and "response" in data
+
+
+def test_ai_extract_special_characters_in_question_runs(session):
+    """A question value with single quotes, a backslash, parentheses, a comma
+    and a trailing "--" must be escaped and kept inside one string literal, so
+    the query produces a single output column and executes without error."""
+    if not _ai_extract_supported(session):
+        pytest.skip("ai_extract not runnable on this account")
+
+    response_format = {"q": "what's the user's name? (v2) -- note \"x\""}
+    df = session.create_dataframe([["some harmless document text"]], schema=["text"])
+    result_df = df.select(ai_extract(col("text"), response_format).alias("extracted"))
+
+    # Exactly one output column: the value stays inside the object literal.
+    assert result_df.columns == ["EXTRACTED"]
+    results = result_df.collect(_emit_ast=False)
+    assert len(results) == 1
+    if results[0]["EXTRACTED"] is not None:
+        data = json.loads(results[0]["EXTRACTED"])
+        assert isinstance(data, dict)
+
+
+def test_dataframe_ai_extract_apostrophe_question_runs(session):
+    """DataFrame.ai.extract wrapper: apostrophe question runs without error."""
+    if not _ai_extract_supported(session):
+        pytest.skip("ai_extract not runnable on this account")
+
+    df = session.create_dataframe([["Maria O'Brien works in Dublin"]], schema=["text"])
+    result_df = df.ai.extract(
+        input_column="text",
+        response_format={"name": "What is the person's last name?"},
+        output_column="extracted",
+    )
+    assert result_df.columns == ["TEXT", "EXTRACTED"]
+    results = result_df.collect(_emit_ast=False)
+    assert len(results) == 1
+    assert results[0]["EXTRACTED"] is not None

--- a/tests/unit/test_function.py
+++ b/tests/unit/test_function.py
@@ -30,6 +30,11 @@ from snowflake.snowpark.functions import (
     xmlget,
 )
 from snowflake.snowpark.table_function import _create_table_function_expression
+from snowflake.snowpark.functions import (
+    _python_obj_to_sql_literal,
+    ai_extract,
+)
+from snowflake.snowpark._internal.analyzer.analyzer_utils import function_expression
 
 
 @pytest.mark.parametrize(
@@ -131,3 +136,110 @@ def test_functions_alias():
     assert functions.expr == functions.sql_expr
     assert functions.monotonically_increasing_id == functions.seq8
     assert functions.from_unixtime == functions.to_timestamp
+
+
+def _render_ai_extract_sql(response_format):
+    """Render the full generated SQL fragment for an ``ai_extract`` call.
+
+    Reproduces what ``Analyzer`` emits into the SELECT projection: each child
+    expression's raw SQL is concatenated by ``function_expression``. This lets
+    us assert at the unit level that ``response_format`` string content is
+    escaped and kept inside the SQL string literal so the generated SQL is valid.
+    """
+    column = ai_extract("INPUT_TEXT", response_format, _emit_ast=False)
+    expr = column._expression
+    children = [
+        child.name if hasattr(child, "name") else "<input>" for child in expr.children
+    ]
+    return function_expression(expr.name, children, False)
+
+
+# ---------------------------------------------------------------------------
+# Special-character escaping tests for the AI function object/array literals.
+# ---------------------------------------------------------------------------
+
+
+def test_python_obj_to_sql_literal_escapes_single_quotes():
+    # An apostrophe in a question must be doubled so it stays inside the literal.
+    out = _python_obj_to_sql_literal({"name": "What is the employee's last name?"})
+    assert out == "{'name': 'What is the employee''s last name?'}"
+    # Every single quote is paired: the literal stays balanced.
+    assert out.count("'") % 2 == 0
+
+
+def test_python_obj_to_sql_literal_escapes_backslash():
+    # Snowflake treats backslash as an escape char inside string literals, so it
+    # must be doubled to stay inside the literal.
+    out = _python_obj_to_sql_literal({"a": "b\\c"})
+    assert out == "{'a': 'b\\\\c'}"
+    # A trailing backslash must not escape the closing quote.
+    out2 = _python_obj_to_sql_literal(["ends_with_backslash\\"])
+    assert out2 == "['ends_with_backslash\\\\']"
+
+
+def test_python_obj_to_sql_literal_scalar_types():
+    assert _python_obj_to_sql_literal(None) == "null"
+    assert _python_obj_to_sql_literal(True) == "true"
+    assert _python_obj_to_sql_literal(False) == "false"
+    assert _python_obj_to_sql_literal(100) == "100"
+    assert _python_obj_to_sql_literal(0.7) == "0.7"
+    # bool must not be serialized as an int
+    assert _python_obj_to_sql_literal({"flag": True}) == "{'flag': true}"
+
+
+def test_python_obj_to_sql_literal_nested_structures():
+    assert (
+        _python_obj_to_sql_literal([["name", "q1"], ["addr", "q2"]])
+        == "[['name', 'q1'], ['addr', 'q2']]"
+    )
+    assert (
+        _python_obj_to_sql_literal({"temperature": 0.7, "max_tokens": 100})
+        == "{'temperature': 0.7, 'max_tokens': 100}"
+    )
+
+
+def test_python_obj_to_sql_literal_rejects_unsupported_type():
+    with pytest.raises(TypeError):
+        _python_obj_to_sql_literal({"k": object()})
+
+
+def test_ai_extract_apostrophe_question_valid_sql():
+    sql = _render_ai_extract_sql({"name": "What is the employee's last name?"})
+    # The whole call is a single ai_extract(...) with exactly one closing paren.
+    assert sql.startswith("ai_extract(")
+    assert sql.endswith(")")
+    assert sql == (
+        "ai_extract(<input>, {'name': 'What is the employee''s last name?'})"
+    )
+    # The literal portion is balanced: every single quote is paired.
+    assert sql.count("'") % 2 == 0
+
+
+def test_ai_extract_dict_value_special_characters_escaped():
+    # A question value with apostrophes, parentheses, commas, a trailing "--"
+    # and a double quote -- all must be escaped and kept inside one literal.
+    response_format = {"q": "what's the user's name? (v2) -- note \"x\""}
+    sql = _render_ai_extract_sql(response_format)
+    assert sql == (
+        "ai_extract(<input>, {'q': 'what''s the user''s name? (v2) -- note \"x\"'})"
+    )
+    # Each apostrophe in the value is doubled inside the literal.
+    assert "what''s the user''s name?" in sql
+    # Exactly one ai_extract(...) call, balanced single quotes, one output value.
+    assert sql.startswith("ai_extract(")
+    assert sql.endswith(")")
+    assert sql.count("'") % 2 == 0
+
+
+def test_ai_extract_list_value_special_characters_escaped():
+    # A list value containing single quotes, a backslash, parentheses, a comma
+    # and a trailing "--" -- all escaped and kept inside one string literal.
+    response_format = ["a'b\\c) , (d --"]
+    sql = _render_ai_extract_sql(response_format)
+    assert sql == "ai_extract(<input>, ['a''b\\\\c) , (d --'])"
+    # The call begins with exactly one ai_extract( and ends with one paren.
+    assert sql.startswith("ai_extract(")
+    assert sql.endswith(")")
+    # Single quotes are doubled and the backslash is doubled inside the literal.
+    assert "a''b\\\\c" in sql
+    assert sql.count("'") % 2 == 0

--- a/tests/unit/test_function.py
+++ b/tests/unit/test_function.py
@@ -203,18 +203,20 @@ def test_python_obj_to_sql_literal_rejects_unsupported_type():
         _python_obj_to_sql_literal({"k": object()})
 
 
-def test_python_obj_to_sql_literal_rejects_non_finite_floats():
-    # NaN/inf/-inf have no valid SQL literal representation and must be rejected
-    # rather than emitted as an invalid token that breaks the generated SQL.
-    # NaN hits the `value != value` clause; the infinities hit the two others.
-    for bad in (float("nan"), float("inf"), float("-inf")):
-        with pytest.raises(TypeError, match="non-finite float"):
-            _python_obj_to_sql_literal(bad)
-    # ...and the guard still fires when the value is nested in a dict/list.
-    with pytest.raises(TypeError, match="non-finite float"):
+def test_python_obj_to_sql_literal_non_finite_floats_match_json():
+    # Non-finite floats are serialized the same way json.dumps does -- NaN /
+    # Infinity / -Infinity -- and left for Snowflake to reject server-side,
+    # rather than raising client-side. NaN hits the `value != value` clause;
+    # the infinities hit the two others.
+    assert _python_obj_to_sql_literal(float("nan")) == "NaN"
+    assert _python_obj_to_sql_literal(float("inf")) == "Infinity"
+    assert _python_obj_to_sql_literal(float("-inf")) == "-Infinity"
+    # ...including when nested in a dict/list.
+    assert (
         _python_obj_to_sql_literal({"temperature": float("inf")})
-    with pytest.raises(TypeError, match="non-finite float"):
-        _python_obj_to_sql_literal([1.0, float("nan")])
+        == "{'temperature': Infinity}"
+    )
+    assert _python_obj_to_sql_literal([1.0, float("nan")]) == "[1.0, NaN]"
 
 
 def test_ai_extract_apostrophe_question_valid_sql():

--- a/tests/unit/test_function.py
+++ b/tests/unit/test_function.py
@@ -203,6 +203,20 @@ def test_python_obj_to_sql_literal_rejects_unsupported_type():
         _python_obj_to_sql_literal({"k": object()})
 
 
+def test_python_obj_to_sql_literal_rejects_non_finite_floats():
+    # NaN/inf/-inf have no valid SQL literal representation and must be rejected
+    # rather than emitted as an invalid token that breaks the generated SQL.
+    # NaN hits the `value != value` clause; the infinities hit the two others.
+    for bad in (float("nan"), float("inf"), float("-inf")):
+        with pytest.raises(TypeError, match="non-finite float"):
+            _python_obj_to_sql_literal(bad)
+    # ...and the guard still fires when the value is nested in a dict/list.
+    with pytest.raises(TypeError, match="non-finite float"):
+        _python_obj_to_sql_literal({"temperature": float("inf")})
+    with pytest.raises(TypeError, match="non-finite float"):
+        _python_obj_to_sql_literal([1.0, float("nan")])
+
+
 def test_ai_extract_apostrophe_question_valid_sql():
     sql = _render_ai_extract_sql({"name": "What is the employee's last name?"})
     # The whole call is a single ai_extract(...) with exactly one closing paren.


### PR DESCRIPTION
<!---
Please answer these questions before creating your pull request. Thanks!
--->

1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   <!---
   In this section, please add a Snowflake Jira issue number.

   Note that if a corresponding GitHub issue exists, you should still include
   the Snowflake Jira issue number. For example, for GitHub issue
   https://github.com/snowflakedb/snowpark-python/issues/1400, you should
   add "SNOW-1335071" here.
    --->

   Fixes SNOW-3718302

The AI functions (ai_extract, ai_classify, ai_similarity, ai_parse_document, ai_transcribe, ai_complete) built SQL object/array literals from caller config via json.dumps(...).replace of double quotes with single quotes, which did not escape single quotes or backslashes inside string values, so config containing those characters (e.g. an apostrophe in a question) produced invalid SQL. Replaces that with a helper that builds the literal directly and escapes string keys/values. Adds unit tests; integ tests skip when Cortex AI is unavailable.

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.
   - [ ] I acknowledge that I have ensured my changes to be thread-safe. Follow the link for more information: [Thread-safe Developer Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#thread-safe-development)
   - [ ] If adding any arguments to public Snowpark APIs or creating new public Snowpark APIs, I acknowledge that I have ensured my changes include AST support. Follow the link for more information: [AST Support Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#ast-abstract-syntax-tree-support-in-snowpark)

3. Please describe how your code solves the related issue.

   Please write a short description of how your code change solves the related issue.
