### PR TITLE
SNOW-2912540: translate create_temp_table=True to table_type in AST encoding

### DIFF
--- a/src/snowflake/snowpark/_internal/proto/ast.proto
+++ b/src/snowflake/snowpark/_internal/proto/ast.proto
@@ -2769,6 +2769,7 @@ message WritePandas {
   bool auto_create_table = 1;
   google.protobuf.Int64Value chunk_size = 2;
   string compression = 3;
+  // Deprecated: use table_type instead.
   bool create_temp_table = 4;
   DataframeData df = 5;
   repeated Tuple_String_Expr kwargs = 6;
@@ -2823,6 +2824,7 @@ message WriteTable {
   string column_order = 4;
   google.protobuf.StringValue comment = 5;
   bool copy_grants = 6;
+  // Deprecated: use table_type instead.
   bool create_temp_table = 7;
   google.protobuf.Int64Value data_retention_time = 8;
   google.protobuf.BoolValue enable_schema_evolution = 9;

--- a/src/snowflake/snowpark/dataframe.py
+++ b/src/snowflake/snowpark/dataframe.py
@@ -6505,7 +6505,7 @@ class DataFrame:
             ast_id = self._ast_id
             self._ast_id = None  # set the AST ID to None to prevent AST emission.
             self.write.save_as_table(
-                temp_table_name, create_temp_table=True, _emit_ast=False
+                temp_table_name, table_type="temp", _emit_ast=False
             )
             self._ast_id = ast_id  # restore the original AST ID.
         else:

--- a/src/snowflake/snowpark/dataframe_writer.py
+++ b/src/snowflake/snowpark/dataframe_writer.py
@@ -392,6 +392,14 @@ class DataFrameWriter:
         statement_params = track_data_source_statement_params(
             self._dataframe, statement_params or self._dataframe._statement_params
         )
+        if create_temp_table:
+            warning(
+                "save_as_table.create_temp_table",
+                "create_temp_table is deprecated. We still respect this parameter when it is True but "
+                'please consider using `table_type="temporary"` instead.',
+            )
+            table_type = "temporary"
+
         if _emit_ast and self._ast is not None:
             # Add an Bind node that applies WriteTable() to the input, followed by its Eval.
             stmt = self._dataframe._session._ast_batch.bind()
@@ -425,7 +433,6 @@ class DataFrameWriter:
 
             if column_order is not None:
                 expr.column_order = column_order
-            expr.create_temp_table = create_temp_table
             expr.table_type = table_type
 
             if clustering_keys is not None:
@@ -503,14 +510,6 @@ class DataFrameWriter:
                 if clustering_keys
                 else []
             )
-
-            if create_temp_table:
-                warning(
-                    "save_as_table.create_temp_table",
-                    "create_temp_table is deprecated. We still respect this parameter when it is True but "
-                    'please consider using `table_type="temporary"` instead.',
-                )
-                table_type = "temporary"
 
             if table_type and table_type.lower() not in SUPPORTED_TABLE_TYPES:
                 raise ValueError(

--- a/src/snowflake/snowpark/session.py
+++ b/src/snowflake/snowpark/session.py
@@ -3614,7 +3614,6 @@ class Session:
                 if chunk_size is not None and chunk_size != WRITE_PANDAS_CHUNK_SIZE:
                     ast.chunk_size.value = chunk_size
                 ast.compression = compression
-                ast.create_temp_table = create_temp_table
                 if isinstance(df, pandas.DataFrame):
                     build_table_name(
                         ast.df.dataframe_data__pandas.v.temp_table, table.table_name

--- a/tests/ast/data/session_write_pandas.test
+++ b/tests/ast/data/session_write_pandas.test
@@ -12,7 +12,7 @@ ans2 = session.write_pandas(df, "test", schema="a", database="b", chunk_size=7, 
 
 ans = session.write_pandas(pandas.DataFrame(<not shown>), "table1")
 
-ans2 = session.write_pandas(pandas.DataFrame(<not shown>), "test", database="b", schema="a", chunk_size=7, compression="brotli", on_error="ignore", parallel=10, quote_identifiers=False, auto_create_table=True, create_temp_table=True, overwrite=True, table_type="temporary", random=90)
+ans2 = session.write_pandas(pandas.DataFrame(<not shown>), "test", database="b", schema="a", chunk_size=7, compression="brotli", on_error="ignore", parallel=10, quote_identifiers=False, auto_create_table=True, overwrite=True, table_type="temporary", random=90)
 
 ## EXPECTED ENCODED AST
 
@@ -78,7 +78,6 @@ body {
           value: 7
         }
         compression: "brotli"
-        create_temp_table: true
         df {
           dataframe_data__pandas {
             v {


### PR DESCRIPTION
## Summary

Extends #4282 by fixing an AST encoding inconsistency: when a caller passes the deprecated `create_temp_table=True` parameter, the Python runtime correctly translates it to `table_type="temporary"`, but the AST proto was still recording `create_temp_table=True` as a separate boolean field — forcing the server-side AST decoder to handle two representations for the same thing.

Changes:
- **`dataframe_writer.py`**: Move `create_temp_table` deprecation coercion to *before* the AST emission block in `save_as_table`, so `table_type` is already resolved when `WriteTable` is encoded. Remove `expr.create_temp_table` emission.
- **`session.py`**: Remove `ast.create_temp_table = create_temp_table` from the `write_pandas` AST block — the coercion already fires before AST emission there, so `ast.table_type` carries the correct value.
- **`dataframe.py`**: Replace `create_temp_table=True` with `table_type="temp"` in the internal `cache_result` mock path, matching the real code path and avoiding a spurious deprecation warning from internal code.
- **`ast.proto`**: Mark both `create_temp_table` fields as `// Deprecated: use table_type instead.` (fields retained for wire compatibility).
- **`tests/ast/data/session_write_pandas.test`**: Remove `create_temp_table: true` from expected encoded AST and `create_temp_table=True` from expected unparser output.

## Test plan

- [ ] `tests/integ/test_dataframe.py` deprecation-warning test (~line 5371) — warning still fires, `table_type` still resolves correctly
- [ ] `tests/integ/test_pandas_to_df.py` deprecation-warning test (~line 385) — same
- [ ] `tests/ast/` golden file tests pass with updated `session_write_pandas.test`
- [ ] `cache_result` mock path no longer emits a deprecation warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)