### PR TITLE
SNOW-2912540: add IS_V5_DRIVER constant for version-conditioned connector imports

### DIFF
--- a/src/snowflake/snowpark/_internal/utils.py
+++ b/src/snowflake/snowpark/_internal/utils.py
@@ -367,6 +367,8 @@ def is_interactive() -> bool:
     return hasattr(sys, "ps1") or sys.flags.interactive or "snowbook" in sys.modules
 
 
+IS_V5_DRIVER: bool = connector_version[0] >= 5
+
 @lru_cache
 def get_connector_version() -> str:
     return ".".join([str(d) for d in connector_version if d is not None])


### PR DESCRIPTION
Removes two imports from snowflake-connector-python that the Universal Driver connector no longer provides as shims.

- \`async_job.py\`: \`ASYNC_RETRY_PATTERN\` defined locally (was imported from \`connector.cursor\`)
- \`mock/_telemetry.py\`: \`from http.client import OK\` (was imported from \`connector.compat\`)

Companion changes in snowflake-eng/universal-driver PR #512 and #513.

---

**Stack** (via Graphite)
- [#4307](https://app.graphite.dev/github/pr/snowflakedb/snowpark-python/4307)
- [#4282](https://app.graphite.dev/github/pr/snowflakedb/snowpark-python/4282)
- [#4308](https://app.graphite.dev/github/pr/snowflakedb/snowpark-python/4308)
- [#4309](https://app.graphite.dev/github/pr/snowflakedb/snowpark-python/4309)
- [#4310](https://app.graphite.dev/github/pr/snowflakedb/snowpark-python/4310)
- [#4313](https://app.graphite.dev/github/pr/snowflakedb/snowpark-python/4313)
- [#4314](https://app.graphite.dev/github/pr/snowflakedb/snowpark-python/4314)

🤖 Generated with [Claude Code](https://claude.com/claude-code)