### PR TITLE
SNOW-3960822: skip test_sample_with_sampling_method on stored proc localfs

### DIFF
--- a/tests/integ/scala/test_dataframe_suite.py
+++ b/tests/integ/scala/test_dataframe_suite.py
@@ -1005,6 +1005,7 @@ def test_sample_with_seed(session):
         Utils.drop_table(session, temp_table_name)
 
 
+@pytest.mark.skipif(IS_IN_STORED_PROC_LOCALFS, reason="Large result")
 def test_sample_with_sampling_method(session):
     """sampling method actually has no impact on result. It has impact on performance."""
     row_count = 10000


### PR DESCRIPTION
## Summary
- Skip `test_sample_with_sampling_method` when running inside a stored proc on local-disk storage (`IS_IN_STORED_PROC_LOCALFS`), matching `test_sample_with_frac` and `test_sample_with_row_count` in the same file.
- A 10k-row `.collect()` can spill past GS's first result chunk (~97KB). On LIGHTWEIGHT/localfs, extra chunks use `/queries/download-result` URLs that Python stored procs do not support, which flakes [SNOW-3960822](https://snowflakecomputing.atlassian.net/browse/SNOW-3960822).
- The durable server-side fix is [SNOW-3967582](https://snowflakecomputing.atlassian.net/browse/SNOW-3967582) (support localfs result-chunk URLs in stored procs). That is not on the near-term radar, so this skip unblocks BPTP until then.

## Test plan
- [ ] Confirm the decorator matches the existing `IS_IN_STORED_PROC_LOCALFS` / `"Large result"` skips in `tests/integ/scala/test_dataframe_suite.py`.
- [ ] After this ships into the Snowfort staged snowpark tests, [SNOW-3960822](https://snowflakecomputing.atlassian.net/browse/SNOW-3960822) should stop failing on `REG_LIGHTWEIGHT`. The test still runs as a normal client integ test and still runs in stored procs on local AWS / remote.

[SNOW-3960822]: https://snowflakecomputing.atlassian.net/browse/SNOW-3960822?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SNOW-3967582]: https://snowflakecomputing.atlassian.net/browse/SNOW-3967582?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SNOW-3960822]: https://snowflakecomputing.atlassian.net/browse/SNOW-3960822?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ