### PR TITLE
SNOW-3972121: tolerate extra CURRENT_DATABASE/SCHEMA queries in stored-proc tests

### DIFF
--- a/tests/integ/test_dataframe.py
+++ b/tests/integ/test_dataframe.py
@@ -9,6 +9,7 @@ import decimal
 import json
 import logging
 import math
+import re
 import time
 from array import array
 from collections import namedtuple
@@ -1679,12 +1680,24 @@ def test_cache_result_query(session):
     with session.query_history() as history:
         df.cache_result()
 
-    assert len(history.queries) == 2
-    assert "CREATE  SCOPED TEMPORARY  TABLE" in history.queries[0].sql_text
+    # connector >= 4.7.1 no longer caches database/schema from non-USE statements (e.g. CREATE TEMP TABLE).
+    # Filter out metadata queries (e.g. SELECT CURRENT_DATABASE()) that may appear
+    # in some environments before or between the expected DDL/DML statements.
+    filtered_queries = [
+        q
+        for q in history.queries
+        if not re.match(
+            r"^\s*SELECT\s+CURRENT_(DATABASE|SCHEMA)\s*\(\s*\)\s*$",
+            q.sql_text,
+            re.IGNORECASE,
+        )
+    ]
+    assert len(filtered_queries) == 2
+    assert "CREATE  SCOPED TEMPORARY  TABLE" in filtered_queries[0].sql_text
     assert (
-        "INSERT  INTO" in history.queries[1].sql_text
+        "INSERT  INTO" in filtered_queries[1].sql_text
         and 'SELECT $1 AS "A", $2 AS "B" FROM  VALUES (1 :: INT, 2 :: INT)'
-        in history.queries[1].sql_text
+        in filtered_queries[1].sql_text
     )
 
 

--- a/tests/integ/test_large_query_breakdown.py
+++ b/tests/integ/test_large_query_breakdown.py
@@ -5,6 +5,7 @@
 
 import logging
 import os
+import re
 import tempfile
 from unittest.mock import patch
 
@@ -31,6 +32,14 @@ pytestmark = [
         run=False,
     )
 ]
+
+_METADATA_QUERY_RE = re.compile(
+    r"^\s*SELECT\s+CURRENT_(DATABASE|SCHEMA)\s*\(\s*\)\s*$", re.IGNORECASE
+)
+
+
+def _filter_metadata_queries(queries):
+    return [q for q in queries if not _METADATA_QUERY_RE.match(q.sql_text)]
 
 
 @pytest.fixture(autouse=True)
@@ -283,13 +292,14 @@ def test_save_as_table(session, large_query_df):
         with SqlCounter(query_count=4, union_count=1, describe_count=1):
             large_query_df.write.save_as_table(table_name, mode="overwrite")
 
-    assert len(history.queries) == 4
-    assert history.queries[0].sql_text == "SELECT CURRENT_TRANSACTION()"
-    assert history.queries[1].sql_text.startswith("CREATE  SCOPED TEMPORARY  TABLE")
-    assert history.queries[2].sql_text.startswith(
+    filtered = _filter_metadata_queries(history.queries)
+    assert len(filtered) == 4
+    assert filtered[0].sql_text == "SELECT CURRENT_TRANSACTION()"
+    assert filtered[1].sql_text.startswith("CREATE  SCOPED TEMPORARY  TABLE")
+    assert filtered[2].sql_text.startswith(
         f"CREATE  OR  REPLACE    TABLE  {table_name}"
     )
-    assert history.queries[3].sql_text.startswith("DROP  TABLE  If  EXISTS")
+    assert filtered[3].sql_text.startswith("DROP  TABLE  If  EXISTS")
 
 
 def test_variable_binding(session):
@@ -338,21 +348,23 @@ def test_update_delete_merge(session, large_query_df):
         # 3 describe call triggered due to column state extraction
         with SqlCounter(query_count=4, union_count=1, describe_count=2):
             t.update({"B": 0}, t.a == large_query_df.a, large_query_df)
-    assert len(history.queries) == 4
-    assert history.queries[0].sql_text == "SELECT CURRENT_TRANSACTION()"
-    assert history.queries[1].sql_text.startswith("CREATE  SCOPED TEMPORARY  TABLE")
-    assert history.queries[2].sql_text.startswith(f"UPDATE {table_name}")
-    assert history.queries[3].sql_text.startswith("DROP  TABLE  If  EXISTS")
+    filtered = _filter_metadata_queries(history.queries)
+    assert len(filtered) == 4
+    assert filtered[0].sql_text == "SELECT CURRENT_TRANSACTION()"
+    assert filtered[1].sql_text.startswith("CREATE  SCOPED TEMPORARY  TABLE")
+    assert filtered[2].sql_text.startswith(f"UPDATE {table_name}")
+    assert filtered[3].sql_text.startswith("DROP  TABLE  If  EXISTS")
 
     # delete
     with session.query_history() as history:
         with SqlCounter(query_count=4, union_count=1, describe_count=0):
             t.delete(t.a == large_query_df.a, large_query_df)
-    assert len(history.queries) == 4
-    assert history.queries[0].sql_text == "SELECT CURRENT_TRANSACTION()"
-    assert history.queries[1].sql_text.startswith("CREATE  SCOPED TEMPORARY  TABLE")
-    assert history.queries[2].sql_text.startswith(f"DELETE  FROM {table_name} USING")
-    assert history.queries[3].sql_text.startswith("DROP  TABLE  If  EXISTS")
+    filtered = _filter_metadata_queries(history.queries)
+    assert len(filtered) == 4
+    assert filtered[0].sql_text == "SELECT CURRENT_TRANSACTION()"
+    assert filtered[1].sql_text.startswith("CREATE  SCOPED TEMPORARY  TABLE")
+    assert filtered[2].sql_text.startswith(f"DELETE  FROM {table_name} USING")
+    assert filtered[3].sql_text.startswith("DROP  TABLE  If  EXISTS")
 
     # merge
     with session.query_history() as history:
@@ -362,11 +374,12 @@ def test_update_delete_merge(session, large_query_df):
                 t.a == large_query_df.a,
                 [when_matched().update({"b": large_query_df.b})],
             )
-    assert len(history.queries) == 4
-    assert history.queries[0].sql_text == "SELECT CURRENT_TRANSACTION()"
-    assert history.queries[1].sql_text.startswith("CREATE  SCOPED TEMPORARY  TABLE")
-    assert history.queries[2].sql_text.startswith(f"MERGE  INTO {table_name} USING")
-    assert history.queries[3].sql_text.startswith("DROP  TABLE  If  EXISTS")
+    filtered = _filter_metadata_queries(history.queries)
+    assert len(filtered) == 4
+    assert filtered[0].sql_text == "SELECT CURRENT_TRANSACTION()"
+    assert filtered[1].sql_text.startswith("CREATE  SCOPED TEMPORARY  TABLE")
+    assert filtered[2].sql_text.startswith(f"MERGE  INTO {table_name} USING")
+    assert filtered[3].sql_text.startswith("DROP  TABLE  If  EXISTS")
 
 
 def test_copy_into_location(session, large_query_df):
@@ -380,11 +393,12 @@ def test_copy_into_location(session, large_query_df):
                 overwrite=True,
                 single=True,
             )
-    assert len(history.queries) == 4, history.queries
-    assert history.queries[0].sql_text == "SELECT CURRENT_TRANSACTION()"
-    assert history.queries[1].sql_text.startswith("CREATE  SCOPED TEMPORARY  TABLE")
-    assert history.queries[2].sql_text.startswith(f"COPY  INTO '{remote_file_path}'")
-    assert history.queries[3].sql_text.startswith("DROP  TABLE  If  EXISTS")
+    filtered = _filter_metadata_queries(history.queries)
+    assert len(filtered) == 4, filtered
+    assert filtered[0].sql_text == "SELECT CURRENT_TRANSACTION()"
+    assert filtered[1].sql_text.startswith("CREATE  SCOPED TEMPORARY  TABLE")
+    assert filtered[2].sql_text.startswith(f"COPY  INTO '{remote_file_path}'")
+    assert filtered[3].sql_text.startswith("DROP  TABLE  If  EXISTS")
 
 
 def test_in_with_subquery_multiple_query(session):
@@ -561,8 +575,9 @@ def test_optimization_skipped_with_transaction(session, large_query_df, caplog):
 
     check_optimization_skipped_reason(patch_send, {"active transaction": 1})
 
-    assert len(history.queries) == 2, history.queries
-    assert history.queries[0].sql_text == "SELECT CURRENT_TRANSACTION()"
+    filtered_queries = _filter_metadata_queries(history.queries)
+    assert len(filtered_queries) == 2, filtered_queries
+    assert filtered_queries[0].sql_text == "SELECT CURRENT_TRANSACTION()"
     assert "Skipping large query breakdown" in caplog.text
     assert Utils.is_active_transaction(session)
     assert session.sql("commit").collect()
@@ -699,15 +714,18 @@ def test_add_parent_plan_uuid_to_statement_params(session, large_query_df):
         Utils.check_answer(result, [Row(1, 5999), Row(2, 5998)])
 
         plan = large_query_df._plan
-        # 1 for current transaction, 1 for partition, 1 for main query, 1 for post action
-        assert patched_run_query.call_count == 4
+        filtered_calls = [
+            call
+            for call in patched_run_query.call_args_list
+            if not _METADATA_QUERY_RE.match(call.args[0])
+        ]
+        assert len(filtered_calls) == 4
 
-        for i, call in enumerate(patched_run_query.call_args_list):
-            if i == 0:
-                assert call.args[0] == "SELECT CURRENT_TRANSACTION()"
-            else:
-                assert "_statement_params" in call.kwargs
-                assert call.kwargs["_statement_params"]["_PLAN_UUID"] == plan.uuid
+        for call in filtered_calls:
+            if call.args[0] == "SELECT CURRENT_TRANSACTION()":
+                continue
+            assert "_statement_params" in call.kwargs
+            assert call.kwargs["_statement_params"]["_PLAN_UUID"] == plan.uuid
 
 
 @pytest.mark.skipif(

--- a/tests/integ/test_multithreading.py
+++ b/tests/integ/test_multithreading.py
@@ -198,7 +198,9 @@ def test_session_stage_created_once(threadsafe_session):
             for _ in range(10):
                 executor.submit(threadsafe_session.get_session_stage)
 
-        assert patched_run_query.call_count == 1
+        # connector >= 4.7.1 no longer caches database/schema from non-USE statements (e.g. CREATE TEMP STAGE).
+        # Older connectors did, expect 3 queries for >= 4.7.1, 1 for earlier versions.
+        assert patched_run_query.call_count in [1, 3]
 
 
 def test_action_ids_are_unique(threadsafe_session):


### PR DESCRIPTION
Snowfort 10.30.100 clones `test-v1.53.1` because `information_schema.packages` still lists snowpark 1.53.1, but the stored-proc runtime is 1.54.0 with snowflake-connector-python >= 4.7.1. That connector no longer caches database/schema after CREATE TEMP TABLE/STAGE, so extra `SELECT CURRENT_DATABASE()` / `SELECT CURRENT_SCHEMA()` queries show up and exact query-count asserts fail.

This is not a 1.53.1 product regression. The same Snowfort mismatch already filed as [SNOW-3958345](https://snowflakecomputing.atlassian.net/browse/SNOW-3958345) on 10.30.10. The test-side fix is already on `main` / `test-v1.54.0`. This ports it onto `test-v1.53.1` so Snowfort stops failing on the branch it actually clones.

**Tickets**
- [SNOW-3972121](https://snowflakecomputing.atlassian.net/browse/SNOW-3972121) (`test_cache_result_query`: `assert 4 == 2`)
- [SNOW-3972180](https://snowflakecomputing.atlassian.net/browse/SNOW-3972180) (`test_session_stage_created_once`: expected `call_count == 1`, got 3; also `test_large_query_breakdown.py`)
- [SNOW-3958345](https://snowflakecomputing.atlassian.net/browse/SNOW-3958345) (same failure on 10.30.10)

**Already on main**
- [#4295](https://github.com/snowflakedb/snowpark-python/pull/4295) ([`fb3ac1e79`](https://github.com/snowflakedb/snowpark-python/commit/fb3ac1e794d31ffc337c4bb77a88f9131acdcbeb)) initial `in [1, 3]` / `in [2, 4]`
- [#4298](https://github.com/snowflakedb/snowpark-python/pull/4298) ([`b99b89b3d`](https://github.com/snowflakedb/snowpark-python/commit/b99b89b3ded6620f9e22af5539dbba8706e45079)) filter CURRENT_DATABASE/SCHEMA, then assert remaining counts
- [#4299](https://github.com/snowflakedb/snowpark-python/pull/4299) ([`4392522fb`](https://github.com/snowflakedb/snowpark-python/commit/4392522fb)) `_filter_metadata_queries` helper in `test_large_query_breakdown.py`

**This PR**
- `test_cache_result_query`: drop CURRENT_DATABASE/SCHEMA from history, then `assert len(filtered_queries) == 2`
- `test_session_stage_created_once`: `assert patched_run_query.call_count in [1, 3]`
- `test_large_query_breakdown.py`: same metadata-query filter on history and `run_query` call counts

<!---
Please answer these questions before creating your pull request. Thanks!
--->

1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes [SNOW-3972121](https://snowflakecomputing.atlassian.net/browse/SNOW-3972121)
   Also [SNOW-3972180](https://snowflakecomputing.atlassian.net/browse/SNOW-3972180)

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.
   - [x] I acknowledge that I have ensured my changes to be thread-safe. Follow the link for more information: [Thread-safe Developer Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#thread-safe-development)
   - [x] If adding any arguments to public Snowpark APIs or creating new public Snowpark APIs, I acknowledge that I have ensured my changes include AST support. Follow the link for more information: [AST Support Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#ast-abstract-syntax-tree-support-in-snowpark)

3. Please describe how your code solves the related issue.

   Filter (or allow) the extra CURRENT_DATABASE/SCHEMA round-trips that connector >= 4.7.1 issues after CREATE TEMP TABLE/STAGE, matching the assertions already on main.


[SNOW-3958345]: https://snowflakecomputing.atlassian.net/browse/SNOW-3958345?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SNOW-3972121]: https://snowflakecomputing.atlassian.net/browse/SNOW-3972121?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SNOW-3972180]: https://snowflakecomputing.atlassian.net/browse/SNOW-3972180?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SNOW-3958345]: https://snowflakecomputing.atlassian.net/browse/SNOW-3958345?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ