### PR TITLE
SNOW-2912540: allow repeated seq2 values in generator timelimit case

### DIFF
--- a/src/snowflake/snowpark/_internal/proto/ast.proto
+++ b/src/snowflake/snowpark/_internal/proto/ast.proto
@@ -2815,6 +2815,7 @@ message WritePandas {
   bool auto_create_table = 1;
   google.protobuf.Int64Value chunk_size = 2;
   string compression = 3;
+  // Deprecated: use table_type instead.
   bool create_temp_table = 4;
   DataframeData df = 5;
   repeated Tuple_String_Expr kwargs = 6;
@@ -2869,6 +2870,7 @@ message WriteTable {
   string column_order = 4;
   google.protobuf.StringValue comment = 5;
   bool copy_grants = 6;
+  // Deprecated: use table_type instead.
   bool create_temp_table = 7;
   google.protobuf.Int64Value data_retention_time = 8;
   google.protobuf.BoolValue enable_schema_evolution = 9;

--- a/src/snowflake/snowpark/dataframe.py
+++ b/src/snowflake/snowpark/dataframe.py
@@ -6512,7 +6512,7 @@ class DataFrame:
             ast_id = self._ast_id
             self._ast_id = None  # set the AST ID to None to prevent AST emission.
             self.write.save_as_table(
-                temp_table_name, create_temp_table=True, _emit_ast=False
+                temp_table_name, table_type="temp", _emit_ast=False
             )
             self._ast_id = ast_id  # restore the original AST ID.
         else:

--- a/src/snowflake/snowpark/dataframe_writer.py
+++ b/src/snowflake/snowpark/dataframe_writer.py
@@ -384,6 +384,14 @@ class DataFrameWriter:
         statement_params = track_data_source_statement_params(
             self._dataframe, statement_params or self._dataframe._statement_params
         )
+        if create_temp_table:
+            warning(
+                "save_as_table.create_temp_table",
+                "create_temp_table is deprecated. We still respect this parameter when it is True but "
+                'please consider using `table_type="temporary"` instead.',
+            )
+            table_type = "temporary"
+
         if _emit_ast and self._ast is not None:
             # Add an Bind node that applies WriteTable() to the input, followed by its Eval.
             stmt = self._dataframe._session._ast_batch.bind()
@@ -417,7 +425,6 @@ class DataFrameWriter:
 
             if column_order is not None:
                 expr.column_order = column_order
-            expr.create_temp_table = create_temp_table
             expr.table_type = table_type
 
             if clustering_keys is not None:
@@ -495,14 +502,6 @@ class DataFrameWriter:
                 if clustering_keys
                 else []
             )
-
-            if create_temp_table:
-                warning(
-                    "save_as_table.create_temp_table",
-                    "create_temp_table is deprecated. We still respect this parameter when it is True but "
-                    'please consider using `table_type="temporary"` instead.',
-                )
-                table_type = "temporary"
 
             if table_type and table_type.lower() not in SUPPORTED_TABLE_TYPES:
                 raise ValueError(

--- a/src/snowflake/snowpark/session.py
+++ b/src/snowflake/snowpark/session.py
@@ -3649,7 +3649,6 @@ class Session:
                 if chunk_size is not None and chunk_size != WRITE_PANDAS_CHUNK_SIZE:
                     ast.chunk_size.value = chunk_size
                 ast.compression = compression
-                ast.create_temp_table = create_temp_table
                 if isinstance(df, pandas.DataFrame):
                     build_table_name(
                         ast.df.dataframe_data__pandas.v.temp_table, table.table_name

--- a/tests/ast/data/session_write_pandas.test
+++ b/tests/ast/data/session_write_pandas.test
@@ -12,7 +12,7 @@ ans2 = session.write_pandas(df, "test", schema="a", database="b", chunk_size=7, 
 
 ans = session.write_pandas(pandas.DataFrame(<not shown>), "table1")
 
-ans2 = session.write_pandas(pandas.DataFrame(<not shown>), "test", database="b", schema="a", chunk_size=7, compression="brotli", on_error="ignore", parallel=10, quote_identifiers=False, auto_create_table=True, create_temp_table=True, overwrite=True, table_type="temporary", random=90)
+ans2 = session.write_pandas(pandas.DataFrame(<not shown>), "test", database="b", schema="a", chunk_size=7, compression="brotli", on_error="ignore", parallel=10, quote_identifiers=False, auto_create_table=True, overwrite=True, table_type="temporary", random=90)
 
 ## EXPECTED ENCODED AST
 
@@ -78,7 +78,6 @@ body {
           value: 7
         }
         compression: "brotli"
-        create_temp_table: true
         df {
           dataframe_data__pandas {
             v {

--- a/tests/integ/test_dataframe.py
+++ b/tests/integ/test_dataframe.py
@@ -550,8 +550,6 @@ def test_select_table_function(session):
     reason="Session.generator is not supported in Local Testing",
 )
 def test_generator_table_function(session):
-    # seq1()/seq2() restart per parallel generator worker, so values repeat and
-    # are only non-decreasing once ordered — never assert strict increase.
     # works with rowcount
     # seq1() is a non-deterministic global sequence — exact values vary across environments.
     # Verify structure: 3 rows, uniform column deterministic with seed=2, ascending order.
@@ -563,7 +561,7 @@ def test_generator_table_function(session):
     result = df.collect()
     assert len(result) == 3
     assert all(row[1] == 3 for row in result)
-    assert result[0][0] <= result[1][0] <= result[2][0]
+    assert result[0][0] < result[1][0] < result[2][0]
 
     # works with timelimit
     # seq2() is also non-deterministic — apply same structural check
@@ -575,7 +573,7 @@ def test_generator_table_function(session):
     result = df.collect()
     assert len(result) == 3
     assert all(row[1] == 3 for row in result)
-    assert result[0][0] <= result[1][0] <= result[2][0]
+    assert result[0][0] < result[1][0] < result[2][0]
 
     # works with combination of both
     df = (
@@ -586,7 +584,7 @@ def test_generator_table_function(session):
     result = df.collect()
     assert len(result) == 3
     assert all(row[1] == 3 for row in result)
-    assert result[0][0] <= result[1][0] <= result[2][0]
+    assert result[0][0] < result[1][0] < result[2][0]
 
     # works without both
     df = session.generator(seq4(1), uniform(1, 10, 2))
@@ -603,7 +601,7 @@ def test_generator_table_function(session):
     result = df.collect()
     assert len(result) == 3
     assert all(row["UNICORN"] == 3 for row in result)
-    assert result[0]["PIXEL"] <= result[1]["PIXEL"] <= result[2]["PIXEL"]
+    assert result[0]["PIXEL"] < result[1]["PIXEL"] < result[2]["PIXEL"]
 
     # aggregation works
     df = session.generator(count(seq1(0)).as_("rows"), rowcount=150)

--- a/tests/integ/test_dataframe.py
+++ b/tests/integ/test_dataframe.py
@@ -564,7 +564,8 @@ def test_generator_table_function(session):
     assert result[0][0] < result[1][0] < result[2][0]
 
     # works with timelimit
-    # seq2() is also non-deterministic — apply same structural check
+    # Unlike the rowcount cases, timelimit leaves the row count unbounded, so the
+    # 2-byte seq2() wraps back to 0 and repeats values. Only assert non-decreasing.
     df = (
         session.generator(seq2(0), uniform(1, 10, 2), timelimit=1)
         .order_by(seq2(0))
@@ -573,7 +574,7 @@ def test_generator_table_function(session):
     result = df.collect()
     assert len(result) == 3
     assert all(row[1] == 3 for row in result)
-    assert result[0][0] < result[1][0] < result[2][0]
+    assert result[0][0] <= result[1][0] <= result[2][0]
 
     # works with combination of both
     df = (

--- a/tests/integ/test_dataframe.py
+++ b/tests/integ/test_dataframe.py
@@ -550,6 +550,8 @@ def test_select_table_function(session):
     reason="Session.generator is not supported in Local Testing",
 )
 def test_generator_table_function(session):
+    # seq1()/seq2() restart per parallel generator worker, so values repeat and
+    # are only non-decreasing once ordered — never assert strict increase.
     # works with rowcount
     # seq1() is a non-deterministic global sequence — exact values vary across environments.
     # Verify structure: 3 rows, uniform column deterministic with seed=2, ascending order.
@@ -561,7 +563,7 @@ def test_generator_table_function(session):
     result = df.collect()
     assert len(result) == 3
     assert all(row[1] == 3 for row in result)
-    assert result[0][0] < result[1][0] < result[2][0]
+    assert result[0][0] <= result[1][0] <= result[2][0]
 
     # works with timelimit
     # seq2() is also non-deterministic — apply same structural check
@@ -573,7 +575,7 @@ def test_generator_table_function(session):
     result = df.collect()
     assert len(result) == 3
     assert all(row[1] == 3 for row in result)
-    assert result[0][0] < result[1][0] < result[2][0]
+    assert result[0][0] <= result[1][0] <= result[2][0]
 
     # works with combination of both
     df = (
@@ -584,7 +586,7 @@ def test_generator_table_function(session):
     result = df.collect()
     assert len(result) == 3
     assert all(row[1] == 3 for row in result)
-    assert result[0][0] < result[1][0] < result[2][0]
+    assert result[0][0] <= result[1][0] <= result[2][0]
 
     # works without both
     df = session.generator(seq4(1), uniform(1, 10, 2))
@@ -601,7 +603,7 @@ def test_generator_table_function(session):
     result = df.collect()
     assert len(result) == 3
     assert all(row["UNICORN"] == 3 for row in result)
-    assert result[0]["PIXEL"] < result[1]["PIXEL"] < result[2]["PIXEL"]
+    assert result[0]["PIXEL"] <= result[1]["PIXEL"] <= result[2]["PIXEL"]
 
     # aggregation works
     df = session.generator(count(seq1(0)).as_("rows"), rowcount=150)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Stacked on #4307. Test-only change, opened to verify that #4307's CI failure is `test_generator_table_function` and not the AST encoding change.

## Problem

`tests/integ/test_dataframe.py::test_generator_table_function` fails on #4307 with:

```
tests/integ/test_dataframe.py:576: in test_generator_table_function
    assert result[0][0] < result[1][0] < result[2][0]
E   assert 0 < 0
```

`generator(timelimit=1)` has no row cap — it emits as many rows as the warehouse manages in one second. `seq2()` is 2 bytes and wraps back to 0, so ordered results repeat values. Snowflake also documents that data-generation sequences are "not guaranteed to be ordered and gap-free ... because the numbers may be generated in parallel, in an unsynchronized fashion".

Before #4306 this case asserted exactly that behavior:

```python
expected_result = [Row(0, 3), Row(0, 3), Row(0, 3)]
```

#4306 replaced it with a strict `<`, which contradicts the result the test previously pinned.

## Change

Only the `timelimit`-only case relaxes to non-decreasing. That still verifies `order_by` was applied without assuming distinct values.

The three `rowcount=150` cases keep the strict `<`: a fixed 150 rows produces 150 distinct values inside `seq1()`'s 1-byte wrap range (`0..127` then `-128..-107`), which is exactly the old hardcoded `-108, -107, 0`.

## Notes

- This assertion is also on `main`, so `main` carries the same flake. It should land there rather than only in this stack.
- No `src/` files touched, so `check_threadsafety` / `check_ast_support` skip.

## Test plan

- [ ] `test_generator_table_function` passes across the precommit matrix
- [ ] Confirms #4307 has no other failures

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e834c9e3-20dd-48f5-ac92-56509afed3a5?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e834c9e3-20dd-48f5-ac92-56509afed3a5&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

