### PR TITLE
SNOW-3689405: quote and escape COPY INTO <location> destination

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 #### Bug Fixes
 
 - Fixed a bug where stage paths and file format names that contain single quotes were not consistently escaped when generating SQL, which could produce malformed statements. This affects `INFER_SCHEMA` (used by `DataFrameReader.csv`/`json`/`parquet`/`orc`/`avro`) and `COPY FILES` (used by `FileOperation.copy_files`).
+- Fixed a bug where the destination passed to `DataFrameWriter.copy_into_location` (and `csv`/`json`/`parquet`/`save`) was embedded into the generated `COPY INTO` statement without quoting, which could produce malformed SQL for locations containing single quotes. The location is now consistently quoted and escaped, and a string that merely starts and ends with a single quote but contains unescaped interior quotes is no longer treated as an already-quoted literal; it is fully escaped so it stays a single SQL string literal.
 - Fixed a bug where UDF default argument values reconstructed from a source file in `register_from_file` were evaluated with `eval()`; they are now evaluated only against the documented set of supported default-value types, and unsupported expressions are ignored.
 - Fixed a bug where `object_name`, `object_domain`, or `object_version` values containing single quotes or backslashes in `session.lineage.trace()` caused incorrect SQL generation. These values are now properly escaped before being embedded in the `SYSTEM$DGQL` call.
 

--- a/src/snowflake/snowpark/_internal/analyzer/analyzer_utils.py
+++ b/src/snowflake/snowpark/_internal/analyzer/analyzer_utils.py
@@ -6,6 +6,7 @@
 import json
 import math
 import os
+import re
 import tempfile
 from typing import Any, Dict, List, Optional, Tuple, Union, Literal, Sequence
 
@@ -1931,7 +1932,7 @@ def copy_into_location(
     return (
         COPY
         + INTO
-        + stage_location
+        + escape_location_literal(stage_location)
         + FROM
         + LEFT_PARENTHESIS
         + query
@@ -2145,6 +2146,39 @@ def single_quote(value: str) -> str:
         # Double any embedded single quotes so the value stays a single literal
         value = value.replace("'", "''")
         return SINGLE_QUOTE + value + SINGLE_QUOTE
+
+
+# Matches a complete, well-formed single-quoted SQL literal. The three body
+# alternatives each start with a different character (non-quote/non-backslash,
+# ', \), so every input character fits exactly one branch -- the engine never
+# backtracks, giving linear-time matching even on adversarial input.
+# Matches:     "'@stage/o''clock/'"    (interior quote is doubled -> one literal)
+# No match:    "'@x' UNION SELECT --'"  (bare interior quote ends the literal early)
+_WELL_FORMED_SINGLE_QUOTED_LITERAL = re.compile(
+    r"""
+    '                # opening single quote
+    (                # body: zero or more of...
+        [^'\\]       #   any char that is neither a quote nor a backslash
+        | ''         #   or a doubled (escaped) quote
+        | \\.        #   or a backslash followed by any char (backslash escape)
+    )*
+    '                # closing single quote
+    """,
+    re.VERBOSE | re.DOTALL,
+)
+
+
+def escape_location_literal(value: str) -> str:
+    """Return ``value`` as a single, well-formed single-quoted SQL literal.
+
+    Unlike :func:`single_quote`, a value that merely starts and ends with a
+    single quote but contains unescaped interior quotes is treated as unquoted
+    and fully escaped. This prevents a caller-controlled location from breaking
+    out of the string literal in the generated ``COPY INTO`` statement.
+    """
+    if _WELL_FORMED_SINGLE_QUOTED_LITERAL.fullmatch(value):
+        return value
+    return SINGLE_QUOTE + value.replace("'", "''") + SINGLE_QUOTE
 
 
 def quote_name_without_upper_casing(name: str) -> str:

--- a/tests/integ/test_dataframe.py
+++ b/tests/integ/test_dataframe.py
@@ -5961,6 +5961,117 @@ def test_write_copy_into_location_options(session):
         Utils.drop_stage(session, temp_stage)
 
 
+@pytest.mark.skipif(
+    "config.getoption('local_testing_mode', default=False)",
+    reason="DataFrame.copy_into_location is not supported in Local Testing",
+)
+@pytest.mark.parametrize(
+    "quote_mode,prefix,should_succeed",
+    [
+        ("unquoted", "quote_mode_unquoted", True),
+        ("single", "quote_mode_single", True),
+        ("double", "quote_mode_double", False),
+    ],
+)
+def test_write_copy_into_location_stage_location_quote_modes(
+    session, quote_mode, prefix, should_succeed
+):
+    temp_stage = Utils.random_name_for_temp_object(TempObjectType.STAGE)
+    Utils.create_stage(session, temp_stage, is_temporary=True)
+    try:
+        df = session.create_dataframe(
+            [["John", "Berry"], ["Rick", "Berry"], ["Anthony", "Davis"]],
+            schema=["FIRST_NAME", "LAST_NAME"],
+        )
+
+        base_stage_location = f"@{temp_stage}/{prefix}/"
+        if quote_mode == "single":
+            stage_location = f"'{base_stage_location}'"
+        elif quote_mode == "double":
+            stage_location = f'"{base_stage_location}"'
+        else:
+            stage_location = base_stage_location
+
+        if should_succeed:
+            ret = df.write.copy_into_location(
+                stage_location,
+                file_format_type="csv",
+                overwrite=True,
+                single=True,
+            )
+            assert len(ret) == 1 and ret[0].rows_unloaded == 3
+
+            copied_files = session.sql(f"list @{temp_stage}/{prefix}/").collect()
+            assert len(copied_files) == 1
+        else:
+            with pytest.raises(SnowparkSQLException, match="does not exist"):
+                df.write.copy_into_location(
+                    stage_location,
+                    file_format_type="csv",
+                    overwrite=True,
+                    single=True,
+                )
+    finally:
+        Utils.drop_stage(session, temp_stage)
+
+
+@pytest.mark.skipif(
+    "config.getoption('local_testing_mode', default=False)",
+    reason="DataFrame.copy_into_location is not supported in Local Testing",
+)
+def test_stage_location_embedded_single_quote_raw_and_preescaped_forms(session):
+    source_stage = Utils.random_name_for_temp_object(TempObjectType.STAGE)
+    target_stage = Utils.random_name_for_temp_object(TempObjectType.STAGE)
+    Utils.create_stage(session, source_stage, is_temporary=True)
+    Utils.create_stage(session, target_stage, is_temporary=True)
+    try:
+        df = session.create_dataframe(
+            [["John", "Berry"], ["Rick", "Berry"], ["Anthony", "Davis"]],
+            schema=["FIRST_NAME", "LAST_NAME"],
+        )
+
+        # Raw form with embedded apostrophe.
+        raw_source_location = f"@{source_stage}/o'clock/raw/"
+        # Equivalent pre-escaped single-quoted form.
+        escaped_source_location = f"'@{source_stage}/o''clock/escaped/'"
+
+        raw_copy_result = df.write.copy_into_location(
+            raw_source_location,
+            file_format_type="csv",
+            overwrite=True,
+            single=True,
+        )
+        escaped_copy_result = df.write.copy_into_location(
+            escaped_source_location,
+            file_format_type="csv",
+            overwrite=True,
+            single=True,
+        )
+        assert len(raw_copy_result) == 1 and raw_copy_result[0].rows_unloaded == 3
+        assert (
+            len(escaped_copy_result) == 1 and escaped_copy_result[0].rows_unloaded == 3
+        )
+
+        raw_target_location = f"@{target_stage}/o'clock/raw/"
+        escaped_target_location = f"'@{target_stage}/o''clock/escaped/'"
+
+        raw_files_copied = session.file.copy_files(
+            raw_source_location,
+            raw_target_location,
+            detailed_output=False,
+        )
+        escaped_files_copied = session.file.copy_files(
+            escaped_source_location,
+            escaped_target_location,
+            detailed_output=False,
+        )
+        assert raw_files_copied == 1
+        assert escaped_files_copied == 1
+    finally:
+        Utils.drop_stage(session, source_stage)
+        Utils.drop_stage(session, target_stage)
+
+
 @pytest.mark.xfail(
     "config.getoption('local_testing_mode', default=False)",
     reason="This is testing SQL generation",

--- a/tests/unit/test_analyzer_utils_quoting.py
+++ b/tests/unit/test_analyzer_utils_quoting.py
@@ -11,6 +11,8 @@ which are already single-quoted are passed through unchanged.
 
 
 from snowflake.snowpark._internal.analyzer.analyzer_utils import (
+    copy_into_location,
+    escape_location_literal,
     infer_schema_statement,
     single_quote,
 )
@@ -107,6 +109,80 @@ class TestCopyFilesQuoting:
             file_name="@source/o'brien",
         )
         assert "'@source/o''brien'" in result
+
+
+class TestEscapeLocationLiteral:
+    """escape_location_literal() passes through well-formed literals and
+    fully escapes anything else (including look-alike quoted strings)."""
+
+    def test_plain_quoted_value_is_preserved(self):
+        assert escape_location_literal("'@stage/data'") == "'@stage/data'"
+
+    def test_value_with_spaces_is_preserved(self):
+        assert escape_location_literal("'@stage/my data'") == "'@stage/my data'"
+
+    def test_doubled_interior_quote_is_preserved(self):
+        assert escape_location_literal("'@stage/o''brien'") == "'@stage/o''brien'"
+
+    def test_backslash_escaped_interior_quote_is_preserved(self):
+        # Form produced by utils.normalize_path()
+        assert escape_location_literal("'@stage/o\\'brien'") == "'@stage/o\\'brien'"
+
+    def test_empty_literal_is_preserved(self):
+        assert escape_location_literal("''") == "''"
+
+    def test_literal_containing_single_quote_is_preserved(self):
+        assert escape_location_literal("''''") == "''''"
+
+    def test_unescaped_interior_quote_breakout_is_escaped(self):
+        # Starts and ends with a quote, but the interior quote terminates the
+        # literal early -- it must be treated as unquoted and fully escaped.
+        assert (
+            escape_location_literal("'@x' trailing text --'")
+            == "'''@x'' trailing text --'''"
+        )
+
+    def test_unterminated_literal_is_escaped(self):
+        # Trailing backslash escapes the final quote, so the literal never closes.
+        assert escape_location_literal("'abc\\'") == "'''abc\\'''"
+
+    def test_unquoted_value_is_escaped(self):
+        assert escape_location_literal("@stage/data") == "'@stage/data'"
+
+    def test_too_short_value_is_escaped(self):
+        assert escape_location_literal("'") == "''''"
+
+
+class TestCopyIntoLocationQuoting:
+    """stage_location in copy_into_location is quoted/escaped."""
+
+    def test_embedded_single_quote_is_doubled(self):
+        result = copy_into_location(
+            query="SELECT * FROM source_table",
+            stage_location="@stage/o'brien",
+        )
+        assert "'@stage/o''brien'" in result
+
+    def test_already_quoted_location_is_preserved(self):
+        result = copy_into_location(
+            query="SELECT * FROM source_table",
+            stage_location="'@stage/out/'",
+        )
+        assert " INTO '@stage/out/' FROM " in result
+
+    def test_quote_wrapped_breakout_is_neutralized(self):
+        """A location that would break out of the literal stays inside it."""
+        value = "'s3://bucket/out/' FROM (SELECT * FROM other_table) --'"
+        result = copy_into_location(
+            query="SELECT * FROM source_table",
+            stage_location=value,
+        )
+        # The whole value is wrapped into a single literal; the trailing
+        # FROM/comment never escapes to top-level SQL.
+        assert (
+            "INTO '''s3://bucket/out/'' FROM (SELECT * FROM other_table) --'''"
+            in result
+        )
 
 
 # Helper to call file_operation_statement for COPY FILES


### PR DESCRIPTION
### Summary
The destination passed to `DataFrameWriter.copy_into_location` (and `csv`/`json`/`parquet`/`save`) was embedded into the generated `COPY INTO` statement without quoting, which could produce malformed SQL for locations containing single quotes.

### Changes
- The location is now consistently quoted and escaped in `analyzer_utils.py`.
- A string that merely starts and ends with a single quote but contains unescaped interior quotes is no longer treated as an already-quoted literal; it is fully escaped so it stays a single SQL string literal.
- Unit tests (`tests/unit/test_analyzer_utils_quoting.py`) and integ tests (`tests/integ/test_dataframe.py`).