### PR TITLE
Merge back release-v1.54.0 into main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 1.54.0 (TBD)
+## 1.54.0 (2026-07-28)
 
 ### Snowpark Python API updates
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release History
 
+## 1.55.0 (TBD)
+
+### Snowpark Python API Updates
+
 ## 1.54.0 (2026-07-29)
 
 ### Snowpark Python API updates

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 1.54.0 (2026-07-28)
+## 1.54.0 (2026-07-29)
 
 ### Snowpark Python API updates
 

--- a/ci/snyk/requirements.txt
+++ b/ci/snyk/requirements.txt
@@ -1,5 +1,5 @@
 setuptools>=40.6.0
 wheel
 cloudpickle>=1.6.0,<=3.1.1,!=2.1.0,!=2.2.0
-snowflake-connector-python>=4.0.0,<5.0.0
+snowflake-connector-python>=4.7.1,<5.0.0
 typing-extensions>=4.1.0,<5.0.0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "snowflake-snowpark-python" %}
-{% set version = "1.53.1" %}
+{% set version = "1.54.0" %}
 {% set noarch_build = (os.environ.get('SNOWFLAKE_SNOWPARK_PYTHON_NOARCH_BUILD', 'false')) == 'true' %}
 {% set build_number = os.environ.get('SNOWFLAKE_SNOWPARK_PYTHON_BUILD_NUMBER', 0) %}
 

--- a/src/snowflake/snowpark/version.py
+++ b/src/snowflake/snowpark/version.py
@@ -2,4 +2,4 @@
 
 
 # Update this for the versions
-VERSION = (1, 53, 1)
+VERSION = (1, 54, 0)

--- a/tests/ast/data/DataFrame.agg.test
+++ b/tests/ast/data/DataFrame.agg.test
@@ -508,7 +508,6 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 53
-  patch: 1
+  minor: 54
 }
 id: "\003U\"\366q\366P\346\260\261?\234\303\254\316\353"

--- a/tests/ast/data/DataFrame.ai.test
+++ b/tests/ast/data/DataFrame.ai.test
@@ -2147,7 +2147,6 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 53
-  patch: 1
+  minor: 54
 }
 id: "\003U\"\366q\366P\346\260\261?\234\303\254\316\353"

--- a/tests/ast/data/DataFrame.col_ilike.test
+++ b/tests/ast/data/DataFrame.col_ilike.test
@@ -239,7 +239,6 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 53
-  patch: 1
+  minor: 54
 }
 id: "\003U\"\366q\366P\346\260\261?\234\303\254\316\353"

--- a/tests/ast/data/DataFrame.collect.test
+++ b/tests/ast/data/DataFrame.collect.test
@@ -511,7 +511,6 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 53
-  patch: 1
+  minor: 54
 }
 id: "\003U\"\366q\366P\346\260\261?\234\303\254\316\353"

--- a/tests/ast/data/DataFrame.count.test
+++ b/tests/ast/data/DataFrame.count.test
@@ -228,7 +228,6 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 53
-  patch: 1
+  minor: 54
 }
 id: "\003U\"\366q\366P\346\260\261?\234\303\254\316\353"

--- a/tests/ast/data/DataFrame.count2.test
+++ b/tests/ast/data/DataFrame.count2.test
@@ -315,7 +315,6 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 53
-  patch: 1
+  minor: 54
 }
 id: "\003U\"\366q\366P\346\260\261?\234\303\254\316\353"

--- a/tests/ast/data/DataFrame.create_or_replace.test
+++ b/tests/ast/data/DataFrame.create_or_replace.test
@@ -823,7 +823,6 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 53
-  patch: 1
+  minor: 54
 }
 id: "\003U\"\366q\366P\346\260\261?\234\303\254\316\353"

--- a/tests/ast/data/DataFrame.cross_join.lsuffix.test
+++ b/tests/ast/data/DataFrame.cross_join.lsuffix.test
@@ -171,7 +171,6 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 53
-  patch: 1
+  minor: 54
 }
 id: "\003U\"\366q\366P\346\260\261?\234\303\254\316\353"

--- a/tests/ast/data/DataFrame.cross_join.rsuffix.test
+++ b/tests/ast/data/DataFrame.cross_join.rsuffix.test
@@ -171,7 +171,6 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 53
-  patch: 1
+  minor: 54
 }
 id: "\003U\"\366q\366P\346\260\261?\234\303\254\316\353"

--- a/tests/ast/data/DataFrame.cross_join.suffix.test
+++ b/tests/ast/data/DataFrame.cross_join.suffix.test
@@ -174,7 +174,6 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 53
-  patch: 1
+  minor: 54
 }
 id: "\003U\"\366q\366P\346\260\261?\234\303\254\316\353"

--- a/tests/ast/data/DataFrame.describe.test
+++ b/tests/ast/data/DataFrame.describe.test
@@ -192,7 +192,6 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 53
-  patch: 1
+  minor: 54
 }
 id: "\003U\"\366q\366P\346\260\261?\234\303\254\316\353"

--- a/tests/ast/data/DataFrame.flatten.test
+++ b/tests/ast/data/DataFrame.flatten.test
@@ -175,7 +175,6 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 53
-  patch: 1
+  minor: 54
 }
 id: "\003U\"\366q\366P\346\260\261?\234\303\254\316\353"

--- a/tests/ast/data/DataFrame.indexers.test
+++ b/tests/ast/data/DataFrame.indexers.test
@@ -207,7 +207,6 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 53
-  patch: 1
+  minor: 54
 }
 id: "\003U\"\366q\366P\346\260\261?\234\303\254\316\353"

--- a/tests/ast/data/DataFrame.join.inner.column.test
+++ b/tests/ast/data/DataFrame.join.inner.column.test
@@ -241,7 +241,6 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 53
-  patch: 1
+  minor: 54
 }
 id: "\003U\"\366q\366P\346\260\261?\234\303\254\316\353"

--- a/tests/ast/data/DataFrame.join.inner.column_list.test
+++ b/tests/ast/data/DataFrame.join.inner.column_list.test
@@ -203,7 +203,6 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 53
-  patch: 1
+  minor: 54
 }
 id: "\003U\"\366q\366P\346\260\261?\234\303\254\316\353"

--- a/tests/ast/data/DataFrame.join.inner.column_list_predicate.test
+++ b/tests/ast/data/DataFrame.join.inner.column_list_predicate.test
@@ -328,7 +328,6 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 53
-  patch: 1
+  minor: 54
 }
 id: "\003U\"\366q\366P\346\260\261?\234\303\254\316\353"

--- a/tests/ast/data/DataFrame.join.inner.predicate.test
+++ b/tests/ast/data/DataFrame.join.inner.predicate.test
@@ -289,7 +289,6 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 53
-  patch: 1
+  minor: 54
 }
 id: "\003U\"\366q\366P\346\260\261?\234\303\254\316\353"

--- a/tests/ast/data/DataFrame.join.inner.predicate_rsuffix.test
+++ b/tests/ast/data/DataFrame.join.inner.predicate_rsuffix.test
@@ -279,7 +279,6 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 53
-  patch: 1
+  minor: 54
 }
 id: "\003U\"\366q\366P\346\260\261?\234\303\254\316\353"

--- a/tests/ast/data/DataFrame.join.left_outer.column.test
+++ b/tests/ast/data/DataFrame.join.left_outer.column.test
@@ -203,7 +203,6 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 53
-  patch: 1
+  minor: 54
 }
 id: "\003U\"\366q\366P\346\260\261?\234\303\254\316\353"

--- a/tests/ast/data/DataFrame.join.right_outer.predicate.test
+++ b/tests/ast/data/DataFrame.join.right_outer.predicate.test
@@ -220,7 +220,6 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 53
-  patch: 1
+  minor: 54
 }
 id: "\003U\"\366q\366P\346\260\261?\234\303\254\316\353"

--- a/tests/ast/data/DataFrame.join_table_function.test
+++ b/tests/ast/data/DataFrame.join_table_function.test
@@ -263,7 +263,6 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 53
-  patch: 1
+  minor: 54
 }
 id: "\003U\"\366q\366P\346\260\261?\234\303\254\316\353"

--- a/tests/ast/data/DataFrame.lateral_join.test
+++ b/tests/ast/data/DataFrame.lateral_join.test
@@ -666,7 +666,6 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 53
-  patch: 1
+  minor: 54
 }
 id: "\003U\"\366q\366P\346\260\261?\234\303\254\316\353"

--- a/tests/ast/data/DataFrame.natural_join.test
+++ b/tests/ast/data/DataFrame.natural_join.test
@@ -171,7 +171,6 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 53
-  patch: 1
+  minor: 54
 }
 id: "\003U\"\366q\366P\346\260\261?\234\303\254\316\353"

--- a/tests/ast/data/DataFrame.pivot.test
+++ b/tests/ast/data/DataFrame.pivot.test
@@ -756,7 +756,6 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 53
-  patch: 1
+  minor: 54
 }
 id: "\003U\"\366q\366P\346\260\261?\234\303\254\316\353"

--- a/tests/ast/data/DataFrame.select_expr.test
+++ b/tests/ast/data/DataFrame.select_expr.test
@@ -359,7 +359,6 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 53
-  patch: 1
+  minor: 54
 }
 id: "\003U\"\366q\366P\346\260\261?\234\303\254\316\353"

--- a/tests/ast/data/DataFrame.stat.test
+++ b/tests/ast/data/DataFrame.stat.test
@@ -1647,7 +1647,6 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 53
-  patch: 1
+  minor: 54
 }
 id: "\003U\"\366q\366P\346\260\261?\234\303\254\316\353"

--- a/tests/ast/data/DataFrame.to_df.test
+++ b/tests/ast/data/DataFrame.to_df.test
@@ -172,7 +172,6 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 53
-  patch: 1
+  minor: 54
 }
 id: "\003U\"\366q\366P\346\260\261?\234\303\254\316\353"

--- a/tests/ast/data/DataFrame.to_local_iterator.test
+++ b/tests/ast/data/DataFrame.to_local_iterator.test
@@ -539,7 +539,6 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 53
-  patch: 1
+  minor: 54
 }
 id: "\003U\"\366q\366P\346\260\261?\234\303\254\316\353"

--- a/tests/ast/data/DataFrame.to_pandas.test
+++ b/tests/ast/data/DataFrame.to_pandas.test
@@ -298,7 +298,6 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 53
-  patch: 1
+  minor: 54
 }
 id: "\003U\"\366q\366P\346\260\261?\234\303\254\316\353"

--- a/tests/ast/data/DataFrame.to_pandas_batch.test
+++ b/tests/ast/data/DataFrame.to_pandas_batch.test
@@ -298,7 +298,6 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 53
-  patch: 1
+  minor: 54
 }
 id: "\003U\"\366q\366P\346\260\261?\234\303\254\316\353"

--- a/tests/ast/data/DataFrame.unpivot.test
+++ b/tests/ast/data/DataFrame.unpivot.test
@@ -237,7 +237,6 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 53
-  patch: 1
+  minor: 54
 }
 id: "\003U\"\366q\366P\346\260\261?\234\303\254\316\353"

--- a/tests/ast/data/DataFrame.write.test
+++ b/tests/ast/data/DataFrame.write.test
@@ -6237,7 +6237,6 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 53
-  patch: 1
+  minor: 54
 }
 id: "\003U\"\366q\366P\346\260\261?\234\303\254\316\353"

--- a/tests/ast/data/Dataframe.cube.test
+++ b/tests/ast/data/Dataframe.cube.test
@@ -520,7 +520,6 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 53
-  patch: 1
+  minor: 54
 }
 id: "\003U\"\366q\366P\346\260\261?\234\303\254\316\353"

--- a/tests/ast/data/Dataframe.distinct.test
+++ b/tests/ast/data/Dataframe.distinct.test
@@ -89,7 +89,6 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 53
-  patch: 1
+  minor: 54
 }
 id: "\003U\"\366q\366P\346\260\261?\234\303\254\316\353"

--- a/tests/ast/data/Dataframe.drop_duplicates.test
+++ b/tests/ast/data/Dataframe.drop_duplicates.test
@@ -278,7 +278,6 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 53
-  patch: 1
+  minor: 54
 }
 id: "\003U\"\366q\366P\346\260\261?\234\303\254\316\353"

--- a/tests/ast/data/Dataframe.drop_duplicates_snow1874622.test
+++ b/tests/ast/data/Dataframe.drop_duplicates_snow1874622.test
@@ -525,7 +525,6 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 53
-  patch: 1
+  minor: 54
 }
 id: "\003U\"\366q\366P\346\260\261?\234\303\254\316\353"

--- a/tests/ast/data/Dataframe.filter.test
+++ b/tests/ast/data/Dataframe.filter.test
@@ -382,7 +382,6 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 53
-  patch: 1
+  minor: 54
 }
 id: "\003U\"\366q\366P\346\260\261?\234\303\254\316\353"

--- a/tests/ast/data/Dataframe.getitem.test
+++ b/tests/ast/data/Dataframe.getitem.test
@@ -273,7 +273,6 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 53
-  patch: 1
+  minor: 54
 }
 id: "\003U\"\366q\366P\346\260\261?\234\303\254\316\353"

--- a/tests/ast/data/Dataframe.group_by.test
+++ b/tests/ast/data/Dataframe.group_by.test
@@ -520,7 +520,6 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 53
-  patch: 1
+  minor: 54
 }
 id: "\003U\"\366q\366P\346\260\261?\234\303\254\316\353"

--- a/tests/ast/data/Dataframe.group_by_grouping_sets.test
+++ b/tests/ast/data/Dataframe.group_by_grouping_sets.test
@@ -1102,7 +1102,6 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 53
-  patch: 1
+  minor: 54
 }
 id: "\003U\"\366q\366P\346\260\261?\234\303\254\316\353"

--- a/tests/ast/data/Dataframe.join.asof.test
+++ b/tests/ast/data/Dataframe.join.asof.test
@@ -736,7 +736,6 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 53
-  patch: 1
+  minor: 54
 }
 id: "\003U\"\366q\366P\346\260\261?\234\303\254\316\353"

--- a/tests/ast/data/Dataframe.join.prefix.test
+++ b/tests/ast/data/Dataframe.join.prefix.test
@@ -819,7 +819,6 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 53
-  patch: 1
+  minor: 54
 }
 id: "\003U\"\366q\366P\346\260\261?\234\303\254\316\353"

--- a/tests/ast/data/Dataframe.rollup.test
+++ b/tests/ast/data/Dataframe.rollup.test
@@ -520,7 +520,6 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 53
-  patch: 1
+  minor: 54
 }
 id: "\003U\"\366q\366P\346\260\261?\234\303\254\316\353"

--- a/tests/ast/data/Dataframe.show.test
+++ b/tests/ast/data/Dataframe.show.test
@@ -1132,7 +1132,6 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 53
-  patch: 1
+  minor: 54
 }
 id: "\003U\"\366q\366P\346\260\261?\234\303\254\316\353"

--- a/tests/ast/data/Dataframe.to_snowpark_pandas.test.DISABLED
+++ b/tests/ast/data/Dataframe.to_snowpark_pandas.test.DISABLED
@@ -183,7 +183,6 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 53
-  patch: 1
+  minor: 54
 }
 id: "\003U\"\366q\366P\346\260\261?\234\303\254\316\353"

--- a/tests/ast/data/Dataframe.with_col_fns.test
+++ b/tests/ast/data/Dataframe.with_col_fns.test
@@ -928,7 +928,6 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 53
-  patch: 1
+  minor: 54
 }
 id: "\003U\"\366q\366P\346\260\261?\234\303\254\316\353"

--- a/tests/ast/data/DataframeNaFunctions.test
+++ b/tests/ast/data/DataframeNaFunctions.test
@@ -882,7 +882,6 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 53
-  patch: 1
+  minor: 54
 }
 id: "\003U\"\366q\366P\346\260\261?\234\303\254\316\353"

--- a/tests/ast/data/RelationalGroupedDataFrame.agg.test
+++ b/tests/ast/data/RelationalGroupedDataFrame.agg.test
@@ -1144,7 +1144,6 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 53
-  patch: 1
+  minor: 54
 }
 id: "\003U\"\366q\366P\346\260\261?\234\303\254\316\353"

--- a/tests/ast/data/RelationalGroupedDataFrame.ai_agg.test
+++ b/tests/ast/data/RelationalGroupedDataFrame.ai_agg.test
@@ -287,7 +287,6 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 53
-  patch: 1
+  minor: 54
 }
 id: "\003U\"\366q\366P\346\260\261?\234\303\254\316\353"

--- a/tests/ast/data/RelationalGroupedDataFrame.test
+++ b/tests/ast/data/RelationalGroupedDataFrame.test
@@ -3621,7 +3621,6 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 53
-  patch: 1
+  minor: 54
 }
 id: "\003U\"\366q\366P\346\260\261?\234\303\254\316\353"

--- a/tests/ast/data/Session.call.test
+++ b/tests/ast/data/Session.call.test
@@ -360,7 +360,6 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 53
-  patch: 1
+  minor: 54
 }
 id: "\003U\"\366q\366P\346\260\261?\234\303\254\316\353"

--- a/tests/ast/data/Session.create_dataframe.test
+++ b/tests/ast/data/Session.create_dataframe.test
@@ -1272,7 +1272,6 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 53
-  patch: 1
+  minor: 54
 }
 id: "\003U\"\366q\366P\346\260\261?\234\303\254\316\353"

--- a/tests/ast/data/Session.create_dataframe_from_pandas.test
+++ b/tests/ast/data/Session.create_dataframe_from_pandas.test
@@ -171,7 +171,6 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 53
-  patch: 1
+  minor: 54
 }
 id: "\003U\"\366q\366P\346\260\261?\234\303\254\316\353"

--- a/tests/ast/data/Session.flatten.test
+++ b/tests/ast/data/Session.flatten.test
@@ -174,7 +174,6 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 53
-  patch: 1
+  minor: 54
 }
 id: "\003U\"\366q\366P\346\260\261?\234\303\254\316\353"

--- a/tests/ast/data/Session.table_function.test
+++ b/tests/ast/data/Session.table_function.test
@@ -990,7 +990,6 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 53
-  patch: 1
+  minor: 54
 }
 id: "\003U\"\366q\366P\346\260\261?\234\303\254\316\353"

--- a/tests/ast/data/Table.delete.test
+++ b/tests/ast/data/Table.delete.test
@@ -545,7 +545,6 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 53
-  patch: 1
+  minor: 54
 }
 id: "\003U\"\366q\366P\346\260\261?\234\303\254\316\353"

--- a/tests/ast/data/Table.drop_table.test
+++ b/tests/ast/data/Table.drop_table.test
@@ -93,7 +93,6 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 53
-  patch: 1
+  minor: 54
 }
 id: "\003U\"\366q\366P\346\260\261?\234\303\254\316\353"

--- a/tests/ast/data/Table.init.test
+++ b/tests/ast/data/Table.init.test
@@ -423,7 +423,6 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 53
-  patch: 1
+  minor: 54
 }
 id: "\003U\"\366q\366P\346\260\261?\234\303\254\316\353"

--- a/tests/ast/data/Table.merge.test
+++ b/tests/ast/data/Table.merge.test
@@ -2448,7 +2448,6 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 53
-  patch: 1
+  minor: 54
 }
 id: "\003U\"\366q\366P\346\260\261?\234\303\254\316\353"

--- a/tests/ast/data/Table.sample.test
+++ b/tests/ast/data/Table.sample.test
@@ -168,7 +168,6 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 53
-  patch: 1
+  minor: 54
 }
 id: "\003U\"\366q\366P\346\260\261?\234\303\254\316\353"

--- a/tests/ast/data/Table.update.test
+++ b/tests/ast/data/Table.update.test
@@ -1030,7 +1030,6 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 53
-  patch: 1
+  minor: 54
 }
 id: "\003U\"\366q\366P\346\260\261?\234\303\254\316\353"

--- a/tests/ast/data/case_when.test
+++ b/tests/ast/data/case_when.test
@@ -1913,7 +1913,6 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 53
-  patch: 1
+  minor: 54
 }
 id: "\003U\"\366q\366P\346\260\261?\234\303\254\316\353"

--- a/tests/ast/data/col_alias.test
+++ b/tests/ast/data/col_alias.test
@@ -409,7 +409,6 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 53
-  patch: 1
+  minor: 54
 }
 id: "\003U\"\366q\366P\346\260\261?\234\303\254\316\353"

--- a/tests/ast/data/col_asc.test
+++ b/tests/ast/data/col_asc.test
@@ -302,7 +302,6 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 53
-  patch: 1
+  minor: 54
 }
 id: "\003U\"\366q\366P\346\260\261?\234\303\254\316\353"

--- a/tests/ast/data/col_between.test
+++ b/tests/ast/data/col_between.test
@@ -184,7 +184,6 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 53
-  patch: 1
+  minor: 54
 }
 id: "\003U\"\366q\366P\346\260\261?\234\303\254\316\353"

--- a/tests/ast/data/col_binops.test
+++ b/tests/ast/data/col_binops.test
@@ -1615,7 +1615,6 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 53
-  patch: 1
+  minor: 54
 }
 id: "\003U\"\366q\366P\346\260\261?\234\303\254\316\353"

--- a/tests/ast/data/col_bitops.test
+++ b/tests/ast/data/col_bitops.test
@@ -394,7 +394,6 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 53
-  patch: 1
+  minor: 54
 }
 id: "\003U\"\366q\366P\346\260\261?\234\303\254\316\353"

--- a/tests/ast/data/col_cast.test
+++ b/tests/ast/data/col_cast.test
@@ -2854,7 +2854,6 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 53
-  patch: 1
+  minor: 54
 }
 id: "\003U\"\366q\366P\346\260\261?\234\303\254\316\353"

--- a/tests/ast/data/col_cast_coll.test
+++ b/tests/ast/data/col_cast_coll.test
@@ -806,7 +806,6 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 53
-  patch: 1
+  minor: 54
 }
 id: "\003U\"\366q\366P\346\260\261?\234\303\254\316\353"

--- a/tests/ast/data/col_desc.test
+++ b/tests/ast/data/col_desc.test
@@ -300,7 +300,6 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 53
-  patch: 1
+  minor: 54
 }
 id: "\003U\"\366q\366P\346\260\261?\234\303\254\316\353"

--- a/tests/ast/data/col_getitem.test
+++ b/tests/ast/data/col_getitem.test
@@ -185,7 +185,6 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 53
-  patch: 1
+  minor: 54
 }
 id: "\003U\"\366q\366P\346\260\261?\234\303\254\316\353"

--- a/tests/ast/data/col_in_.test
+++ b/tests/ast/data/col_in_.test
@@ -358,7 +358,6 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 53
-  patch: 1
+  minor: 54
 }
 id: "\003U\"\366q\366P\346\260\261?\234\303\254\316\353"

--- a/tests/ast/data/col_lit.test
+++ b/tests/ast/data/col_lit.test
@@ -528,7 +528,6 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 53
-  patch: 1
+  minor: 54
 }
 id: "\003U\"\366q\366P\346\260\261?\234\303\254\316\353"

--- a/tests/ast/data/col_literal.test
+++ b/tests/ast/data/col_literal.test
@@ -3709,7 +3709,6 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 53
-  patch: 1
+  minor: 54
 }
 id: "\003U\"\366q\366P\346\260\261?\234\303\254\316\353"

--- a/tests/ast/data/col_null_nan.test
+++ b/tests/ast/data/col_null_nan.test
@@ -403,7 +403,6 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 53
-  patch: 1
+  minor: 54
 }
 id: "\003U\"\366q\366P\346\260\261?\234\303\254\316\353"

--- a/tests/ast/data/col_rbinops.test
+++ b/tests/ast/data/col_rbinops.test
@@ -773,7 +773,6 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 53
-  patch: 1
+  minor: 54
 }
 id: "\003U\"\366q\366P\346\260\261?\234\303\254\316\353"

--- a/tests/ast/data/col_star.test
+++ b/tests/ast/data/col_star.test
@@ -127,7 +127,6 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 53
-  patch: 1
+  minor: 54
 }
 id: "\003U\"\366q\366P\346\260\261?\234\303\254\316\353"

--- a/tests/ast/data/col_string.test
+++ b/tests/ast/data/col_string.test
@@ -740,7 +740,6 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 53
-  patch: 1
+  minor: 54
 }
 id: "\003U\"\366q\366P\346\260\261?\234\303\254\316\353"

--- a/tests/ast/data/col_try_cast.test
+++ b/tests/ast/data/col_try_cast.test
@@ -2514,7 +2514,6 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 53
-  patch: 1
+  minor: 54
 }
 id: "\003U\"\366q\366P\346\260\261?\234\303\254\316\353"

--- a/tests/ast/data/col_udf.test
+++ b/tests/ast/data/col_udf.test
@@ -1487,7 +1487,6 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 53
-  patch: 1
+  minor: 54
 }
 id: "\003U\"\366q\366P\346\260\261?\234\303\254\316\353"

--- a/tests/ast/data/col_unary_ops.test
+++ b/tests/ast/data/col_unary_ops.test
@@ -215,7 +215,6 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 53
-  patch: 1
+  minor: 54
 }
 id: "\003U\"\366q\366P\346\260\261?\234\303\254\316\353"

--- a/tests/ast/data/col_within_group.test
+++ b/tests/ast/data/col_within_group.test
@@ -431,7 +431,6 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 53
-  patch: 1
+  minor: 54
 }
 id: "\003U\"\366q\366P\346\260\261?\234\303\254\316\353"

--- a/tests/ast/data/df_alias.test
+++ b/tests/ast/data/df_alias.test
@@ -90,7 +90,6 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 53
-  patch: 1
+  minor: 54
 }
 id: "\003U\"\366q\366P\346\260\261?\234\303\254\316\353"

--- a/tests/ast/data/df_analytics_functions.test
+++ b/tests/ast/data/df_analytics_functions.test
@@ -950,7 +950,6 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 53
-  patch: 1
+  minor: 54
 }
 id: "\003U\"\366q\366P\346\260\261?\234\303\254\316\353"

--- a/tests/ast/data/df_col.test
+++ b/tests/ast/data/df_col.test
@@ -144,7 +144,6 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 53
-  patch: 1
+  minor: 54
 }
 id: "\003U\"\366q\366P\346\260\261?\234\303\254\316\353"

--- a/tests/ast/data/df_copy.test
+++ b/tests/ast/data/df_copy.test
@@ -778,7 +778,6 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 53
-  patch: 1
+  minor: 54
 }
 id: "\003U\"\366q\366P\346\260\261?\234\303\254\316\353"

--- a/tests/ast/data/df_drop.test
+++ b/tests/ast/data/df_drop.test
@@ -127,7 +127,6 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 53
-  patch: 1
+  minor: 54
 }
 id: "\003U\"\366q\366P\346\260\261?\234\303\254\316\353"

--- a/tests/ast/data/df_except.test
+++ b/tests/ast/data/df_except.test
@@ -128,7 +128,6 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 53
-  patch: 1
+  minor: 54
 }
 id: "\003U\"\366q\366P\346\260\261?\234\303\254\316\353"

--- a/tests/ast/data/df_first.test
+++ b/tests/ast/data/df_first.test
@@ -383,7 +383,6 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 53
-  patch: 1
+  minor: 54
 }
 id: "\003U\"\366q\366P\346\260\261?\234\303\254\316\353"

--- a/tests/ast/data/df_intersect.test
+++ b/tests/ast/data/df_intersect.test
@@ -129,7 +129,6 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 53
-  patch: 1
+  minor: 54
 }
 id: "\003U\"\366q\366P\346\260\261?\234\303\254\316\353"

--- a/tests/ast/data/df_limit.test
+++ b/tests/ast/data/df_limit.test
@@ -342,7 +342,6 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 53
-  patch: 1
+  minor: 54
 }
 id: "\003U\"\366q\366P\346\260\261?\234\303\254\316\353"

--- a/tests/ast/data/df_map.test
+++ b/tests/ast/data/df_map.test
@@ -2142,7 +2142,6 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 53
-  patch: 1
+  minor: 54
 }
 id: "\003U\"\366q\366P\346\260\261?\234\303\254\316\353"

--- a/tests/ast/data/df_random_split.test
+++ b/tests/ast/data/df_random_split.test
@@ -710,7 +710,6 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 53
-  patch: 1
+  minor: 54
 }
 id: "\003U\"\366q\366P\346\260\261?\234\303\254\316\353"

--- a/tests/ast/data/df_sample.test
+++ b/tests/ast/data/df_sample.test
@@ -124,7 +124,6 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 53
-  patch: 1
+  minor: 54
 }
 id: "\003U\"\366q\366P\346\260\261?\234\303\254\316\353"

--- a/tests/ast/data/df_sort.test
+++ b/tests/ast/data/df_sort.test
@@ -833,7 +833,6 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 53
-  patch: 1
+  minor: 54
 }
 id: "\003U\"\366q\366P\346\260\261?\234\303\254\316\353"

--- a/tests/ast/data/df_union.test
+++ b/tests/ast/data/df_union.test
@@ -375,7 +375,6 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 53
-  patch: 1
+  minor: 54
 }
 id: "\003U\"\366q\366P\346\260\261?\234\303\254\316\353"

--- a/tests/ast/data/functions.table_functions.test
+++ b/tests/ast/data/functions.table_functions.test
@@ -2212,7 +2212,6 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 53
-  patch: 1
+  minor: 54
 }
 id: "\003U\"\366q\366P\346\260\261?\234\303\254\316\353"

--- a/tests/ast/data/functions1.test
+++ b/tests/ast/data/functions1.test
@@ -18800,7 +18800,6 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 53
-  patch: 1
+  minor: 54
 }
 id: "\003U\"\366q\366P\346\260\261?\234\303\254\316\353"

--- a/tests/ast/data/functions2.test
+++ b/tests/ast/data/functions2.test
@@ -29678,7 +29678,6 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 53
-  patch: 1
+  minor: 54
 }
 id: "\003U\"\366q\366P\346\260\261?\234\303\254\316\353"

--- a/tests/ast/data/interval.test
+++ b/tests/ast/data/interval.test
@@ -1069,7 +1069,6 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 53
-  patch: 1
+  minor: 54
 }
 id: "\003U\"\366q\366P\346\260\261?\234\303\254\316\353"

--- a/tests/ast/data/select.test
+++ b/tests/ast/data/select.test
@@ -139,7 +139,6 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 53
-  patch: 1
+  minor: 54
 }
 id: "\003U\"\366q\366P\346\260\261?\234\303\254\316\353"

--- a/tests/ast/data/session.read.test
+++ b/tests/ast/data/session.read.test
@@ -1772,7 +1772,6 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 53
-  patch: 1
+  minor: 54
 }
 id: "\003U\"\366q\366P\346\260\261?\234\303\254\316\353"

--- a/tests/ast/data/session.sql.test
+++ b/tests/ast/data/session.sql.test
@@ -149,7 +149,6 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 53
-  patch: 1
+  minor: 54
 }
 id: "\003U\"\366q\366P\346\260\261?\234\303\254\316\353"

--- a/tests/ast/data/session_directory.test
+++ b/tests/ast/data/session_directory.test
@@ -101,7 +101,6 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 53
-  patch: 1
+  minor: 54
 }
 id: "\003U\"\366q\366P\346\260\261?\234\303\254\316\353"

--- a/tests/ast/data/session_generator.test
+++ b/tests/ast/data/session_generator.test
@@ -362,7 +362,6 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 53
-  patch: 1
+  minor: 54
 }
 id: "\003U\"\366q\366P\346\260\261?\234\303\254\316\353"

--- a/tests/ast/data/session_range.test
+++ b/tests/ast/data/session_range.test
@@ -172,7 +172,6 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 53
-  patch: 1
+  minor: 54
 }
 id: "\003U\"\366q\366P\346\260\261?\234\303\254\316\353"

--- a/tests/ast/data/session_table_dq_abs_l.test
+++ b/tests/ast/data/session_table_dq_abs_l.test
@@ -105,7 +105,6 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 53
-  patch: 1
+  minor: 54
 }
 id: "\003U\"\366q\366P\346\260\261?\234\303\254\316\353"

--- a/tests/ast/data/session_table_dq_abs_s.test
+++ b/tests/ast/data/session_table_dq_abs_s.test
@@ -103,7 +103,6 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 53
-  patch: 1
+  minor: 54
 }
 id: "\003U\"\366q\366P\346\260\261?\234\303\254\316\353"

--- a/tests/ast/data/session_table_dq_rs_l.test
+++ b/tests/ast/data/session_table_dq_rs_l.test
@@ -104,7 +104,6 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 53
-  patch: 1
+  minor: 54
 }
 id: "\003U\"\366q\366P\346\260\261?\234\303\254\316\353"

--- a/tests/ast/data/session_table_dq_rs_s.test
+++ b/tests/ast/data/session_table_dq_rs_s.test
@@ -103,7 +103,6 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 53
-  patch: 1
+  minor: 54
 }
 id: "\003U\"\366q\366P\346\260\261?\234\303\254\316\353"

--- a/tests/ast/data/session_table_dq_rt_l.test
+++ b/tests/ast/data/session_table_dq_rt_l.test
@@ -103,7 +103,6 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 53
-  patch: 1
+  minor: 54
 }
 id: "\003U\"\366q\366P\346\260\261?\234\303\254\316\353"

--- a/tests/ast/data/session_table_dq_rt_s.test
+++ b/tests/ast/data/session_table_dq_rt_s.test
@@ -103,7 +103,6 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 53
-  patch: 1
+  minor: 54
 }
 id: "\003U\"\366q\366P\346\260\261?\234\303\254\316\353"

--- a/tests/ast/data/session_table_temp_table_cleanup.test
+++ b/tests/ast/data/session_table_temp_table_cleanup.test
@@ -170,7 +170,6 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 53
-  patch: 1
+  minor: 54
 }
 id: "\003U\"\366q\366P\346\260\261?\234\303\254\316\353"

--- a/tests/ast/data/session_table_uq_abs_l.test
+++ b/tests/ast/data/session_table_uq_abs_l.test
@@ -105,7 +105,6 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 53
-  patch: 1
+  minor: 54
 }
 id: "\003U\"\366q\366P\346\260\261?\234\303\254\316\353"

--- a/tests/ast/data/session_table_uq_abs_s.test
+++ b/tests/ast/data/session_table_uq_abs_s.test
@@ -103,7 +103,6 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 53
-  patch: 1
+  minor: 54
 }
 id: "\003U\"\366q\366P\346\260\261?\234\303\254\316\353"

--- a/tests/ast/data/session_table_uq_rs_l.test
+++ b/tests/ast/data/session_table_uq_rs_l.test
@@ -104,7 +104,6 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 53
-  patch: 1
+  minor: 54
 }
 id: "\003U\"\366q\366P\346\260\261?\234\303\254\316\353"

--- a/tests/ast/data/session_table_uq_rs_s.test
+++ b/tests/ast/data/session_table_uq_rs_s.test
@@ -103,7 +103,6 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 53
-  patch: 1
+  minor: 54
 }
 id: "\003U\"\366q\366P\346\260\261?\234\303\254\316\353"

--- a/tests/ast/data/session_table_uq_rt_l.test
+++ b/tests/ast/data/session_table_uq_rt_l.test
@@ -103,7 +103,6 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 53
-  patch: 1
+  minor: 54
 }
 id: "\003U\"\366q\366P\346\260\261?\234\303\254\316\353"

--- a/tests/ast/data/session_table_uq_rt_s.test
+++ b/tests/ast/data/session_table_uq_rt_s.test
@@ -388,7 +388,6 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 53
-  patch: 1
+  minor: 54
 }
 id: "\003U\"\366q\366P\346\260\261?\234\303\254\316\353"

--- a/tests/ast/data/session_transaction.test
+++ b/tests/ast/data/session_transaction.test
@@ -121,7 +121,6 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 53
-  patch: 1
+  minor: 54
 }
 id: "\003U\"\366q\366P\346\260\261?\234\303\254\316\353"

--- a/tests/ast/data/session_write_pandas.test
+++ b/tests/ast/data/session_write_pandas.test
@@ -149,7 +149,6 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 53
-  patch: 1
+  minor: 54
 }
 id: "\003U\"\366q\366P\346\260\261?\234\303\254\316\353"

--- a/tests/ast/data/shadowed_local_name.test
+++ b/tests/ast/data/shadowed_local_name.test
@@ -205,7 +205,6 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 53
-  patch: 1
+  minor: 54
 }
 id: "\003U\"\366q\366P\346\260\261?\234\303\254\316\353"

--- a/tests/ast/data/smoke1.test
+++ b/tests/ast/data/smoke1.test
@@ -2192,7 +2192,6 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 53
-  patch: 1
+  minor: 54
 }
 id: "\003U\"\366q\366P\346\260\261?\234\303\254\316\353"

--- a/tests/ast/data/smoke2.test
+++ b/tests/ast/data/smoke2.test
@@ -2356,7 +2356,6 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 53
-  patch: 1
+  minor: 54
 }
 id: "\003U\"\366q\366P\346\260\261?\234\303\254\316\353"

--- a/tests/ast/data/sproc.test
+++ b/tests/ast/data/sproc.test
@@ -2828,7 +2828,6 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 53
-  patch: 1
+  minor: 54
 }
 id: "\003U\"\366q\366P\346\260\261?\234\303\254\316\353"

--- a/tests/ast/data/udaf.test
+++ b/tests/ast/data/udaf.test
@@ -1277,7 +1277,6 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 53
-  patch: 1
+  minor: 54
 }
 id: "\003U\"\366q\366P\346\260\261?\234\303\254\316\353"

--- a/tests/ast/data/udtf.test
+++ b/tests/ast/data/udtf.test
@@ -3580,7 +3580,6 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 53
-  patch: 1
+  minor: 54
 }
 id: "\003U\"\366q\366P\346\260\261?\234\303\254\316\353"

--- a/tests/ast/data/windows.test
+++ b/tests/ast/data/windows.test
@@ -2091,7 +2091,6 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 53
-  patch: 1
+  minor: 54
 }
 id: "\003U\"\366q\366P\346\260\261?\234\303\254\316\353"

--- a/tests/integ/test_dataframe.py
+++ b/tests/integ/test_dataframe.py
@@ -9,6 +9,7 @@ import decimal
 import json
 import logging
 import math
+import re
 import time
 from array import array
 from collections import namedtuple
@@ -1680,13 +1681,24 @@ def test_cache_result_query(session):
         df.cache_result()
 
     # connector >= 4.7.1 no longer caches database/schema from non-USE statements (e.g. CREATE TEMP TABLE).
-    # Older connectors did, expect 4 queries for >= 4.7.1, 2 for earlier versions.
-    assert len(history.queries) in [2, 4]
-    assert "CREATE  SCOPED TEMPORARY  TABLE" in history.queries[0].sql_text
+    # Older connectors did, expect 4 queries for >= 4.7.1, 2 for earlier versions in sproc execution env.
+    # Filter out metadata queries (e.g. SELECT CURRENT_DATABASE()) that may appear
+    # in some environments before or between the expected DDL/DML statements.
+    filtered_queries = [
+        q
+        for q in history.queries
+        if not re.match(
+            r"^\s*SELECT\s+CURRENT_(DATABASE|SCHEMA)\s*\(\s*\)\s*$",
+            q.sql_text,
+            re.IGNORECASE,
+        )
+    ]
+    assert len(filtered_queries) == 2
+    assert "CREATE  SCOPED TEMPORARY  TABLE" in filtered_queries[0].sql_text
     assert (
-        "INSERT  INTO" in history.queries[1].sql_text
+        "INSERT  INTO" in filtered_queries[1].sql_text
         and 'SELECT $1 AS "A", $2 AS "B" FROM  VALUES (1 :: INT, 2 :: INT)'
-        in history.queries[1].sql_text
+        in filtered_queries[1].sql_text
     )
 
 

--- a/tests/integ/test_large_query_breakdown.py
+++ b/tests/integ/test_large_query_breakdown.py
@@ -33,6 +33,18 @@ pytestmark = [
     )
 ]
 
+# Matches SELECT CURRENT_DATABASE() / SELECT CURRENT_SCHEMA() metadata queries
+# that the connector may inject in some environments. Used to filter these out
+# before asserting on the meaningful query history entries.
+_METADATA_QUERY_RE = re.compile(
+    r"^\s*SELECT\s+CURRENT_(DATABASE|SCHEMA)\s*\(\s*\)\s*$", re.IGNORECASE
+)
+
+
+def _filter_metadata_queries(queries):
+    """Return query-history entries that are not connector metadata queries."""
+    return [q for q in queries if not _METADATA_QUERY_RE.match(q.sql_text)]
+
 
 @pytest.fixture(autouse=True)
 def large_query_df(session):
@@ -284,13 +296,14 @@ def test_save_as_table(session, large_query_df):
         with SqlCounter(query_count=4, union_count=1, describe_count=1):
             large_query_df.write.save_as_table(table_name, mode="overwrite")
 
-    assert len(history.queries) == 4
-    assert history.queries[0].sql_text == "SELECT CURRENT_TRANSACTION()"
-    assert history.queries[1].sql_text.startswith("CREATE  SCOPED TEMPORARY  TABLE")
-    assert history.queries[2].sql_text.startswith(
+    filtered = _filter_metadata_queries(history.queries)
+    assert len(filtered) == 4
+    assert filtered[0].sql_text == "SELECT CURRENT_TRANSACTION()"
+    assert filtered[1].sql_text.startswith("CREATE  SCOPED TEMPORARY  TABLE")
+    assert filtered[2].sql_text.startswith(
         f"CREATE  OR  REPLACE    TABLE  {table_name}"
     )
-    assert history.queries[3].sql_text.startswith("DROP  TABLE  If  EXISTS")
+    assert filtered[3].sql_text.startswith("DROP  TABLE  If  EXISTS")
 
 
 def test_variable_binding(session):
@@ -339,21 +352,23 @@ def test_update_delete_merge(session, large_query_df):
         # 3 describe call triggered due to column state extraction
         with SqlCounter(query_count=4, union_count=1, describe_count=2):
             t.update({"B": 0}, t.a == large_query_df.a, large_query_df)
-    assert len(history.queries) == 4
-    assert history.queries[0].sql_text == "SELECT CURRENT_TRANSACTION()"
-    assert history.queries[1].sql_text.startswith("CREATE  SCOPED TEMPORARY  TABLE")
-    assert history.queries[2].sql_text.startswith(f"UPDATE {table_name}")
-    assert history.queries[3].sql_text.startswith("DROP  TABLE  If  EXISTS")
+    filtered = _filter_metadata_queries(history.queries)
+    assert len(filtered) == 4
+    assert filtered[0].sql_text == "SELECT CURRENT_TRANSACTION()"
+    assert filtered[1].sql_text.startswith("CREATE  SCOPED TEMPORARY  TABLE")
+    assert filtered[2].sql_text.startswith(f"UPDATE {table_name}")
+    assert filtered[3].sql_text.startswith("DROP  TABLE  If  EXISTS")
 
     # delete
     with session.query_history() as history:
         with SqlCounter(query_count=4, union_count=1, describe_count=0):
             t.delete(t.a == large_query_df.a, large_query_df)
-    assert len(history.queries) == 4
-    assert history.queries[0].sql_text == "SELECT CURRENT_TRANSACTION()"
-    assert history.queries[1].sql_text.startswith("CREATE  SCOPED TEMPORARY  TABLE")
-    assert history.queries[2].sql_text.startswith(f"DELETE  FROM {table_name} USING")
-    assert history.queries[3].sql_text.startswith("DROP  TABLE  If  EXISTS")
+    filtered = _filter_metadata_queries(history.queries)
+    assert len(filtered) == 4
+    assert filtered[0].sql_text == "SELECT CURRENT_TRANSACTION()"
+    assert filtered[1].sql_text.startswith("CREATE  SCOPED TEMPORARY  TABLE")
+    assert filtered[2].sql_text.startswith(f"DELETE  FROM {table_name} USING")
+    assert filtered[3].sql_text.startswith("DROP  TABLE  If  EXISTS")
 
     # merge
     with session.query_history() as history:
@@ -363,11 +378,12 @@ def test_update_delete_merge(session, large_query_df):
                 t.a == large_query_df.a,
                 [when_matched().update({"b": large_query_df.b})],
             )
-    assert len(history.queries) == 4
-    assert history.queries[0].sql_text == "SELECT CURRENT_TRANSACTION()"
-    assert history.queries[1].sql_text.startswith("CREATE  SCOPED TEMPORARY  TABLE")
-    assert history.queries[2].sql_text.startswith(f"MERGE  INTO {table_name} USING")
-    assert history.queries[3].sql_text.startswith("DROP  TABLE  If  EXISTS")
+    filtered = _filter_metadata_queries(history.queries)
+    assert len(filtered) == 4
+    assert filtered[0].sql_text == "SELECT CURRENT_TRANSACTION()"
+    assert filtered[1].sql_text.startswith("CREATE  SCOPED TEMPORARY  TABLE")
+    assert filtered[2].sql_text.startswith(f"MERGE  INTO {table_name} USING")
+    assert filtered[3].sql_text.startswith("DROP  TABLE  If  EXISTS")
 
 
 def test_copy_into_location(session, large_query_df):
@@ -381,11 +397,12 @@ def test_copy_into_location(session, large_query_df):
                 overwrite=True,
                 single=True,
             )
-    assert len(history.queries) == 4, history.queries
-    assert history.queries[0].sql_text == "SELECT CURRENT_TRANSACTION()"
-    assert history.queries[1].sql_text.startswith("CREATE  SCOPED TEMPORARY  TABLE")
-    assert history.queries[2].sql_text.startswith(f"COPY  INTO '{remote_file_path}'")
-    assert history.queries[3].sql_text.startswith("DROP  TABLE  If  EXISTS")
+    filtered = _filter_metadata_queries(history.queries)
+    assert len(filtered) == 4, filtered
+    assert filtered[0].sql_text == "SELECT CURRENT_TRANSACTION()"
+    assert filtered[1].sql_text.startswith("CREATE  SCOPED TEMPORARY  TABLE")
+    assert filtered[2].sql_text.startswith(f"COPY  INTO '{remote_file_path}'")
+    assert filtered[3].sql_text.startswith("DROP  TABLE  If  EXISTS")
 
 
 def test_in_with_subquery_multiple_query(session):
@@ -564,17 +581,7 @@ def test_optimization_skipped_with_transaction(session, large_query_df, caplog):
 
     # connector >= 4.7.1 no longer caches database/schema from non-USE statements (e.g. CREATE TEMP TABLE).
     # Older connectors did, expect 4 queries for >= 4.7.1, 2 for earlier versions in sproc execution env.
-    # Filter out metadata queries (e.g. SELECT CURRENT_DATABASE/SCHEMA()) that may appear
-    # in some environments before or between the expected statements.
-    filtered_queries = [
-        q
-        for q in history.queries
-        if not re.match(
-            r"^\s*SELECT\s+CURRENT_(DATABASE|SCHEMA)\s*\(\s*\)\s*$",
-            q.sql_text,
-            re.IGNORECASE,
-        )
-    ]
+    filtered_queries = _filter_metadata_queries(history.queries)
     assert len(filtered_queries) == 2, filtered_queries
     assert filtered_queries[0].sql_text == "SELECT CURRENT_TRANSACTION()"
     assert "Skipping large query breakdown" in caplog.text
@@ -720,11 +727,7 @@ def test_add_parent_plan_uuid_to_statement_params(session, large_query_df):
         filtered_calls = [
             call
             for call in patched_run_query.call_args_list
-            if not re.match(
-                r"^\s*SELECT\s+CURRENT_(DATABASE|SCHEMA)\s*\(\s*\)\s*$",
-                call.args[0],
-                re.IGNORECASE,
-            )
+            if not _METADATA_QUERY_RE.match(call.args[0])
         ]
         assert len(filtered_calls) == 4
 

--- a/tests/integ/test_large_query_breakdown.py
+++ b/tests/integ/test_large_query_breakdown.py
@@ -5,6 +5,7 @@
 
 import logging
 import os
+import re
 import tempfile
 from unittest.mock import patch
 
@@ -561,8 +562,21 @@ def test_optimization_skipped_with_transaction(session, large_query_df, caplog):
 
     check_optimization_skipped_reason(patch_send, {"active transaction": 1})
 
-    assert len(history.queries) == 2, history.queries
-    assert history.queries[0].sql_text == "SELECT CURRENT_TRANSACTION()"
+    # connector >= 4.7.1 no longer caches database/schema from non-USE statements (e.g. CREATE TEMP TABLE).
+    # Older connectors did, expect 4 queries for >= 4.7.1, 2 for earlier versions in sproc execution env.
+    # Filter out metadata queries (e.g. SELECT CURRENT_DATABASE/SCHEMA()) that may appear
+    # in some environments before or between the expected statements.
+    filtered_queries = [
+        q
+        for q in history.queries
+        if not re.match(
+            r"^\s*SELECT\s+CURRENT_(DATABASE|SCHEMA)\s*\(\s*\)\s*$",
+            q.sql_text,
+            re.IGNORECASE,
+        )
+    ]
+    assert len(filtered_queries) == 2, filtered_queries
+    assert filtered_queries[0].sql_text == "SELECT CURRENT_TRANSACTION()"
     assert "Skipping large query breakdown" in caplog.text
     assert Utils.is_active_transaction(session)
     assert session.sql("commit").collect()
@@ -699,17 +713,26 @@ def test_add_parent_plan_uuid_to_statement_params(session, large_query_df):
         Utils.check_answer(result, [Row(1, 5999), Row(2, 5998)])
 
         plan = large_query_df._plan
-        # 1 for current transaction, 1 for partition, 1 for main query, 1 for post action
-        # connector >= 4.7.1 no longer caches database/schema from non-USE statements (e.g. CREATE TEMP TABLE).
-        # Older connectors did, expect 8 queries for >= 4.7.1, 4 for earlier versions.
-        assert patched_run_query.call_count in [4, 8]
+        # Filter out metadata queries (e.g. SELECT CURRENT_DATABASE/SCHEMA()) that may appear
+        # in some environments. Expect: 1 for current transaction, 1 for partition,
+        # 1 for main query, 1 for post action (connector >= 4.7.1 may double to 8 due to
+        # cache behavior; metadata queries are excluded from this count).
+        filtered_calls = [
+            call
+            for call in patched_run_query.call_args_list
+            if not re.match(
+                r"^\s*SELECT\s+CURRENT_(DATABASE|SCHEMA)\s*\(\s*\)\s*$",
+                call.args[0],
+                re.IGNORECASE,
+            )
+        ]
+        assert len(filtered_calls) == 4
 
-        for i, call in enumerate(patched_run_query.call_args_list):
-            if i == 0:
-                assert call.args[0] == "SELECT CURRENT_TRANSACTION()"
-            else:
-                assert "_statement_params" in call.kwargs
-                assert call.kwargs["_statement_params"]["_PLAN_UUID"] == plan.uuid
+        for call in filtered_calls:
+            if call.args[0] == "SELECT CURRENT_TRANSACTION()":
+                continue
+            assert "_statement_params" in call.kwargs
+            assert call.kwargs["_statement_params"]["_PLAN_UUID"] == plan.uuid
 
 
 @pytest.mark.skipif(


### PR DESCRIPTION
Post-release merge-back for v1.54.0 — brings the release-prep commit (version bump, CHANGELOG date finalization, AST `client_version` bumps) and the release-branch-only test fixes back into `main`.

v1.54.0 is live on PyPI, the private Anaconda channel, and conda-forge (feedstock PR merged).

This is a pure merge-back of already-released, already-reviewed changes — no new public API arguments or thread-safety-relevant changes.

- [x] If adding any arguments to public Snowpark APIs or creating new public Snowpark APIs, I acknowledge that I have ensured my changes include AST support.
- [x] I acknowledge that I have ensured my changes to be thread-safe