### PR TITLE
SNOW-2912540: remove _pandas_importer(), dedup mock/_options.py numpy handling

### DIFF
--- a/src/snowflake/snowpark/_internal/utils.py
+++ b/src/snowflake/snowpark/_internal/utils.py
@@ -63,7 +63,9 @@ if IS_V5_DRIVER:
     from snowflake.connector._common.extras import (
         MissingOptionalDependency,
         ModuleLikeObject,
+        pandas,
         pyarrow,
+        installed_pandas,
         installed_pyarrow,
     )
 else:
@@ -71,7 +73,9 @@ else:
         MissingOptionalDependency,
         MissingPandas,
         ModuleLikeObject,
+        pandas,
         pyarrow,
+        installed_pandas,
     )
 
     # connector.options (v4) never exported installed_pyarrow as its own name.
@@ -268,22 +272,6 @@ TEMPORARY_STRING = "TEMPORARY"
 SCOPED_TEMPORARY_STRING = "SCOPED TEMPORARY"
 
 SUPPORTED_TABLE_TYPES = ["temp", "temporary", "transient"]
-
-def _pandas_importer():  # noqa: E302
-    """Helper function to lazily import pandas and return MissingPandas if not installed."""
-    result = _missing_pandas()
-    try:
-        result = importlib.import_module("pandas")
-        # since we enable relative imports without dots this import gives us an issues when ran from test directory
-        from pandas import DataFrame  # NOQA
-    except ImportError:  # pragma: no cover
-        pass  # pragma: no cover
-    return result
-
-
-pandas = _pandas_importer()
-installed_pandas = not isinstance(pandas, MissingOptionalDependency)
-
 
 class TempObjectType(Enum):
     TABLE = "TABLE"

--- a/src/snowflake/snowpark/mock/_options.py
+++ b/src/snowflake/snowpark/mock/_options.py
@@ -4,7 +4,11 @@
 
 import importlib
 
-from snowflake.snowpark._internal.utils import MissingOptionalDependency, _missing_pandas
+from snowflake.snowpark._internal.utils import (
+    IS_V5_DRIVER,
+    MissingOptionalDependency,
+    _missing_pandas,
+)
 
 try:
     import pandas
@@ -15,15 +19,20 @@ except ImportError:
     installed_pandas = False
 
 
-class MissingNumpy(MissingOptionalDependency):
-    """The class is specifically for numpy optional dependency."""
+if IS_V5_DRIVER:
+    from snowflake.connector._common.extras import numpy
 
-    _dep_name = "numpy"
+    installed_numpy = not isinstance(numpy, MissingOptionalDependency)
+else:
 
+    class MissingNumpy(MissingOptionalDependency):
+        """The class is specifically for numpy optional dependency."""
 
-try:
-    numpy = importlib.import_module("numpy")
-    installed_numpy = True
-except ImportError:
-    numpy = MissingNumpy()
-    installed_numpy = False
+        _dep_name = "numpy"
+
+    try:
+        numpy = importlib.import_module("numpy")
+        installed_numpy = True
+    except ImportError:
+        numpy = MissingNumpy()
+        installed_numpy = False

--- a/tests/unit/test_internal_utils.py
+++ b/tests/unit/test_internal_utils.py
@@ -4,11 +4,9 @@
 import concurrent.futures
 import random
 import pytest
-from snowflake.connector.options import MissingPandas
 
 from snowflake.snowpark._internal import utils
 from snowflake.snowpark._internal.utils import (
-    _pandas_importer,
     generate_random_alphanumeric,
     split_snowflake_identifier_with_dot,
 )
@@ -146,16 +144,6 @@ def test_normalize_path_escapes_backslash_and_quote(raw_path, is_local):
     assert decoded.endswith(
         expected_tail
     ), f"decoded={decoded!r} does not end with {expected_tail!r}"
-
-
-def test__pandas_importer():
-    imported_pandas = _pandas_importer()
-    try:
-        import pandas
-
-        assert imported_pandas == pandas
-    except ImportError:
-        assert isinstance(imported_pandas, MissingPandas)
 
 
 def test_generate_random_alphanumeric():


### PR DESCRIPTION
## Summary

- `_internal/utils.py`'s `_pandas_importer()` predated this whole effort and duplicated pandas resolution the connector already does correctly on both driver generations, including the "relative imports without dots" `DataFrame` workaround (folded into UD's `_common.extras.pandas` per not-yet-merged UD PR #1151/#1152; v4's `options.py` already had it). Removed; `pandas`/`installed_pandas` now come from the same `IS_V5_DRIVER`-gated import block as the rest of these names.
- `mock/_options.py`'s `MissingNumpy`/`numpy` handling was a confirmed pure duplicate of `_common.extras`'s own numpy resolution (per UD PR #1152's investigation). Deduped on v5; v4 keeps its own `MissingNumpy`, since v4's `options.py` has no numpy handling to delegate to. Pandas resolution in this file is untouched — Local Testing deliberately never resolves pyarrow (commit #1628), unrelated to this change.
- Stacked on [#4313](https://github.com/snowflakedb/snowpark-python/pull/4313)/[#4314](https://github.com/snowflakedb/snowpark-python/pull/4314), part of the SNOW-2912540 effort decoupling Snowpark from the connector compat shim.

**Still open**: UD PRs [#1151](https://app.graphite.com/github/pr/snowflake-eng/drivers/1151) and [#1152](https://app.graphite.com/github/pr/snowflake-eng/drivers/1152) are both draft/unreviewed/unmerged. This PR's `IS_V5_DRIVER=True` path is written against their current source but unverifiable end-to-end (wheel build + install) until they merge.

## Test plan

- [x] Verified the `DataFrame` workaround isn't needed on Snowpark's side by running the exact invocation style its comment called out (`cd tests/unit && pytest test_utils.py test_internal_utils.py`) — no failure.
- [x] Full unit suite (excluding `modin`, missing extra in this env) passes against the real v4.7.2 connector: 2419 passed, 2 skipped, 1 xfailed.
- [ ] Verify against the UD wheel once #1151/#1152 merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)