### PR TITLE
NO-SNOW: cast numeric prompt arg in AI complete test, drop expired date xfails

### DIFF
--- a/src/conftest.py
+++ b/src/conftest.py
@@ -2,7 +2,6 @@
 #
 # Copyright (c) 2012-2025 Snowflake Computing Inc. All rights reserved.
 #
-import datetime
 import doctest
 import logging
 import os
@@ -101,16 +100,6 @@ def pytest_collection_modifyitems(config, items):
     This function is used to skip some doctests on certain conditions.
     For example, some functions in PrPr might not be available on Azure and GCP.
     """
-    # Mark flaky tests as xfail for a time
-    if datetime.date.today() <= datetime.date(2026, 6, 4):
-        xfail_ai = pytest.mark.xfail(
-            reason="dataframe_ai_functions doctests flaky due to infrastructure issues",
-            strict=False,
-        )
-        for item in items:
-            if isinstance(item, DoctestItem) and "dataframe_ai" in item.name:
-                item.add_marker(xfail_ai)
-
     host = (
         conn_params.get("host") or conn_params.get("HOST") or conn_params.get("account")
     )

--- a/tests/integ/test_dataframe_ai.py
+++ b/tests/integ/test_dataframe_ai.py
@@ -5,6 +5,7 @@
 import json
 import pytest
 from snowflake.snowpark.functions import ai_complete, ai_extract, col, lit, to_file
+from snowflake.snowpark.types import StringType
 from tests.utils import RUNNING_ON_JENKINS, TestFiles, Utils
 from snowflake.snowpark.exceptions import SnowparkSQLException
 
@@ -16,15 +17,6 @@ pytestmark = [
 ]
 
 
-@pytest.mark.xfail(
-    reason=(
-        "Server-side PROMPT() rejects non-string arguments: the integer 'rating' "
-        "column is embedded in the prompt object as a number, which fails with "
-        "'unsupported argument type' and surfaces as a NULL completion. Casting "
-        "the column to VARCHAR makes it pass, so this needs a server-side fix."
-    ),
-    strict=False,
-)
 def test_dataframe_ai_complete_with_named_placeholders(session):
     """Test DataFrame.ai.complete with named placeholders."""
     # Create a DataFrame with review data
@@ -42,7 +34,9 @@ def test_dataframe_ai_complete_with_named_placeholders(session):
         prompt="Analyze this {category} product review: '{review}' with rating {rating}/5. What is the sentiment?",
         input_columns={
             "review": col("review"),
-            "rating": col("rating"),
+            # PROMPT() only accepts string arguments; a numeric column reaches the
+            # server as a number and fails with "unsupported argument type".
+            "rating": col("rating").cast(StringType()),
             "category": col("category"),
         },
         output_column="sentiment_analysis",

--- a/tests/integ/test_dataframe_ai.py
+++ b/tests/integ/test_dataframe_ai.py
@@ -34,8 +34,8 @@ def test_dataframe_ai_complete_with_named_placeholders(session):
         prompt="Analyze this {category} product review: '{review}' with rating {rating}/5. What is the sentiment?",
         input_columns={
             "review": col("review"),
-            # PROMPT() only accepts string arguments; a numeric column reaches the
-            # server as a number and fails with "unsupported argument type".
+            # Docs allow NUMBER prompt args; runtime currently rejects them with
+            # "unsupported argument type". Cast until the server-side bug is fixed.
             "rating": col("rating").cast(StringType()),
             "category": col("category"),
         },

--- a/tests/integ/test_dataframe_ai.py
+++ b/tests/integ/test_dataframe_ai.py
@@ -2,7 +2,6 @@
 # Copyright (c) 2012-2025 Snowflake Computing Inc. All rights reserved.
 #
 
-import datetime
 import json
 import pytest
 from snowflake.snowpark.functions import ai_complete, ai_extract, col, lit, to_file
@@ -14,14 +13,17 @@ pytestmark = [
         "config.getoption('local_testing_mode', default=False)",
         reason="AI functions are not yet supported in local testing mode.",
     ),
-    pytest.mark.xfail(
-        datetime.date.today() <= datetime.date(2026, 6, 4),
-        reason="AI tests flaky due to infrastructure issues",
-        strict=False,
-    ),
 ]
 
 
+@pytest.mark.xfail(
+    reason=(
+        "AI_COMPLETE returns NULL for this named-placeholder prompt in daily CI "
+        "(26/26 jobs on 2026-08-17). Client SQL generation is correct; sibling "
+        "llama3.1-8b complete tests pass. Keep this test running so XPASS is visible."
+    ),
+    strict=False,
+)
 def test_dataframe_ai_complete_with_named_placeholders(session):
     """Test DataFrame.ai.complete with named placeholders."""
     # Create a DataFrame with review data

--- a/tests/integ/test_dataframe_ai.py
+++ b/tests/integ/test_dataframe_ai.py
@@ -18,9 +18,10 @@ pytestmark = [
 
 @pytest.mark.xfail(
     reason=(
-        "AI_COMPLETE returns NULL for this named-placeholder prompt in daily CI "
-        "(26/26 jobs on 2026-08-17). Client SQL generation is correct; sibling "
-        "llama3.1-8b complete tests pass. Keep this test running so XPASS is visible."
+        "Server-side PROMPT() rejects non-string arguments: the integer 'rating' "
+        "column is embedded in the prompt object as a number, which fails with "
+        "'unsupported argument type' and surfaces as a NULL completion. Casting "
+        "the column to VARCHAR makes it pass, so this needs a server-side fix."
     ),
     strict=False,
 )


### PR DESCRIPTION
## Summary

`test_dataframe_ai_complete_with_named_placeholders` has been failing in every daily precommit job (26/26, all clouds) since the blanket date-based `xfail`s in `src/conftest.py` and `tests/integ/test_dataframe_ai.py` expired on 2026-06-04. Deterministic, not a flake.

**Root cause:** the test passes an integer `rating` column into `PROMPT()`. Official docs say NUMBER is allowed ("any type coercible to a string (for example, VARCHAR, NUMBER, etc.), or FILE"), but the runtime stores the number verbatim and rejects it with `unsupported argument type`. With `return_error_details` off, that surfaces as a `NULL` completion.

Minimal repro:

```sql
SELECT AI_COMPLETE('llama3.1-8b', PROMPT('{0}', 1), {'return_error_details': true});
-- {"value": null, "error": "unsupported argument type"}
```

Sibling `llama3.1-8b` tests pass because they only pass string columns.

## Changes

- Cast `rating` to `StringType` in `input_columns` so this test covers named-placeholder rewriting instead of tripping over the server-side type bug.
- Remove the two expired date-based `xfail`s (doctest hook in `src/conftest.py`, module-level mark in `test_dataframe_ai.py`).

Server-side follow-up for the AI SQL team: either cast string-coercible args in `PROMPT()` as documented, or have the prompt parser stringify scalars. Separately, a type error collapsing to silent `NULL` is a bad failure mode.

## Test plan

- [ ] Daily precommit passes with `test_dataframe_ai_complete_with_named_placeholders` green.
- [ ] Other `dataframe_ai` tests and doctests now run unmasked; confirm no other latent failures.

Verified the casted SQL against a live deployment: all three rows return non-empty completions. Pytest integ run is covered by CI (no local snowpark integ credentials here).