### PR TITLE
SNOW-2912540: use IS_V5_DRIVER for cursor request_id access

### DIFF
--- a/src/snowflake/snowpark/_internal/server_connection.py
+++ b/src/snowflake/snowpark/_internal/server_connection.py
@@ -467,7 +467,9 @@ class ServerConnection:
             )
             raise ex
 
-        notify_kwargs["requestId"] = str(results_cursor._request_id)
+        notify_kwargs["requestId"] = str(
+            results_cursor.request_id if IS_V5_DRIVER else results_cursor._request_id
+        )
         self.notify_query_listeners(
             QueryRecord(results_cursor.sfqid, results_cursor.query), **notify_kwargs
         )

--- a/tests/unit/test_server_connection.py
+++ b/tests/unit/test_server_connection.py
@@ -100,7 +100,10 @@ def test_run_query_exceptions(mock_server_connection, caplog):
     mock_server_connection._cursor.execute.return_value = mock_server_connection._cursor
     mock_server_connection._cursor.sfqid = "fake id"
     mock_server_connection._cursor.query = "fake query"
-    mock_server_connection._cursor._request_id = "1234"
+    if IS_V5_DRIVER:
+        mock_server_connection._cursor.request_id = "1234"
+    else:
+        mock_server_connection._cursor._request_id = "1234"
     with mock.patch.object(
         mock_server_connection._cursor,
         "fetch_pandas_all",


### PR DESCRIPTION
## Summary

- The UD's `SnowflakeCursor` exposes the client-generated request UUID as a public `request_id` property; `_request_id` is only a backward-compat alias slated for removal.
- The legacy v4 connector is the opposite: it only ever sets `self._request_id` as a plain instance attribute in `cursor.py`, with no public `request_id` property at all.
- Branch on `IS_V5_DRIVER` at the one call site that reads this — `execute_and_notify_query_listener` in `server_connection.py` — and its unit test mock.
- Investigated (but left untouched) the other `_request_id`-named attributes in the repo: `AstBatch._request_id` and `AstBuilder`'s request-id generation are Snowpark's own self-generated UUIDs for the AST Bind/Eval batching protocol — unrelated to the connector cursor, same name by coincidence.

## Test plan

- [x] `grep -rn "\._request_id\b" src/ tests/` confirms only the AST-batch (unrelated) and the fixed call sites remain

## Checklist

- [x] I acknowledge that I have ensured my changes to be thread-safe

---

**Stack** (via Graphite)
- [#4307](https://app.graphite.dev/github/pr/snowflakedb/snowpark-python/4307)
- [#4282](https://app.graphite.dev/github/pr/snowflakedb/snowpark-python/4282)
- [#4308](https://app.graphite.dev/github/pr/snowflakedb/snowpark-python/4308)
- [#4309](https://app.graphite.dev/github/pr/snowflakedb/snowpark-python/4309)
- [#4313](https://app.graphite.dev/github/pr/snowflakedb/snowpark-python/4313)
- [#4314](https://app.graphite.dev/github/pr/snowflakedb/snowpark-python/4314)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
