### PR TITLE
Snow-3859269 migrate regress test

### DIFF
--- a/.github/workflows/daily_connector_regress.yml
+++ b/.github/workflows/daily_connector_regress.yml
@@ -1,11 +1,5 @@
-# Nightly regression of snowpark-python against the connector's UNRELEASED main branch.
-# Replaces the Jenkins job SnowparkPythonSnowflakePythonClientRegressRunner (SNOW-3859269).
-#
-# Two choices below are deliberate -- please do not "fix" them:
-#   * the connector is BUILT FROM MAIN, not installed from PyPI. Testing the released
-#     connector would just duplicate daily_precommit.yml and lose the early warning.
-#   * the tests run against the public/prod account, like every other workflow here,
-#     rather than the preprod account the Jenkins job used. That is the point of SNOW-3859269.
+# Nightly regression of snowpark-python against the connector's unreleased main branch,
+# replacing the Jenkins job SnowparkPythonSnowflakePythonClientRegressRunner (SNOW-3859269).
 
 name: Daily connector-main regress
 on:
@@ -23,13 +17,11 @@ jobs:
   regress:
     runs-on: ubuntu-latest-64-cores
     steps:
-      # snowpark must be checked out FIRST: a checkout without `path:` wipes
-      # $GITHUB_WORKSPACE, which would delete an already-cloned connector.
+      # Must be first: a checkout without `path:` wipes $GITHUB_WORKSPACE.
       - name: Checkout snowpark-python
         uses: actions/checkout@v4
 
-      # `|| 'main'` is required, not cosmetic: on a `schedule` run there is no
-      # `inputs` context at all, so the declared default never materialises.
+      # A schedule run has no `inputs` context, so the default above never applies.
       - name: Checkout snowflake-connector-python
         uses: actions/checkout@v4
         with:
@@ -53,15 +45,13 @@ jobs:
       - name: Upgrade setuptools, pip and wheel
         run: uv pip install -U setuptools pip wheel --system
 
-      # connector main reports the same version as the latest PyPI release, so the
-      # commit is the only way to tell two nightly runs apart or to bisect a break.
+      # main reports the released version number, so only the commit identifies a run.
       - name: Record connector commit
         run: |
           echo "connector ref=\`${{ inputs.connector_ref || 'main' }}\` sha=\`$(git -C connector-src rev-parse HEAD)\`" \
             >> $GITHUB_STEP_SUMMARY
 
-      # Do NOT add --no-build-isolation: isolation is what guarantees Cython is
-      # present. Without it the build silently emits a pure-python wheel, exit 0.
+      # No --no-build-isolation: without Cython the build silently goes pure-python, exit 0.
       - name: Build connector wheel
         run: |
           python -m pip wheel -v --no-deps -w "$RUNNER_TEMP/connector-wheels" ./connector-src
@@ -71,22 +61,17 @@ jobs:
         shell: bash
         run: |
           ls -1 "$RUNNER_TEMP"/connector-wheels/snowflake_connector_python*cp310*.whl \
-            || { echo "::error::no cp310 wheel -- built a pure-python wheel; tox's glob would miss it"; exit 1; }
+            || { echo "::error::no cp310 wheel: the build fell back to pure python"; exit 1; }
 
-      # Static check on the wheel -- no install, so no deps and no network. Note that
-      # importing ArrowResultBatch would NOT prove anything: result_batch.py imports the
-      # extension lazily, inside _create_nanoarrow_iterator(). Inspecting the wheel does.
-      # `grep` runs without -q on purpose: GitHub's bash sets -o pipefail, so a grep that
-      # exits early would SIGPIPE unzip and fail this step even on a good wheel.
+      # result_batch imports the extension lazily; grep avoids -q because of -o pipefail.
       - name: Assert the wheel contains the Arrow extension
         shell: bash
         run: |
           unzip -l "$RUNNER_TEMP"/connector-wheels/snowflake_connector_python*cp310*.whl \
             | grep 'nanoarrow_arrow_iterator.*\.so' \
-            || { echo "::error::wheel has no nanoarrow_arrow_iterator .so -- the Arrow extension was not built"; exit 1; }
+            || { echo "::error::wheel has no nanoarrow_arrow_iterator .so"; exit 1; }
 
-      # CLOUD_PROVIDER (upper case) selects the encrypted parameters file, and
-      # therefore which Snowflake account the tests land on.
+      # CLOUD_PROVIDER selects the parameters file, and so the account under test.
       - name: Decrypt parameters.py
         shell: bash
         run: .github/scripts/decrypt_parameters.sh
@@ -101,11 +86,8 @@ jobs:
       - name: Install tox
         run: uv pip install tox --system
 
-      # The env name must stay byte-identical to the one scripts/jenkins_regress.sh
-      # runs -- it is the single thing that keeps coverage equal to the Jenkins job.
-      # snowflake_path is what makes tox install the connector we just built instead
-      # of the one from PyPI; note cloud_provider (lower case) is a different variable
-      # from CLOUD_PROVIDER above and only affects the junit filename.
+      # The env name must match scripts/jenkins_regress.sh exactly; that is what keeps
+      # coverage equal to the Jenkins job. Lower-case cloud_provider is not CLOUD_PROVIDER.
       - name: Run connector-main regression
         id: regress
         run: python -m tox -e notdoctest-pandascap-pyarrowcap
@@ -118,23 +100,14 @@ jobs:
           SNOWPARK_PYTHON_API_S3_STORAGE_INTEGRATION: ${{ vars.SNOWPARK_PYTHON_API_S3_STORAGE_INTEGRATION }}
         shell: bash
 
-      # Runs whether the suite passed or failed, but only once tox actually built its
-      # env -- otherwise a dep-resolution failure would add a second, unrelated red step
-      # pointing at a python that never existed.
+      # tox installs the other deps after our wheel, so it can put the PyPI connector back.
+      # direct_url.json exists only for a local-path install; tag and version cannot tell.
       - name: Assert the tests used the locally built connector
         if: ${{ steps.regress.outcome == 'success' || steps.regress.outcome == 'failure' }}
         shell: bash
         run: |
           PY=.tox/notdoctest-pandascap-pyarrowcap/bin/python
-          # The extension must load in the interpreter that actually ran the tests. A
-          # broken .so still lets `import snowflake.connector` succeed with a warning,
-          # after which the whole suite quietly falls back to the JSON path.
           "$PY" -c "import snowflake.connector.nanoarrow_arrow_iterator; print('arrow extension loads')"
           SITE=$("$PY" -c "import snowflake.connector as c, pathlib; print(pathlib.Path(c.__file__).parents[2])")
-          # tox installs our wheel first and the remaining deps second, so the second
-          # install can quietly put the PyPI connector back. direct_url.json (PEP 610)
-          # is written only for a local-path install; an index install has none. The
-          # wheel tag cannot tell us this -- an sdist rebuilt from PyPI is also tagged
-          # linux_x86_64. Version cannot either: main reports the released version.
           ls "$SITE"/snowflake_connector_python-*.dist-info/direct_url.json \
             || { echo "::error::connector came from an index, not the local main build"; exit 1; }

--- a/.github/workflows/daily_connector_regress.yml
+++ b/.github/workflows/daily_connector_regress.yml
@@ -1,0 +1,140 @@
+# Nightly regression of snowpark-python against the connector's UNRELEASED main branch.
+# Replaces the Jenkins job SnowparkPythonSnowflakePythonClientRegressRunner (SNOW-3859269).
+#
+# Two choices below are deliberate -- please do not "fix" them:
+#   * the connector is BUILT FROM MAIN, not installed from PyPI. Testing the released
+#     connector would just duplicate daily_precommit.yml and lose the early warning.
+#   * the tests run against the public/prod account, like every other workflow here,
+#     rather than the preprod account the Jenkins job used. That is the point of SNOW-3859269.
+
+name: Daily connector-main regress
+on:
+  schedule:
+    # 6 AM UTC
+    - cron: "0 6 * * *"
+
+  workflow_dispatch:
+    inputs:
+      connector_ref:
+        description: "snowflake-connector-python ref to test against"
+        default: "main"
+
+jobs:
+  regress:
+    runs-on: ubuntu-latest-64-cores
+    steps:
+      # snowpark must be checked out FIRST: a checkout without `path:` wipes
+      # $GITHUB_WORKSPACE, which would delete an already-cloned connector.
+      - name: Checkout snowpark-python
+        uses: actions/checkout@v4
+
+      # `|| 'main'` is required, not cosmetic: on a `schedule` run there is no
+      # `inputs` context at all, so the declared default never materialises.
+      - name: Checkout snowflake-connector-python
+        uses: actions/checkout@v4
+        with:
+          repository: snowflakedb/snowflake-connector-python
+          ref: ${{ inputs.connector_ref || 'main' }}
+          path: connector-src
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v6
+        with:
+          version: "latest"
+
+      - name: Display Python version
+        run: python -c "import sys; print(sys.version)"
+
+      - name: Upgrade setuptools, pip and wheel
+        run: uv pip install -U setuptools pip wheel --system
+
+      # connector main reports the same version as the latest PyPI release, so the
+      # commit is the only way to tell two nightly runs apart or to bisect a break.
+      - name: Record connector commit
+        run: |
+          echo "connector ref=\`${{ inputs.connector_ref || 'main' }}\` sha=\`$(git -C connector-src rev-parse HEAD)\`" \
+            >> $GITHUB_STEP_SUMMARY
+
+      # Do NOT add --no-build-isolation: isolation is what guarantees Cython is
+      # present. Without it the build silently emits a pure-python wheel, exit 0.
+      - name: Build connector wheel
+        run: |
+          python -m pip wheel -v --no-deps -w "$RUNNER_TEMP/connector-wheels" ./connector-src
+          ls -lh "$RUNNER_TEMP/connector-wheels"
+
+      - name: Assert the wheel is a cp310 binary wheel
+        shell: bash
+        run: |
+          ls -1 "$RUNNER_TEMP"/connector-wheels/snowflake_connector_python*cp310*.whl \
+            || { echo "::error::no cp310 wheel -- built a pure-python wheel; tox's glob would miss it"; exit 1; }
+
+      # Static check on the wheel -- no install, so no deps and no network. Note that
+      # importing ArrowResultBatch would NOT prove anything: result_batch.py imports the
+      # extension lazily, inside _create_nanoarrow_iterator(). Inspecting the wheel does.
+      # `grep` runs without -q on purpose: GitHub's bash sets -o pipefail, so a grep that
+      # exits early would SIGPIPE unzip and fail this step even on a good wheel.
+      - name: Assert the wheel contains the Arrow extension
+        shell: bash
+        run: |
+          unzip -l "$RUNNER_TEMP"/connector-wheels/snowflake_connector_python*cp310*.whl \
+            | grep 'nanoarrow_arrow_iterator.*\.so' \
+            || { echo "::error::wheel has no nanoarrow_arrow_iterator .so -- the Arrow extension was not built"; exit 1; }
+
+      # CLOUD_PROVIDER (upper case) selects the encrypted parameters file, and
+      # therefore which Snowflake account the tests land on.
+      - name: Decrypt parameters.py
+        shell: bash
+        run: .github/scripts/decrypt_parameters.sh
+        env:
+          PARAMETER_PASSWORD: ${{ secrets.PARAMETER_PASSWORD }}
+          CLOUD_PROVIDER: aws
+
+      - name: Install protoc
+        shell: bash
+        run: .github/scripts/install_protoc.sh
+
+      - name: Install tox
+        run: uv pip install tox --system
+
+      # The env name must stay byte-identical to the one scripts/jenkins_regress.sh
+      # runs -- it is the single thing that keeps coverage equal to the Jenkins job.
+      # snowflake_path is what makes tox install the connector we just built instead
+      # of the one from PyPI; note cloud_provider (lower case) is a different variable
+      # from CLOUD_PROVIDER above and only affects the junit filename.
+      - name: Run connector-main regression
+        id: regress
+        run: python -m tox -e notdoctest-pandascap-pyarrowcap
+        env:
+          snowflake_path: ${{ runner.temp }}/connector-wheels
+          cloud_provider: aws
+          PYTEST_ADDOPTS: --color=yes --tb=short
+          TOX_PARALLEL_NO_SPINNER: 1
+          SNOWPARK_PYTHON_API_TEST_BUCKET_PATH: ${{ secrets.SNOWPARK_PYTHON_API_TEST_BUCKET_PATH }}
+          SNOWPARK_PYTHON_API_S3_STORAGE_INTEGRATION: ${{ vars.SNOWPARK_PYTHON_API_S3_STORAGE_INTEGRATION }}
+        shell: bash
+
+      # Runs whether the suite passed or failed, but only once tox actually built its
+      # env -- otherwise a dep-resolution failure would add a second, unrelated red step
+      # pointing at a python that never existed.
+      - name: Assert the tests used the locally built connector
+        if: ${{ steps.regress.outcome == 'success' || steps.regress.outcome == 'failure' }}
+        shell: bash
+        run: |
+          PY=.tox/notdoctest-pandascap-pyarrowcap/bin/python
+          # The extension must load in the interpreter that actually ran the tests. A
+          # broken .so still lets `import snowflake.connector` succeed with a warning,
+          # after which the whole suite quietly falls back to the JSON path.
+          "$PY" -c "import snowflake.connector.nanoarrow_arrow_iterator; print('arrow extension loads')"
+          SITE=$("$PY" -c "import snowflake.connector as c, pathlib; print(pathlib.Path(c.__file__).parents[2])")
+          # tox installs our wheel first and the remaining deps second, so the second
+          # install can quietly put the PyPI connector back. direct_url.json (PEP 610)
+          # is written only for a local-path install; an index install has none. The
+          # wheel tag cannot tell us this -- an sdist rebuilt from PyPI is also tagged
+          # linux_x86_64. Version cannot either: main reports the released version.
+          ls "$SITE"/snowflake_connector_python-*.dist-info/direct_url.json \
+            || { echo "::error::connector came from an index, not the local main build"; exit 1; }

--- a/.github/workflows/trigger_daily_tests_on_branch.yml
+++ b/.github/workflows/trigger_daily_tests_on_branch.yml
@@ -64,6 +64,18 @@ jobs:
             });
             console.log('Triggered daily_jupyter_nb_test.yml on branch: ${{ inputs.branch }}');
 
+      - name: Trigger daily_connector_regress.yml
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.actions.createWorkflowDispatch({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              workflow_id: 'daily_connector_regress.yml',
+              ref: '${{ inputs.branch }}',
+            });
+            console.log('Triggered daily_connector_regress.yml on branch: ${{ inputs.branch }}');
+
       - name: Summary
         run: |
           echo "## Triggered Workflows" >> $GITHUB_STEP_SUMMARY
@@ -74,3 +86,4 @@ jobs:
           echo "- daily_modin_precommit_py310.yml" >> $GITHUB_STEP_SUMMARY
           echo "- daily_modin_precommit_py311_py312.yml" >> $GITHUB_STEP_SUMMARY
           echo "- daily_jupyter_nb_test.yml" >> $GITHUB_STEP_SUMMARY
+          echo "- daily_connector_regress.yml" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
---
1. Which Jira issue is this PR addressing?

Fixes SNOW-3859269

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.
   - [x] I acknowledge that I have ensured my changes to be thread-safe.
   - [x] If adding any arguments to public Snowpark APIs or creating new public Snowpark APIs, I acknowledge that I have ensured my changes include AST support.

This PR only touches `.github/workflows/`, so it adds no tests, logging, telemetry, credentials, or dependencies.

3. Please describe how your code solves the related issue.

Step one of SNOW-3859269: this only adds the GitHub Actions workflow. The Jenkins job `SnowparkPythonSnowflakePythonClientRegressRunner` is untouched and still running. Retiring it, and removing it from the release-validation fan-out in `jenkins_utils`, is a separate PR once this has run for a few nights.

That job runs the snowpark suite against the connector's unreleased `main` branch, so a connector change that breaks snowpark shows up before the connector ships. On Jenkins it connects to a preprod account whose parameters can differ from prod, so a red build was often an environment difference rather than a real regression, and its definition lived in a different repo from the code it tests.

The line to review closely: `daily_connector_regress.yml` runs `tox -e notdoctest-pandascap-pyarrowcap`, identical to what `scripts/jenkins_regress.sh` runs today. `jenkins_regress.sh` has no test list of its own and delegates everything to `tox.ini`, so that string is the whole guarantee that coverage matches the Jenkins job. Editing it changes coverage silently.

The workflow checks out the connector at `main`, builds a wheel, and sets `snowflake_path` to it, which is all `scripts/tox_install_cmd.sh` needs. Nothing under `src/` or `tests/` changes, and no new secrets are needed: it reuses `decrypt_parameters.sh` and `PARAMETER_PASSWORD`, which is also what lands the run on the same prod account as `daily_precommit.yml`. That account change is the actual fix for the drift.

It runs nightly at 06:00 UTC and on `workflow_dispatch`. `trigger_daily_tests_on_branch.yml` gains a fifth entry so release validation dispatches it alongside the four existing daily workflows.

The three assert steps exist because the bad outcome here is a green run that tested the released connector instead of `main`: the wheel has to carry a cp310 tag, contain the nanoarrow `.so`, and be the one the tests actually imported. Two things deliberately differ from the other daily workflows, both commented in the file: the env resolves to `-n logical` rather than `-n 6`, because a `daily*` env would change the env name and would also drop `--reruns 5` (`precommit.yml` already runs this env on the same runner size), and no junit artifact is uploaded, matching the other workflows here which upload coverage instead.

---