### PR TITLE
SNOW-2912540: translate create_temp_table=True to table_type in AST encoding (rebased onto main)

### DIFF
--- a/src/snowflake/snowpark/_internal/proto/ast.proto
+++ b/src/snowflake/snowpark/_internal/proto/ast.proto
@@ -2815,6 +2815,7 @@ message WritePandas {
   bool auto_create_table = 1;
   google.protobuf.Int64Value chunk_size = 2;
   string compression = 3;
+  // Deprecated: use table_type instead.
   bool create_temp_table = 4;
   DataframeData df = 5;
   repeated Tuple_String_Expr kwargs = 6;
@@ -2869,6 +2870,7 @@ message WriteTable {
   string column_order = 4;
   google.protobuf.StringValue comment = 5;
   bool copy_grants = 6;
+  // Deprecated: use table_type instead.
   bool create_temp_table = 7;
   google.protobuf.Int64Value data_retention_time = 8;
   google.protobuf.BoolValue enable_schema_evolution = 9;

--- a/src/snowflake/snowpark/dataframe.py
+++ b/src/snowflake/snowpark/dataframe.py
@@ -6512,7 +6512,7 @@ class DataFrame:
             ast_id = self._ast_id
             self._ast_id = None  # set the AST ID to None to prevent AST emission.
             self.write.save_as_table(
-                temp_table_name, create_temp_table=True, _emit_ast=False
+                temp_table_name, table_type="temp", _emit_ast=False
             )
             self._ast_id = ast_id  # restore the original AST ID.
         else:

--- a/src/snowflake/snowpark/dataframe_writer.py
+++ b/src/snowflake/snowpark/dataframe_writer.py
@@ -384,6 +384,14 @@ class DataFrameWriter:
         statement_params = track_data_source_statement_params(
             self._dataframe, statement_params or self._dataframe._statement_params
         )
+        if create_temp_table:
+            warning(
+                "save_as_table.create_temp_table",
+                "create_temp_table is deprecated. We still respect this parameter when it is True but "
+                'please consider using `table_type="temporary"` instead.',
+            )
+            table_type = "temporary"
+
         if _emit_ast and self._ast is not None:
             # Add an Bind node that applies WriteTable() to the input, followed by its Eval.
             stmt = self._dataframe._session._ast_batch.bind()
@@ -417,7 +425,6 @@ class DataFrameWriter:
 
             if column_order is not None:
                 expr.column_order = column_order
-            expr.create_temp_table = create_temp_table
             expr.table_type = table_type
 
             if clustering_keys is not None:
@@ -495,14 +502,6 @@ class DataFrameWriter:
                 if clustering_keys
                 else []
             )
-
-            if create_temp_table:
-                warning(
-                    "save_as_table.create_temp_table",
-                    "create_temp_table is deprecated. We still respect this parameter when it is True but "
-                    'please consider using `table_type="temporary"` instead.',
-                )
-                table_type = "temporary"
 
             if table_type and table_type.lower() not in SUPPORTED_TABLE_TYPES:
                 raise ValueError(

--- a/src/snowflake/snowpark/session.py
+++ b/src/snowflake/snowpark/session.py
@@ -3649,7 +3649,6 @@ class Session:
                 if chunk_size is not None and chunk_size != WRITE_PANDAS_CHUNK_SIZE:
                     ast.chunk_size.value = chunk_size
                 ast.compression = compression
-                ast.create_temp_table = create_temp_table
                 if isinstance(df, pandas.DataFrame):
                     build_table_name(
                         ast.df.dataframe_data__pandas.v.temp_table, table.table_name

--- a/tests/ast/data/session_write_pandas.test
+++ b/tests/ast/data/session_write_pandas.test
@@ -12,7 +12,7 @@ ans2 = session.write_pandas(df, "test", schema="a", database="b", chunk_size=7, 
 
 ans = session.write_pandas(pandas.DataFrame(<not shown>), "table1")
 
-ans2 = session.write_pandas(pandas.DataFrame(<not shown>), "test", database="b", schema="a", chunk_size=7, compression="brotli", on_error="ignore", parallel=10, quote_identifiers=False, auto_create_table=True, create_temp_table=True, overwrite=True, table_type="temporary", random=90)
+ans2 = session.write_pandas(pandas.DataFrame(<not shown>), "test", database="b", schema="a", chunk_size=7, compression="brotli", on_error="ignore", parallel=10, quote_identifiers=False, auto_create_table=True, overwrite=True, table_type="temporary", random=90)
 
 ## EXPECTED ENCODED AST
 
@@ -78,7 +78,6 @@ body {
           value: 7
         }
         compression: "brotli"
-        create_temp_table: true
         df {
           dataframe_data__pandas {
             v {

--- a/tests/integ/test_dataframe.py
+++ b/tests/integ/test_dataframe.py
@@ -550,8 +550,6 @@ def test_select_table_function(session):
     reason="Session.generator is not supported in Local Testing",
 )
 def test_generator_table_function(session):
-    # seq1()/seq2() restart per parallel generator worker, so values repeat and
-    # are only non-decreasing once ordered — never assert strict increase.
     # works with rowcount
     # seq1() is a non-deterministic global sequence — exact values vary across environments.
     # Verify structure: 3 rows, uniform column deterministic with seed=2, ascending order.
@@ -563,7 +561,7 @@ def test_generator_table_function(session):
     result = df.collect()
     assert len(result) == 3
     assert all(row[1] == 3 for row in result)
-    assert result[0][0] <= result[1][0] <= result[2][0]
+    assert result[0][0] < result[1][0] < result[2][0]
 
     # works with timelimit
     # seq2() is also non-deterministic — apply same structural check
@@ -575,7 +573,7 @@ def test_generator_table_function(session):
     result = df.collect()
     assert len(result) == 3
     assert all(row[1] == 3 for row in result)
-    assert result[0][0] <= result[1][0] <= result[2][0]
+    assert result[0][0] < result[1][0] < result[2][0]
 
     # works with combination of both
     df = (
@@ -586,7 +584,7 @@ def test_generator_table_function(session):
     result = df.collect()
     assert len(result) == 3
     assert all(row[1] == 3 for row in result)
-    assert result[0][0] <= result[1][0] <= result[2][0]
+    assert result[0][0] < result[1][0] < result[2][0]
 
     # works without both
     df = session.generator(seq4(1), uniform(1, 10, 2))
@@ -603,7 +601,7 @@ def test_generator_table_function(session):
     result = df.collect()
     assert len(result) == 3
     assert all(row["UNICORN"] == 3 for row in result)
-    assert result[0]["PIXEL"] <= result[1]["PIXEL"] <= result[2]["PIXEL"]
+    assert result[0]["PIXEL"] < result[1]["PIXEL"] < result[2]["PIXEL"]
 
     # aggregation works
     df = session.generator(count(seq1(0)).as_("rows"), rowcount=150)

--- a/tests/integ/test_dataframe.py
+++ b/tests/integ/test_dataframe.py
@@ -550,6 +550,8 @@ def test_select_table_function(session):
     reason="Session.generator is not supported in Local Testing",
 )
 def test_generator_table_function(session):
+    # seq1()/seq2() restart per parallel generator worker, so values repeat and
+    # are only non-decreasing once ordered — never assert strict increase.
     # works with rowcount
     # seq1() is a non-deterministic global sequence — exact values vary across environments.
     # Verify structure: 3 rows, uniform column deterministic with seed=2, ascending order.
@@ -561,7 +563,7 @@ def test_generator_table_function(session):
     result = df.collect()
     assert len(result) == 3
     assert all(row[1] == 3 for row in result)
-    assert result[0][0] < result[1][0] < result[2][0]
+    assert result[0][0] <= result[1][0] <= result[2][0]
 
     # works with timelimit
     # seq2() is also non-deterministic — apply same structural check
@@ -573,7 +575,7 @@ def test_generator_table_function(session):
     result = df.collect()
     assert len(result) == 3
     assert all(row[1] == 3 for row in result)
-    assert result[0][0] < result[1][0] < result[2][0]
+    assert result[0][0] <= result[1][0] <= result[2][0]
 
     # works with combination of both
     df = (
@@ -584,7 +586,7 @@ def test_generator_table_function(session):
     result = df.collect()
     assert len(result) == 3
     assert all(row[1] == 3 for row in result)
-    assert result[0][0] < result[1][0] < result[2][0]
+    assert result[0][0] <= result[1][0] <= result[2][0]
 
     # works without both
     df = session.generator(seq4(1), uniform(1, 10, 2))
@@ -601,7 +603,7 @@ def test_generator_table_function(session):
     result = df.collect()
     assert len(result) == 3
     assert all(row["UNICORN"] == 3 for row in result)
-    assert result[0]["PIXEL"] < result[1]["PIXEL"] < result[2]["PIXEL"]
+    assert result[0]["PIXEL"] <= result[1]["PIXEL"] <= result[2]["PIXEL"]
 
     # aggregation works
     df = session.generator(count(seq1(0)).as_("rows"), rowcount=150)


### PR DESCRIPTION
## Summary

Rebases the fix from #4296 onto `main`. #4296's head branch (`worktree-create-temp-table-ast-fix`) is based on the stale `ud-local-test-scripts` branch, which is 49 commits behind `main` — so it can't land there cleanly. This PR cherry-picks #4296's two commits (unchanged, same authorship) directly onto current `main`, where they apply without conflicts.

Same fix as #4296: stops emitting the deprecated `create_temp_table` parameter into the encoded AST sent to the server, without changing Snowpark's own public API — `create_temp_table` stays in the function signatures, still fires its deprecation warning, and still works exactly as before for callers. Only `table_type` (already resolved from `create_temp_table` when needed) is now recorded in the AST.

Changes:
- **`dataframe_writer.py`**: Move `create_temp_table` deprecation coercion to *before* the AST emission block in `save_as_table`, so `table_type` is already resolved when `WriteTable` is encoded. Remove `expr.create_temp_table` emission.
- **`session.py`**: Remove `ast.create_temp_table = create_temp_table` from the `write_pandas` AST block — the coercion already fires before AST emission there, so `ast.table_type` carries the correct value.
- **`dataframe.py`**: Replace `create_temp_table=True` with `table_type="temp"` in the internal `cache_result` mock path, matching the real code path and avoiding a spurious deprecation warning from internal code.
- **`ast.proto`**: Mark both `create_temp_table` fields as `// Deprecated: use table_type instead.` (fields retained for wire compatibility).
- **`tests/ast/data/session_write_pandas.test`**: Remove `create_temp_table: true` from expected encoded AST and `create_temp_table=True` from expected unparser output.

## Test plan

- [x] `tests/ast/test_ast_driver.py::test_ast[session_write_pandas.test]` passes
- [x] `tests/ast/test_ast_driver.py::test_ast[DataFrame.write.test]` passes
- [x] Manually verified on a local-testing session: `save_as_table(..., create_temp_table=True)` still logs the deprecation warning and creates a temp table
- [x] Manually verified `cache_result()` no longer emits the spurious deprecation warning

Supersedes #4296 for the purpose of landing on `main`.

## Checklist

- [x] If adding any arguments to public Snowpark APIs or creating new public Snowpark APIs, I acknowledge that I have ensured my changes include AST support.
- [x] I acknowledge that I have ensured my changes to be thread-safe

---

**Stack** (via Graphite)
- [#4307](https://app.graphite.dev/github/pr/snowflakedb/snowpark-python/4307)
- [#4282](https://app.graphite.dev/github/pr/snowflakedb/snowpark-python/4282)
- [#4308](https://app.graphite.dev/github/pr/snowflakedb/snowpark-python/4308)
- [#4309](https://app.graphite.dev/github/pr/snowflakedb/snowpark-python/4309)
- [#4313](https://app.graphite.dev/github/pr/snowflakedb/snowpark-python/4313)
- [#4314](https://app.graphite.dev/github/pr/snowflakedb/snowpark-python/4314)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
