### PR TITLE
fix: integer optional-argument defaults + generator SEQ test, to clear merge gates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
 
 - Added interval type support for Python UDFs and stored procedures. Use `datetime.timedelta` as the type annotation for day-time interval (`DayTimeIntervalType`) parameters and return values, and `YearMonthInterval` (a type annotation sentinel from `snowflake.snowpark.types`) for year-month interval (`YearMonthIntervalType`) parameters and return values.
 
+#### Bug Fixes
+
+- Fixed registering a UDF, UDTF, or stored procedure with an integer optional argument failing with `SQL compilation error: invalid default argument expression`. Integer defaults were emitted as `DEFAULT <value> :: INT`, and a parameter default only accepts a constant expression. The redundant cast is no longer generated.
+
 ## 1.54.0 (2026-07-29)
 
 ### Snowpark Python API updates

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@
 
 - Fixed registering a UDF, UDTF, or stored procedure with an integer optional argument failing with `SQL compilation error: invalid default argument expression`. Integer defaults were emitted as `DEFAULT <value> :: INT`, and a parameter default only accepts a constant expression. The redundant cast is no longer generated.
 
+#### Other Changes
+
+- Test-only: fixed `test_generator_table_function` failing as `assert 0 < 0` on the `seq2(0)` + `generator(timelimit => 1)` case. `seq2(0)` passes sign=0, so it continues at 0 after 32767, and a one-second generator run usually emits far more than one 32768-value cycle, making `ORDER BY seq2(0) LIMIT 3` return `0, 0, 0`. That assertion now allows equal values; the `seq1(1)` + `rowcount` assertions stay strictly increasing.
+
 ## 1.54.0 (2026-07-29)
 
 ### Snowpark Python API updates

--- a/src/snowflake/snowpark/_internal/analyzer/datatype_mapper.py
+++ b/src/snowflake/snowpark/_internal/analyzer/datatype_mapper.py
@@ -331,6 +331,25 @@ def to_sql_no_cast(
     return f"{value}"
 
 
+def to_sql_for_default_arg(value: Any, datatype: DataType) -> str:
+    """Convert a value with DataType to SQL usable as a parameter's DEFAULT.
+
+    Identical to :func:`to_sql` except that integral values are emitted as bare
+    literals rather than ``<value> :: INT``. A DEFAULT only accepts a constant
+    expression, and the parameter already declares its own type, so the cast is
+    redundant. Snowflake rejects it outright on some server versions with
+    ``invalid default argument expression`` (SNOW-4013704).
+    """
+    if isinstance(datatype, _IntegralType):
+        if value is None:
+            return "NULL"
+        if isinstance(value, int):
+            # bool is a subclass of int, so normalize it to 0/1 for an
+            # integral parameter rather than emitting True/False.
+            return str(int(value))
+    return to_sql(value, datatype)
+
+
 def to_sql(
     value: Any,
     datatype: DataType,

--- a/src/snowflake/snowpark/_internal/udf_utils.py
+++ b/src/snowflake/snowpark/_internal/udf_utils.py
@@ -32,7 +32,11 @@ from packaging.requirements import Requirement
 import snowflake.snowpark
 from snowflake.connector.options import installed_pandas, pandas
 from snowflake.snowpark._internal import code_generation, type_utils
-from snowflake.snowpark._internal.analyzer.datatype_mapper import to_sql, to_sql_no_cast
+from snowflake.snowpark._internal.analyzer.datatype_mapper import (
+    to_sql,
+    to_sql_for_default_arg,
+    to_sql_no_cast,
+)
 from snowflake.snowpark._internal.telemetry import TelemetryField
 from snowflake.snowpark._internal.type_utils import (
     NoneType,
@@ -448,7 +452,7 @@ def get_opt_arg_defaults(
 
         if num_optional_args != 0:
             default_values_to_sql_str = [
-                to_sql(value, datatype)
+                to_sql_for_default_arg(value, datatype)
                 for value, datatype in zip(default_values, input_types_for_default_args)
             ]
         else:

--- a/tests/integ/test_dataframe.py
+++ b/tests/integ/test_dataframe.py
@@ -551,8 +551,9 @@ def test_select_table_function(session):
 )
 def test_generator_table_function(session):
     # works with rowcount
-    # seq1() is a non-deterministic global sequence — exact values vary across environments.
-    # Verify structure: 3 rows, uniform column deterministic with seed=2, ascending order.
+    # seq1(1) passes sign=1, so it continues at the smallest 1-byte int (-128)
+    # after 127. 150 rows stay within one 256-value cycle, so the values are
+    # distinct and ORDER BY makes them strictly increasing.
     df = (
         session.generator(seq1(1), uniform(1, 10, 2), rowcount=150)
         .order_by(seq1(1))
@@ -564,7 +565,12 @@ def test_generator_table_function(session):
     assert result[0][0] < result[1][0] < result[2][0]
 
     # works with timelimit
-    # seq2() is also non-deterministic — apply same structural check
+    # seq2(0) passes sign=0, so it continues at 0 (never negative) after 32767.
+    # generator(timelimit => 1) emits as many rows as the warehouse manages in
+    # a second, which is usually far more than the 32768-value cycle, so 0
+    # repeats and ORDER BY seq2(0) LIMIT 3 returns 0, 0, 0. Slower warehouses
+    # stay inside one cycle and return 0, 1, 2, so only the ordering and the
+    # sign=0 value range can be asserted here.
     df = (
         session.generator(seq2(0), uniform(1, 10, 2), timelimit=1)
         .order_by(seq2(0))
@@ -573,9 +579,12 @@ def test_generator_table_function(session):
     result = df.collect()
     assert len(result) == 3
     assert all(row[1] == 3 for row in result)
-    assert result[0][0] < result[1][0] < result[2][0]
+    assert result[0][0] <= result[1][0] <= result[2][0]
+    assert all(0 <= row[0] <= 32767 for row in result)
 
     # works with combination of both
+    # rowcount is reached long before the timelimit, so this behaves like the
+    # rowcount case above: 150 distinct seq1(1) values.
     df = (
         session.generator(seq1(1), uniform(1, 10, 2), timelimit=1, rowcount=150)
         .order_by(seq1(1))

--- a/tests/unit/test_datatype_mapper.py
+++ b/tests/unit/test_datatype_mapper.py
@@ -14,6 +14,7 @@ from snowflake.snowpark._internal.analyzer.datatype_mapper import (
     numeric_to_sql_without_cast,
     schema_expression,
     to_sql,
+    to_sql_for_default_arg,
     to_sql_no_cast,
 )
 from snowflake.snowpark._internal.type_utils import (
@@ -765,6 +766,33 @@ def test_numeric_to_sql_without_cast():
     assert numeric_to_sql_without_cast(float("inf"), DoubleType()) == "'INF' :: FLOAT"
 
     assert numeric_to_sql_without_cast(Decimal(0.5), DecFloatType()) == "0.5"
+
+
+def test_to_sql_for_default_arg():
+    # Integral defaults must not carry a cast: a DEFAULT only accepts a constant
+    # expression and Snowflake rejects `<value> :: INT` there on some versions.
+    for datatype in (ByteType(), ShortType(), IntegerType(), LongType()):
+        assert to_sql(0, datatype) == "0 :: INT"
+        assert to_sql_for_default_arg(0, datatype) == "0"
+        assert to_sql_for_default_arg(-5, datatype) == "-5"
+        assert to_sql_for_default_arg(None, datatype) == "NULL"
+
+    # bool is a subclass of int, so it normalizes to 0/1 for integral parameters
+    assert to_sql_for_default_arg(True, LongType()) == "1"
+    assert to_sql_for_default_arg(False, LongType()) == "0"
+
+    # every other type keeps its to_sql rendering, which Snowflake accepts
+    for value, datatype in (
+        (1.0, DoubleType()),
+        ("one", StringType()),
+        (True, BooleanType()),
+        (Decimal(1), DecimalType(38, 0)),
+        ([4], ArrayType()),
+        ({"s": 1}, MapType()),
+        (datetime.date(2021, 1, 1), DateType()),
+        (b"123", BinaryType()),
+    ):
+        assert to_sql_for_default_arg(value, datatype) == to_sql(value, datatype)
 
 
 def test_schema_expression():


### PR DESCRIPTION
1. Which Jira issue is this PR addressing?

   Related to SNOW-4013704 (server-side regression that surfaced this).

2. Pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.
   - [x] I acknowledge that I have ensured my changes to be thread-safe.
   - [ ] If adding any arguments to public Snowpark APIs or creating new public Snowpark APIs, I acknowledge that I have ensured my changes include AST support.

3. Please describe how your code solves the related issue.

This PR carries two independent fixes, both of which are currently failing merge gates on every PR in the repo. They are together because each one fixes the check that blocks the other — see [Why both fixes are in one PR](#why-both-fixes-are-in-one-pr) at the bottom.

## Fix 1 — integer optional-argument defaults (product)

### Problem

Registering a UDF, UDTF, UDAF, or stored procedure with an **integer** optional argument generates:

```sql
CREATE FUNCTION ... (x BIGINT DEFAULT 0 :: INT, ...)
```

A parameter default only accepts a constant expression. Snowflake rejects the cast on some server versions:

```
000947 (42601): SQL compilation error:
invalid default argument expression CAST(0 AS NUMBER(38,0))
```

`None` defaults hit the same validation through `NULL :: INT`, reported as `invalid default argument expression SYSTEM$NULL_TO_FIXED(null)`.

This fails the `py-windows-latest-64-cores-3.14-gcp` merge gate (a required check) via these six tests:

- `tests/integ/test_udf.py::test_register_udf_with_optional_args[True|False]`
- `tests/integ/test_udtf.py::test_udtf_register_with_optional_args[True|False]`
- `tests/integ/test_stored_procedure.py::test_register_sp_with_optional_args[True|False]`

### Fix

The cast is redundant — the parameter already declares its own type — so integral defaults are now rendered as bare literals (`DEFAULT 0`, `DEFAULT NULL`) via a new `to_sql_for_default_arg`. It is scoped to the default-argument path only; `to_sql` is unchanged, so `VALUES` and expression rendering keep their casts.

I checked every default form Snowpark generates against an affected deployment. Only the integral one is rejected, so everything else keeps its existing rendering:

| default type | generated SQL | affected server |
|---|---|---|
| **int** | `0 :: INT` | **rejected** |
| float | `'1.0' :: FLOAT` | ok |
| str | `'one'` | ok |
| bool | `True :: BOOLEAN` | ok |
| decimal | `1 :: NUMBER (38, 0)` | ok |
| array / map | `PARSE_JSON(...) :: ARRAY` / `:: OBJECT` | ok |
| variant | `PARSE_JSON(...)` | ok |
| geometry / geography | `TO_GEOMETRY(...)` / `TO_GEOGRAPHY(...)` | ok |
| timestamp / date / time | `TIMESTAMP '...'` / `DATE '...'` / `TIME('...')` | ok |
| binary | `'313233' :: BINARY` | ok |

### Test plan

- New unit test `test_to_sql_for_default_arg` covering all integral types, negatives, `None`, `bool` normalization, and that all other types are unchanged relative to `to_sql`.
- Verified end-to-end against a live account on an affected version (10.30.50), which reproduces the failure before the change:

| case | before | after |
|---|---|---|
| `udf.register` (int defaults) | rejected | `add() = 0`, `add(3) = 3` |
| `udf.register_from_file` (int defaults) | rejected | `add2() = 12` |
| `udtf.register` (int default) | rejected | 2 rows |
| `sproc.register` (int default) | rejected | `bump() = 12` |
| `udf.register` (`None` default) | rejected | `maybe() = -1` |

- Regression check: re-registered the 14-type `return_all_datatypes` UDF from `test_register_udf_with_optional_args`, plus the mixed positional + array-default `return_arr`. Both register and evaluate their defaults correctly.
- Confirmed on CI: on the previous run of this branch, all six `optional_args` tests passed on `py-windows-latest-64-cores-3.14-gcp` with zero `invalid default argument` errors, and the job's pass count rose by exactly six.

## Fix 2 — `test_generator_table_function` (test-only)

Ported unchanged from #4334, which was approved by @sfc-gh-yuwang.

`test_generator_table_function` fails as `assert 0 < 0` on the `seq2(0)` + `generator(timelimit => 1)` case:

```
tests/integ/test_dataframe.py:576: in test_generator_table_function
    assert result[0][0] < result[1][0] < result[2][0]
E   assert 0 < 0
```

`seq2(0)` passes sign=0, so [per the SEQ docs](https://docs.snowflake.com/en/sql-reference/functions/seq1) it continues at 0 rather than going negative after 32767. A one-second `generator` run usually emits far more than one 32768-value cycle, so 0 repeats and `ORDER BY seq2(0) ... LIMIT 3` returns `0, 0, 0`. The strict `<` introduced in #4306 cannot hold in that case.

That one assertion now allows equal values, plus a `0 <= v <= 32767` range check to keep the sign=0 contract covered. The three `seq1(1)` + `rowcount` assertions stay strictly increasing, since 150 rows stay inside one 256-value cycle and really are distinct.

This is load-dependent, which is why it was intermittent at first. It is no longer intermittent: on the previous run of this branch it failed on **six** jobs, including four AWS/Azure 64-core ones, not just GCP.

## Why both fixes are in one PR

The two fixes deadlocked each other:

| PR | fixes | was blocked by |
|---|---|---|
| #4334 | the generator test | the six `optional_args` tests |
| #4335 (this) | the six `optional_args` tests | the generator test |

`py-windows-latest-64-cores-3.14-gcp` is a required check and it fails on both bugs, so neither branch could go green on its own. Combining them is the only way to land either without an admin override. #4334 is redundant once this merges.

Made with [Cursor](https://cursor.com)
