### PR TITLE
Fix ignored direct time travel parameters in DataFrameReader

### DIFF
--- a/src/snowflake/snowpark/dataframe_reader.py
+++ b/src/snowflake/snowpark/dataframe_reader.py
@@ -833,12 +833,19 @@ class DataFrameReader:
                 start_snapshot_id=start_snapshot_id,
                 end_snapshot_id=end_snapshot_id,
             )
-        elif (
-            time_travel_mode is not None
-            or version is not None
-            or version_tag is not None
-            or version_ref is not None
-            or branch is not None
+        elif any(
+            value is not None
+            for value in (
+                time_travel_mode,
+                statement,
+                offset,
+                timestamp,
+                stream,
+                version,
+                version_tag,
+                version_ref,
+                branch,
+            )
         ):
             # If version / named-ref params are provided without mode,
             # default to 'at'.

--- a/tests/unit/test_dataframe.py
+++ b/tests/unit/test_dataframe.py
@@ -103,6 +103,43 @@ def test_dataframe_method_alias():
 
 
 @pytest.mark.parametrize(
+    ("parameter", "value"),
+    [
+        ("statement", "query-id"),
+        ("offset", -60),
+        ("timestamp", "2026-01-01 00:00:00"),
+        ("stream", "my_stream"),
+    ],
+)
+def test_dataframe_reader_direct_time_travel_parameter_requires_mode(
+    mock_server_connection, parameter, value
+):
+    session = Session(mock_server_connection)
+
+    with pytest.raises(ValueError, match="Must specify time travel mode"):
+        session.read.table("my_table", _emit_ast=False, **{parameter: value})
+
+
+@pytest.mark.parametrize(
+    ("parameter", "value"),
+    [
+        ("statement", "query-id"),
+        ("offset", -60),
+        ("timestamp", "2026-01-01 00:00:00"),
+        ("stream", "my_stream"),
+    ],
+)
+def test_dataframe_reader_direct_time_travel_parameter_overrides_options(
+    mock_server_connection, parameter, value
+):
+    session = Session(mock_server_connection)
+    reader = session.read.option("time_travel_mode", "at").option("offset", -3600)
+
+    with pytest.raises(ValueError, match="Must specify time travel mode"):
+        reader.table("my_table", _emit_ast=False, **{parameter: value})
+
+
+@pytest.mark.parametrize(
     "format_type",
     [
         "json",


### PR DESCRIPTION
## Summary

- recognize direct `statement`, `offset`, `timestamp`, and `stream` arguments when choosing the time-travel parameter path
- preserve the documented behavior that direct parameters override reader options
- add public API regression coverage for each affected selector

Previously, `DataFrameReader.table()` only selected the direct-parameter path when `time_travel_mode` or an Iceberg-specific argument was set. A selector such as `offset=-60` was therefore dropped before reaching `Session.table`, silently returning the current table instead of raising the existing missing-mode validation error.

## Testing

- `python -m pytest tests/unit/test_dataframe.py tests/unit/test_utils.py -q`
- `pre-commit run --files src/snowflake/snowpark/dataframe_reader.py tests/unit/test_dataframe.py`