### PR TITLE
Potential fix: mock OOB telemetry service is always disabled

### DIFF
--- a/src/snowflake/snowpark/mock/_telemetry.py
+++ b/src/snowflake/snowpark/mock/_telemetry.py
@@ -113,13 +113,7 @@ class LocalTestOOBTelemetryService:
             os.getenv("SNOWPARK_LOCAL_TESTING_INTERNAL_TELEMETRY", False)
         )
         self._deployment_url = self.PROD
-        # NOTE: preserved as-is from the connector's telemetry_oob.TelemetryService
-        # based implementation for 1:1 behavior parity. This sets an attribute that
-        # is never read (the `enabled` property reads `self._enabled`, which
-        # defaults to `False`), so the service is effectively always disabled
-        # unless something else calls `.enable()`. See follow-up PR for a fix.
-        self._enable = True
-        self._enabled = False
+        self._enabled = True
         self._queue: "Queue" = Queue()
         self.batch_size = DEFAULT_BATCH_SIZE
         self._lock = threading.RLock()


### PR DESCRIPTION
## Stacked on #4293

This PR is stacked on #4293 (decoupling `LocalTestOOBTelemetryService` from the connector's `telemetry_oob.TelemetryService`). Only the last commit here is new; please review #4293 first.

## Summary

`LocalTestOOBTelemetryService.__init__` sets `self._enable = True` (no trailing `d`), but the `enabled` property, and every consumer of it (`add`, `flush`, `close`), read `self._enabled`. That attribute is never set to `True` anywhere else in the codebase (`mock/_connection.py` only ever calls `.disable()`, never `.enable()`, outside of Snowpark's own test suite).

As a result, the OOB telemetry service for local testing is **effectively always disabled** in real usage. This is masked in CI because `tests/conftest.py`'s `local_testing_telemetry_setup` fixture explicitly calls `.enable()` before every OOB telemetry test.

## Proposed fix

Change `self._enable = True` to `self._enabled = True`, matching the apparent original intent: `mock/_connection.py` explicitly calls `.disable()` when telemetry should be turned off, implying the service was expected to start enabled by default.

## Why this is a separate, stacked PR

Fixing this changes observable behavior: OOB telemetry events (session-creation and not-supported-feature events for local testing) will now actually be sent where they previously silently no-op'd. Flagging as "potential fix" since this may warrant its own discussion (e.g. whether local testing telemetry should default to on) before merging, independent of the pure refactor in #4293.

## Testing

- `tests/mock/test_oob_telemetry.py` (5 tests) pass.
- Verified manually that `LocalTestOOBTelemetryService.get_instance().enabled` is `True` immediately after construction (previously `False`).

Made with [Cursor](https://cursor.com)