### PR TITLE
NO-SNOW: stop relying on connector threads in pandas CTE test

### DIFF
--- a/tests/integ/modin/test_session_cte_optimization.py
+++ b/tests/integ/modin/test_session_cte_optimization.py
@@ -4,7 +4,6 @@
 #
 
 import logging
-import pandas as native_pd
 import threading
 from contextlib import contextmanager
 from typing import Any, Generator
@@ -31,29 +30,32 @@ def session_parameter_override(
 
 
 @sql_count_checker(query_count=0)
-def test_cte_optimization_for_snowpark_pandas(db_parameters, caplog):
+def test_cte_optimization_for_snowpark_pandas(caplog):
     session = _get_active_session()
 
     caplog.set_level(logging.WARNING)
 
-    # Creating a dataframe ensures that another thread is running which triggers the warning
-    session.create_dataframe(
-        native_pd.DataFrame([[1, 11], [2, 12], [2, 13]], columns=["A", "B"])
+    # The multithreading warning is emitted only while another thread is alive.
+    stop = threading.Event()
+    extra_thread = threading.Thread(
+        target=stop.wait, name="cte-opt-warning-probe", daemon=True
     )
-    assert len(threading.enumerate()) > 1
+    extra_thread.start()
+    try:
+        assert len(threading.enumerate()) > 1
 
-    # Use context manager to temporarily disable CTE optimization
-    with session_parameter_override(session, "cte_optimization_enabled", False):
-        assert session.cte_optimization_enabled is False
+        with session_parameter_override(session, "cte_optimization_enabled", False):
+            assert session.cte_optimization_enabled is False
 
-        caplog.clear()
+            caplog.clear()
 
-        # Verify that cte optimization will be enabled once snowpark pandas is used
-        assert pd.session == session
-        assert pd.session.cte_optimization_enabled is True
+            assert pd.session == session
+            assert pd.session.cte_optimization_enabled is True
 
-        # Verify that the warning is filtered out
-        assert (
-            "You might have more than one threads sharing the Session object trying to update"
-            not in caplog.text
-        )
+            assert (
+                "You might have more than one threads sharing the Session object trying to update"
+                not in caplog.text
+            )
+    finally:
+        stop.set()
+        extra_thread.join()

--- a/tests/integ/modin/test_session_cte_optimization.py
+++ b/tests/integ/modin/test_session_cte_optimization.py
@@ -15,6 +15,10 @@ from snowflake.snowpark.session import _get_active_session
 
 from tests.integ.utils.sql_counter import sql_count_checker
 
+_MULTITHREAD_SESSION_WARNING = (
+    "You might have more than one threads sharing the Session object trying to update"
+)
+
 
 @contextmanager
 def session_parameter_override(
@@ -37,12 +41,14 @@ def test_cte_optimization_for_snowpark_pandas(caplog):
 
     # The multithreading warning is emitted only while another thread is alive.
     stop = threading.Event()
-    extra_thread = threading.Thread(
-        target=stop.wait, name="cte-opt-warning-probe", daemon=True
-    )
+    extra_thread = threading.Thread(target=stop.wait, name="cte-opt-warning-probe")
     extra_thread.start()
     try:
         assert len(threading.enumerate()) > 1
+
+        caplog.clear()
+        session.cte_optimization_enabled = session.cte_optimization_enabled
+        assert _MULTITHREAD_SESSION_WARNING in caplog.text
 
         with session_parameter_override(session, "cte_optimization_enabled", False):
             assert session.cte_optimization_enabled is False
@@ -52,10 +58,8 @@ def test_cte_optimization_for_snowpark_pandas(caplog):
             assert pd.session == session
             assert pd.session.cte_optimization_enabled is True
 
-            assert (
-                "You might have more than one threads sharing the Session object trying to update"
-                not in caplog.text
-            )
+            assert _MULTITHREAD_SESSION_WARNING not in caplog.text
     finally:
         stop.set()
-        extra_thread.join()
+        extra_thread.join(timeout=5)
+        assert not extra_thread.is_alive()


### PR DESCRIPTION
## Summary
- Daily Snowpark pandas CI (`test_cte_optimization_for_snowpark_pandas`) has been failing on Linux/macOS since ~Aug 12 because `create_dataframe` no longer leaves a connector background thread around.
- The test only needed another live thread so `warn_session_config_update_in_multithreaded_mode` would fire; it now starts a dummy thread instead of depending on connector internals.
- Windows jobs were already passing because extra threads exist there anyway.

## Test plan
- [x] `pytest tests/integ/modin/test_session_cte_optimization.py::test_cte_optimization_for_snowpark_pandas` locally in the `snowflake` conda env (passed)
- [ ] Daily Snowpark pandas API job should go green for this test on Linux/macOS