### PR TITLE
SNOW-3898656: XML perf optimization variant projection (Stacked 1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,13 +8,7 @@
 
 - Added interval type support for Python UDFs and stored procedures. Use `datetime.timedelta` as the type annotation for day-time interval (`DayTimeIntervalType`) parameters and return values, and `YearMonthInterval` (a type annotation sentinel from `snowflake.snowpark.types`) for year-month interval (`YearMonthIntervalType`) parameters and return values.
 
-#### Improvements
-
-- Improved the performance of `DataFrameReader.xml` when `rowTag` is specified by projecting each XML element or attribute directly out of the reader's VARIANT output instead of expanding every record into one row per key with `flatten()` and then reassembling it with a dynamic `pivot()`. This removes an M×N intermediate (records × keys per record) from the query plan. The previous projection is still used when `cacheResult` is `False` and no schema is available, so that `.xml()` stays lazy.
-
-#### Bug Fixes
-
-- Fixed a bug in `DataFrameReader.xml` where the `columnNameOfCorruptRecord` column (default `_corrupt_record`) was added to the output in `PERMISSIVE` mode based on the reader's declared output schema rather than on whether any record was actually corrupt. The column is now added only when at least one record failed to parse, matching the behavior the dynamic `pivot()` projection produced (it only ever materialized keys the reader actually wrote).
+- Added a `useVariantProjection` option to `DataFrameReader.xml` for reads that specify `rowTag`. The default, `False`, builds the output as before: every record is expanded into one row per key with `flatten()` and reassembled with a dynamic `pivot()`. Setting it to `True` instead projects each XML element or attribute directly out of the reader's VARIANT output, removing that M×N intermediate (records × keys per record) from the query plan, which is substantially faster on wide records. Under this option the column order of a read without a schema is alphabetical, and the `columnNameOfCorruptRecord` column is included only when at least one record actually failed to parse. It has no effect when `cacheResult` is `False` and no schema is available, since the keys cannot be discovered without materializing the result first.
 
 ## 1.54.0 (2026-07-29)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 - Added interval type support for Python UDFs and stored procedures. Use `datetime.timedelta` as the type annotation for day-time interval (`DayTimeIntervalType`) parameters and return values, and `YearMonthInterval` (a type annotation sentinel from `snowflake.snowpark.types`) for year-month interval (`YearMonthIntervalType`) parameters and return values.
 
-- Added a `useVariantProjection` option to `DataFrameReader.xml` for reads that specify `rowTag`. The default, `False`, builds the output as before: every record is expanded into one row per key with `flatten()` and reassembled with a dynamic `pivot()`. Setting it to `True` instead projects each XML element or attribute directly out of the reader's VARIANT output, removing that M×N intermediate (records × keys per record) from the query plan, which is substantially faster on wide records. Under this option the column order of a read without a schema is alphabetical, and the `columnNameOfCorruptRecord` column is included only when at least one record actually failed to parse. It has no effect when `cacheResult` is `False` and no schema is available, since the keys cannot be discovered without materializing the result first.
+- Added a `useVariantProjection` option to `DataFrameReader.xml` that speeds up XML ingestion. The default is `False`; setting it to `True` requires `cacheResult` to also be `True` (the default).
 
 ## 1.54.0 (2026-07-29)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@
 
 - Added interval type support for Python UDFs and stored procedures. Use `datetime.timedelta` as the type annotation for day-time interval (`DayTimeIntervalType`) parameters and return values, and `YearMonthInterval` (a type annotation sentinel from `snowflake.snowpark.types`) for year-month interval (`YearMonthIntervalType`) parameters and return values.
 
+#### Improvements
+
+- Improved the performance of `DataFrameReader.xml` when `rowTag` is specified by projecting each XML element or attribute directly out of the reader's VARIANT output instead of expanding every record into one row per key with `flatten()` and then reassembling it with a dynamic `pivot()`. This removes an M×N intermediate (records × keys per record) from the query plan. The previous projection is still used when `cacheResult` is `False` and no schema is available, so that `.xml()` stays lazy.
+
+#### Bug Fixes
+
+- Fixed a bug in `DataFrameReader.xml` where the `columnNameOfCorruptRecord` column (default `_corrupt_record`) was added to the output in `PERMISSIVE` mode based on the reader's declared output schema rather than on whether any record was actually corrupt. The column is now added only when at least one record failed to parse, matching the behavior the dynamic `pivot()` projection produced (it only ever materialized keys the reader actually wrote).
+
 ## 1.54.0 (2026-07-29)
 
 ### Snowpark Python API updates

--- a/src/snowflake/snowpark/_internal/analyzer/snowflake_plan.py
+++ b/src/snowflake/snowpark/_internal/analyzer/snowflake_plan.py
@@ -53,6 +53,7 @@ import snowflake.connector
 import snowflake.snowpark
 from snowflake.snowpark._internal.analyzer.analyzer_utils import (
     quote_name_without_upper_casing,
+    unquote_if_quoted,
     TEMPORARY_STRING_SET,
     aggregate_statement,
     attribute_to_schema_string,
@@ -128,6 +129,8 @@ from snowflake.snowpark._internal.utils import (
     INFER_SCHEMA_FORMAT_TYPES,
     XML_ROW_TAG_STRING,
     XML_ROW_DATA_COLUMN_NAME,
+    xml_variant_projection,
+    use_xml_variant_projection,
     TempObjectType,
     generate_random_alphanumeric,
     get_copy_into_table_options,
@@ -1872,29 +1875,47 @@ class SnowflakePlanBuilder:
         # Create a range from 0 to N-1
         df = self.session.range(num_workers).to_df(worker_column_name)
 
+        udtf_args = (
+            lit(file_path),
+            lit(num_workers),
+            lit(row_tag),
+            col(worker_column_name),
+            lit(mode),
+            lit(column_name_of_corrupt_record),
+            lit(ignore_namespace),
+            lit(attribute_prefix),
+            lit(exclude_attributes),
+            lit(value_tag),
+            lit(null_value),
+            lit(charset),
+            lit(ignore_surrounding_whitespace),
+            lit(row_validation_xsd_path),
+            lit(schema_string),
+            lit(context._is_snowpark_connect_compatible_mode),
+        )
+
+        if use_xml_variant_projection(options, schema is not None):
+            df = df.select(xml_reader_udtf(*udtf_args))
+
+            if schema is None:
+                # Emit raw ROW_DATA; DataFrameReader._xml_project_from_variant_cache
+                # discovers the top-level keys from the cached result and projects them.
+                return df.queries["queries"][-1]
+
+            keys = [unquote_if_quoted(attr.name) for attr in schema]
+            # Project the corrupt-record column unconditionally so _apply_xml_schema can
+            # test whether any row is actually corrupt; it drops the column when none is.
+            if mode == "PERMISSIVE":
+                keys.append(column_name_of_corrupt_record)
+            df = df.select(*(xml_variant_projection(key) for key in keys))
+            return df.queries["queries"][-1]
+
         # Apply UDTF to the XML file and get each XML record as a Variant data,
         # and append a unique row number to each record.
         df = df.select(
             worker_column_name,
             seq8().as_(xml_row_number_column_name),
-            xml_reader_udtf(
-                lit(file_path),
-                lit(num_workers),
-                lit(row_tag),
-                col(worker_column_name),
-                lit(mode),
-                lit(column_name_of_corrupt_record),
-                lit(ignore_namespace),
-                lit(attribute_prefix),
-                lit(exclude_attributes),
-                lit(value_tag),
-                lit(null_value),
-                lit(charset),
-                lit(ignore_surrounding_whitespace),
-                lit(row_validation_xsd_path),
-                lit(schema_string),
-                lit(context._is_snowpark_connect_compatible_mode),
-            ),
+            xml_reader_udtf(*udtf_args),
         )
 
         # Flatten the Variant data to get the key-value pairs

--- a/src/snowflake/snowpark/_internal/analyzer/snowflake_plan.py
+++ b/src/snowflake/snowpark/_internal/analyzer/snowflake_plan.py
@@ -1898,13 +1898,12 @@ class SnowflakePlanBuilder:
             df = df.select(xml_reader_udtf(*udtf_args))
 
             if schema is None:
-                # Emit raw ROW_DATA; DataFrameReader._xml_project_from_variant_cache
-                # discovers the top-level keys from the cached result and projects them.
+                # Keys are discovered later from the cached result; see
+                # DataFrameReader._xml_project_from_variant_cache.
                 return df.queries["queries"][-1]
 
             keys = [unquote_if_quoted(attr.name) for attr in schema]
-            # Project the corrupt-record column unconditionally so _apply_xml_schema can
-            # test whether any row is actually corrupt; it drops the column when none is.
+            # Always projected so _apply_xml_schema can detect whether any row is corrupt.
             if mode == "PERMISSIVE":
                 keys.append(column_name_of_corrupt_record)
             df = df.select(*(xml_variant_projection(key) for key in keys))

--- a/src/snowflake/snowpark/_internal/utils.py
+++ b/src/snowflake/snowpark/_internal/utils.py
@@ -461,6 +461,40 @@ def escape_subfield_key(field: str) -> str:
     return escape_quotes_and_backslashes(field)
 
 
+def use_xml_variant_projection(options: Dict[str, Any], schema_known: bool) -> bool:
+    """Whether the XML reader may project ROW_DATA keys directly instead of flatten+pivot.
+
+    Direct projection needs a materialized result -- to discover the keys when no schema
+    is known, and to probe cheaply whether any record was corrupt in PERMISSIVE mode. With
+    ``cacheResult=False`` and neither available, flatten+pivot is what keeps ``.xml()``
+    lazy: discovering keys or probing for corrupt records there would re-read the file
+    once at ``.xml()`` time and again on ``collect()``.
+
+    ``_LEGACY_XML_PIVOT`` forces flatten+pivot unconditionally as a rollback lever.
+    """
+    if options.get("_LEGACY_XML_PIVOT", False):
+        return False
+    if options.get("CACHERESULT", True):
+        return True
+    return schema_known and options.get("MODE", "PERMISSIVE").upper() != "PERMISSIVE"
+
+
+def xml_variant_projection(key: str) -> "snowflake.snowpark.Column":  # type: ignore[name-defined] # noqa: F821
+    """Project a single top-level key out of the XML reader's ROW_DATA VARIANT column.
+
+    Subfield (bracket) notation is used rather than ``ROW_DATA:key`` path notation
+    because a namespace-prefixed XML name such as ``px:name`` would otherwise be
+    parsed as a further path segment instead of a literal key.
+
+    The single-quoted alias reproduces the column names that dynamic PIVOT produced,
+    which the XML reader's output contract still depends on (see SNOW-2923003).
+    """
+    from snowflake.snowpark._internal.analyzer.analyzer_utils import single_quote
+    from snowflake.snowpark.functions import col
+
+    return col(XML_ROW_DATA_COLUMN_NAME)[key].alias(single_quote(key))
+
+
 def is_sql_select_statement(sql: str) -> bool:
     return (
         SNOWFLAKE_SELECT_SQL_PREFIX_PATTERN.match(sql) is not None

--- a/src/snowflake/snowpark/_internal/utils.py
+++ b/src/snowflake/snowpark/_internal/utils.py
@@ -462,37 +462,24 @@ def escape_subfield_key(field: str) -> str:
 
 
 def use_xml_variant_projection(options: Dict[str, Any], schema_known: bool) -> bool:
-    """Whether the XML reader may project ROW_DATA keys directly instead of flatten+pivot.
-
-    Off unless ``useVariantProjection`` is set, so an unconfigured read keeps the
-    flatten+pivot output it has always produced.
-
-    Once opted in, direct projection still needs a materialized result -- to discover the
-    keys when no schema is known, and to probe cheaply whether any record was corrupt in
-    PERMISSIVE mode. With ``cacheResult=False`` and neither available, flatten+pivot is what
-    keeps ``.xml()`` lazy: discovering keys or probing for corrupt records there would
-    re-read the file once at ``.xml()`` time and again on ``collect()``.
-    """
+    """Whether the XML reader may project ROW_DATA keys directly instead of flatten+pivot."""
     if not options.get("USEVARIANTPROJECTION", False):
         return False
     if options.get("CACHERESULT", True):
         return True
+    # No materialized result means keys can't be discovered, and PERMISSIVE mode's
+    # corrupt-record column can't be probed, without re-reading the file -- so this path
+    # is only safe with a known schema and a mode that has no such column.
     return schema_known and options.get("MODE", "PERMISSIVE").upper() != "PERMISSIVE"
 
 
 def xml_variant_projection(key: str) -> "snowflake.snowpark.Column":  # type: ignore[name-defined] # noqa: F821
-    """Project a single top-level key out of the XML reader's ROW_DATA VARIANT column.
-
-    Subfield (bracket) notation is used rather than ``ROW_DATA:key`` path notation
-    because a namespace-prefixed XML name such as ``px:name`` would otherwise be
-    parsed as a further path segment instead of a literal key.
-
-    The single-quoted alias reproduces the column names that dynamic PIVOT produced,
-    which the XML reader's output contract still depends on (see SNOW-2923003).
-    """
+    """Project a single top-level key out of the XML reader's ROW_DATA VARIANT column."""
     from snowflake.snowpark._internal.analyzer.analyzer_utils import single_quote
     from snowflake.snowpark.functions import col
 
+    # Bracket notation, not ROW_DATA:key path notation, so a namespace-prefixed name like
+    # "px:name" is treated as a literal key rather than a further path segment.
     return col(XML_ROW_DATA_COLUMN_NAME)[key].alias(single_quote(key))
 
 

--- a/src/snowflake/snowpark/_internal/utils.py
+++ b/src/snowflake/snowpark/_internal/utils.py
@@ -464,15 +464,16 @@ def escape_subfield_key(field: str) -> str:
 def use_xml_variant_projection(options: Dict[str, Any], schema_known: bool) -> bool:
     """Whether the XML reader may project ROW_DATA keys directly instead of flatten+pivot.
 
-    Direct projection needs a materialized result -- to discover the keys when no schema
-    is known, and to probe cheaply whether any record was corrupt in PERMISSIVE mode. With
-    ``cacheResult=False`` and neither available, flatten+pivot is what keeps ``.xml()``
-    lazy: discovering keys or probing for corrupt records there would re-read the file
-    once at ``.xml()`` time and again on ``collect()``.
+    Off unless ``useVariantProjection`` is set, so an unconfigured read keeps the
+    flatten+pivot output it has always produced.
 
-    ``_LEGACY_XML_PIVOT`` forces flatten+pivot unconditionally as a rollback lever.
+    Once opted in, direct projection still needs a materialized result -- to discover the
+    keys when no schema is known, and to probe cheaply whether any record was corrupt in
+    PERMISSIVE mode. With ``cacheResult=False`` and neither available, flatten+pivot is what
+    keeps ``.xml()`` lazy: discovering keys or probing for corrupt records there would
+    re-read the file once at ``.xml()`` time and again on ``collect()``.
     """
-    if options.get("_LEGACY_XML_PIVOT", False):
+    if not options.get("USEVARIANTPROJECTION", False):
         return False
     if options.get("CACHERESULT", True):
         return True

--- a/src/snowflake/snowpark/dataframe_reader.py
+++ b/src/snowflake/snowpark/dataframe_reader.py
@@ -1324,13 +1324,9 @@ class DataFrameReader:
                 This means the actual computation occurs before :meth:`DataFrame.collect` is called.
                 When set to ``False``, the DataFrame is computed lazily and the actual computation occurs when :meth:`DataFrame.collect` is called.
 
-              + ``useVariantProjection``: Whether to build the output by projecting each XML element or
-                attribute directly out of the reader's VARIANT output. The default value is ``False``, which
-                expands every record into one row per key with ``flatten()`` and reassembles it with a
-                dynamic ``pivot()``. Setting this to ``True`` removes that intermediate, which is
-                substantially faster on wide records, and makes the column order of a read without a schema
-                alphabetical. It has no effect when ``cacheResult`` is ``False`` and no schema is available,
-                since the keys cannot be discovered without materializing the result first.
+              + ``useVariantProjection``: A performance optimization that speeds up XML ingestion. The
+                default value is ``False``. Setting this to ``True`` requires ``cacheResult`` to also be
+                ``True`` (the default).
         """
         df = self._read_semi_structured_file(path, "XML")
         # AST.
@@ -1375,11 +1371,8 @@ class DataFrameReader:
             df_columns = {c.strip('"').strip("'") for c in df.columns}
             if corrupt_col_name in df_columns:
                 corrupt_ref = df[single_quote(corrupt_col_name)]
-                # The VARIANT-projection path always projects this column, so presence in
-                # df.columns no longer implies any record was corrupt -- probe for a
-                # non-NULL value instead. Under PIVOT the column only materialized when
-                # the UDTF wrote the key (which it does only for corrupt records), so
-                # both paths end up omitting the column for clean data.
+                # Under variant projection the column is always present, so its presence
+                # alone doesn't mean a row was corrupt -- probe for a non-NULL value instead.
                 has_corrupt_record = (
                     df.filter(corrupt_ref.is_not_null()).limit(1).count() > 0
                     if use_xml_variant_projection(self._cur_options, True)
@@ -1400,13 +1393,8 @@ class DataFrameReader:
         return result
 
     def _xml_project_from_variant_cache(self, df: DataFrame) -> DataFrame:
-        """Project the XML reader's raw ROW_DATA VARIANT into one column per XML key.
-
-        Discovers the union of top-level element and attribute names across every
-        record of the already-materialized ``df``, then projects each one directly.
-        This replaces the flatten + dynamic pivot that built an M x N intermediate,
-        and reuses the cached result so the file is still only read once.
-        """
+        """Project the XML reader's raw ROW_DATA VARIANT into one column per XML key,
+        discovered from the already-materialized ``df``."""
         from snowflake.snowpark.functions import flatten, object_keys
 
         keys = sorted(
@@ -1417,9 +1405,7 @@ class DataFrameReader:
             .collect()
         )
         if not keys:
-            # The UDTF produced no records at all, so the row tag matched nothing.
-            # Under PIVOT this surfaced as a "SELECT with no columns" SQL error that
-            # snowflake_plan translated into this same exception.
+            # No keys means the row tag matched nothing.
             raise SnowparkClientExceptionMessages.DF_XML_ROW_TAG_NOT_FOUND(
                 self._cur_options.get(XML_ROW_TAG_STRING), self._file_path
             )
@@ -2119,8 +2105,6 @@ class DataFrameReader:
                 # (not all VARIANT), so don't enable the all-variant dot-notation mode.
                 if xml_inferred_schema is None and not self._user_schema:
                     if use_xml_variant_projection(self._cur_options, False):
-                        # ROW_DATA is materialized now, so the keys can be discovered
-                        # from the cache instead of via flatten + pivot.
                         df = self._xml_project_from_variant_cache(df)
                     else:
                         df._all_variant_cols = True

--- a/src/snowflake/snowpark/dataframe_reader.py
+++ b/src/snowflake/snowpark/dataframe_reader.py
@@ -1324,10 +1324,13 @@ class DataFrameReader:
                 This means the actual computation occurs before :meth:`DataFrame.collect` is called.
                 When set to ``False``, the DataFrame is computed lazily and the actual computation occurs when :meth:`DataFrame.collect` is called.
 
-            - ``_LEGACY_XML_PIVOT`` is an internal, unsupported escape hatch that restores the
-              previous ``flatten()`` + dynamic ``pivot()`` output projection. It exists only to
-              roll back a regression in the direct VARIANT projection and may be removed at any
-              time; it is not part of the public API.
+              + ``useVariantProjection``: Whether to build the output by projecting each XML element or
+                attribute directly out of the reader's VARIANT output. The default value is ``False``, which
+                expands every record into one row per key with ``flatten()`` and reassembles it with a
+                dynamic ``pivot()``. Setting this to ``True`` removes that intermediate, which is
+                substantially faster on wide records, and makes the column order of a read without a schema
+                alphabetical. It has no effect when ``cacheResult`` is ``False`` and no schema is available,
+                since the keys cannot be discovered without materializing the result first.
         """
         df = self._read_semi_structured_file(path, "XML")
         # AST.

--- a/src/snowflake/snowpark/dataframe_reader.py
+++ b/src/snowflake/snowpark/dataframe_reader.py
@@ -67,6 +67,8 @@ from snowflake.snowpark._internal.utils import (
     STAGE_PREFIX,
     XML_ROW_TAG_STRING,
     XML_ROW_DATA_COLUMN_NAME,
+    xml_variant_projection,
+    use_xml_variant_projection,
     XML_READER_FILE_PATH,
     XML_SCHEMA_INFERENCE_FILE_PATH,
     XML_READER_API_SIGNATURE,
@@ -1321,6 +1323,11 @@ class DataFrameReader:
                 When set to ``True`` (default), the result is cached and all subsequent operations on the DataFrame are performed on the cached data.
                 This means the actual computation occurs before :meth:`DataFrame.collect` is called.
                 When set to ``False``, the DataFrame is computed lazily and the actual computation occurs when :meth:`DataFrame.collect` is called.
+
+            - ``_LEGACY_XML_PIVOT`` is an internal, unsupported escape hatch that restores the
+              previous ``flatten()`` + dynamic ``pivot()`` output projection. It exists only to
+              roll back a regression in the direct VARIANT projection and may be removed at any
+              time; it is not part of the public API.
         """
         df = self._read_semi_structured_file(path, "XML")
         # AST.
@@ -1365,17 +1372,57 @@ class DataFrameReader:
             df_columns = {c.strip('"').strip("'") for c in df.columns}
             if corrupt_col_name in df_columns:
                 corrupt_ref = df[single_quote(corrupt_col_name)]
-                cols.append(
-                    corrupt_ref.cast(StringType()).alias(
-                        quote_name_without_upper_casing(corrupt_col_name)
-                    )
+                # The VARIANT-projection path always projects this column, so presence in
+                # df.columns no longer implies any record was corrupt -- probe for a
+                # non-NULL value instead. Under PIVOT the column only materialized when
+                # the UDTF wrote the key (which it does only for corrupt records), so
+                # both paths end up omitting the column for clean data.
+                has_corrupt_record = (
+                    df.filter(corrupt_ref.is_not_null()).limit(1).count() > 0
+                    if use_xml_variant_projection(self._cur_options, True)
+                    else True
                 )
-                if self._xml_inferred_schema is not None:
-                    self._xml_inferred_schema.fields.append(
-                        StructField(corrupt_col_name, StringType())
+                if has_corrupt_record:
+                    cols.append(
+                        corrupt_ref.cast(StringType()).alias(
+                            quote_name_without_upper_casing(corrupt_col_name)
+                        )
                     )
+                    if self._xml_inferred_schema is not None:
+                        self._xml_inferred_schema.fields.append(
+                            StructField(corrupt_col_name, StringType())
+                        )
 
         result = df.select(cols)
+        return result
+
+    def _xml_project_from_variant_cache(self, df: DataFrame) -> DataFrame:
+        """Project the XML reader's raw ROW_DATA VARIANT into one column per XML key.
+
+        Discovers the union of top-level element and attribute names across every
+        record of the already-materialized ``df``, then projects each one directly.
+        This replaces the flatten + dynamic pivot that built an M x N intermediate,
+        and reuses the cached result so the file is still only read once.
+        """
+        from snowflake.snowpark.functions import flatten, object_keys
+
+        keys = sorted(
+            row[0]
+            for row in df.select(flatten(object_keys(col(XML_ROW_DATA_COLUMN_NAME))))
+            .select(col("VALUE").cast(StringType()))
+            .distinct()
+            .collect()
+        )
+        if not keys:
+            # The UDTF produced no records at all, so the row tag matched nothing.
+            # Under PIVOT this surfaced as a "SELECT with no columns" SQL error that
+            # snowflake_plan translated into this same exception.
+            raise SnowparkClientExceptionMessages.DF_XML_ROW_TAG_NOT_FOUND(
+                self._cur_options.get(XML_ROW_TAG_STRING), self._file_path
+            )
+
+        result = df.select(*(xml_variant_projection(key) for key in keys))
+        result._all_variant_cols = True
         return result
 
     @publicapi
@@ -2068,7 +2115,12 @@ class DataFrameReader:
                 # When schema is inferred or user-provided, columns are typed
                 # (not all VARIANT), so don't enable the all-variant dot-notation mode.
                 if xml_inferred_schema is None and not self._user_schema:
-                    df._all_variant_cols = True
+                    if use_xml_variant_projection(self._cur_options, False):
+                        # ROW_DATA is materialized now, so the keys can be discovered
+                        # from the cache instead of via flatten + pivot.
+                        df = self._xml_project_from_variant_cache(df)
+                    else:
+                        df._all_variant_cols = True
         else:
             set_api_call_source(df, f"DataFrameReader.{format.lower()}")
         return df

--- a/tests/integ/test_xml_reader_row_tag.py
+++ b/tests/integ/test_xml_reader_row_tag.py
@@ -1222,6 +1222,17 @@ def test_read_xml_use_variant_projection_switches_the_query_plan(session):
     assert "PIVOT" not in projection_sql
 
 
+def test_read_xml_variant_projection_row_tag_not_found(session):
+    """The projection path's own key-discovery step must raise the same error as pivot's
+    when the row tag matches nothing, not just when pivot's SELECT-with-no-columns fires."""
+    with pytest.raises(
+        SnowparkDataframeReaderException, match="Cannot find the row tag"
+    ):
+        session.read.option("rowTag", "non-existing-tag").option(
+            "useVariantProjection", True
+        ).xml(f"@{tmp_stage_name}/{test_file_books_xml}")
+
+
 def test_read_xml_default_options_preserve_pivot_output(session):
     """A read with no options set must produce the flatten+pivot output unchanged.
 
@@ -1310,3 +1321,62 @@ def test_read_xml_corrupt_record_column_omitted_when_no_corrupt_record(session):
         "_corrupt_record",
     ]
     assert any(row["_corrupt_record"] is not None for row in corrupt.collect())
+
+
+def test_read_xml_corrupt_record_column_with_variant_projection_and_schema(session):
+    """Same guarantee as the pivot case above, but with useVariantProjection=True and a
+    user-provided schema, which drives a different code path in both the reader's query
+    construction and the corrupt-record column probe."""
+    schema = StructType(
+        [StructField("_id", StringType()), StructField("author", StringType())]
+    )
+    clean = (
+        session.read.schema(schema)
+        .option("rowTag", "book")
+        .option("useVariantProjection", True)
+        .xml(f"@{tmp_stage_name}/{test_file_books_xml}")
+    )
+    assert [c.strip('"') for c in clean.columns] == ["_id", "author"]
+    assert len(clean.collect()[0]) == 2
+
+    corrupt_schema = StructType(
+        [StructField("_key", StringType()), StructField("title", StringType())]
+    )
+    corrupt = (
+        session.read.schema(corrupt_schema)
+        .option("rowTag", "incollection")
+        .option("useVariantProjection", True)
+        .xml(f"@{tmp_stage_name}/{test_file_dblp_xml}")
+    )
+    assert [c.strip('"') for c in corrupt.columns] == [
+        "_key",
+        "title",
+        "_corrupt_record",
+    ]
+    assert any(row["_corrupt_record"] is not None for row in corrupt.collect())
+
+
+def test_read_xml_variant_projection_with_schema_and_dropmalformed(
+    session, enable_scos_compatible_mode
+):
+    """DROPMALFORMED with a schema and useVariantProjection=True must still drop
+    mismatched rows; this mode never adds a corrupt-record key, unlike PERMISSIVE."""
+    narrow_schema = StructType(
+        [
+            StructField("name", StringType()),
+            StructField("value", LongType()),
+        ]
+    )
+    df = (
+        session.read.option("rowTag", "ROW")
+        .option("mode", "DROPMALFORMED")
+        .option("useVariantProjection", True)
+        .schema(narrow_schema)
+        .xml(f"@{tmp_stage_name}/{_staged_files['sampling_mismatch']}")
+    )
+    result = df.order_by('"name"').collect()
+    assert len(result) == 5
+    names = [r["name"] for r in result]
+    assert "Frank" not in names
+    for r in result:
+        assert r["value"] is not None

--- a/tests/integ/test_xml_reader_row_tag.py
+++ b/tests/integ/test_xml_reader_row_tag.py
@@ -1148,3 +1148,127 @@ def test_dropmalformed_multifield_drops_any_bad_field(
     assert result[0]["int_col"] == 42
     assert result[0]["bool_col"] is True
     assert abs(result[0]["dbl_col"] - 3.14) < 0.001
+
+
+#
+# Output projection: direct VARIANT key projection instead of flatten + dynamic pivot.
+#
+
+
+def _read_xml_content(session, file_name, row_tag, **options):
+    """Read an XML file and return (columns, row content keyed by column name).
+
+    Row content is keyed rather than positional so it can be compared across
+    projections without depending on column order.
+    """
+    reader = session.read.option("rowTag", row_tag)
+    for key, value in options.items():
+        reader = reader.option(key, value)
+    df = reader.xml(f"@{tmp_stage_name}/{file_name}")
+    names = [c.strip('"').strip("'") for c in df.columns]
+    content = sorted(
+        tuple(sorted(zip(names, (str(v) for v in row)))) for row in df.collect()
+    )
+    return df.columns, content
+
+
+@pytest.mark.parametrize(
+    "file_name,row_tag",
+    [
+        (test_file_books_xml, "book"),
+        (test_file_books2_xml, "book"),
+        (test_file_nested_xml, "tag"),
+        (test_file_null_value_xml, "test"),
+        (test_file_books_attr_val_xml, "book"),
+        # Heterogeneous records: the corrupt-record key exists on some rows only, so this
+        # also covers discovery taking the union of keys rather than sampling one record.
+        (test_file_malformed_no_closing_tag_xml, "record"),
+        (test_file_malformed_not_self_closing_xml, "record"),
+    ],
+)
+def test_read_xml_variant_projection_matches_legacy_pivot(session, file_name, row_tag):
+    """Direct VARIANT projection must be output-equivalent to the flatten+pivot it replaces."""
+    columns, content = _read_xml_content(session, file_name, row_tag)
+    legacy_columns, legacy_content = _read_xml_content(
+        session, file_name, row_tag, _LEGACY_XML_PIVOT=True
+    )
+
+    assert content == legacy_content
+    assert sorted(columns) == sorted(legacy_columns)
+    # Column order is only a contract for the new path; pivot's ordering is incidental.
+    assert columns == sorted(columns)
+
+
+def test_read_xml_variant_projection_replaces_pivot_in_generated_sql(session):
+    """The rollback lever must actually switch query plans, not just produce equal output."""
+    path = f"@{tmp_stage_name}/{test_file_books_xml}"
+
+    with session.query_history() as projection_history:
+        session.read.option("rowTag", "book").xml(path)
+    with session.query_history() as pivot_history:
+        session.read.option("rowTag", "book").option("_LEGACY_XML_PIVOT", True).xml(
+            path
+        )
+
+    projection_sql = " ".join(q.sql_text.upper() for q in projection_history.queries)
+    pivot_sql = " ".join(q.sql_text.upper() for q in pivot_history.queries)
+
+    assert "PIVOT" in pivot_sql
+    assert "OBJECT_KEYS" not in pivot_sql
+    assert "OBJECT_KEYS" in projection_sql
+    assert "PIVOT" not in projection_sql
+
+
+def test_read_xml_legacy_pivot_option_preserves_column_names(session):
+    """The lever restores the previous output, including the single-quoted column names."""
+    clean = (
+        session.read.option("rowTag", "book")
+        .option("_LEGACY_XML_PIVOT", True)
+        .xml(f"@{tmp_stage_name}/{test_file_books_xml}")
+    )
+    assert len(clean.columns) == 7
+    result = clean.collect()
+    assert len(result) == 12
+    # Records are read by parallel workers, so row order is not deterministic.
+    assert '"Gambardella, Matthew"' in {row["'author'"] for row in result}
+
+    malformed = (
+        session.read.option("rowTag", "record")
+        .option("_LEGACY_XML_PIVOT", True)
+        .xml(f"@{tmp_stage_name}/{test_file_malformed_no_closing_tag_xml}")
+    )
+    malformed_result = malformed.collect()
+    assert len(malformed_result[0]) == 4
+    assert any(row["'_corrupt_record'"] is not None for row in malformed_result)
+
+
+def test_read_xml_corrupt_record_column_omitted_when_no_corrupt_record(session):
+    """In PERMISSIVE mode the corrupt-record column is added only when a record actually
+    failed to parse -- matching what pivot produced, since the reader only ever writes
+    that key for corrupt records."""
+    schema = StructType(
+        [StructField("_id", StringType()), StructField("author", StringType())]
+    )
+    clean = (
+        session.read.schema(schema)
+        .option("rowTag", "book")
+        .xml(f"@{tmp_stage_name}/{test_file_books_xml}")
+    )
+    assert [c.strip('"') for c in clean.columns] == ["_id", "author"]
+    assert len(clean.collect()[0]) == 2
+
+    corrupt_schema = StructType(
+        [StructField("_key", StringType()), StructField("title", StringType())]
+    )
+    # dblp_6kb.xml is truncated mid-record, so its last record cannot be parsed.
+    corrupt = (
+        session.read.schema(corrupt_schema)
+        .option("rowTag", "incollection")
+        .xml(f"@{tmp_stage_name}/{test_file_dblp_xml}")
+    )
+    assert [c.strip('"') for c in corrupt.columns] == [
+        "_key",
+        "title",
+        "_corrupt_record",
+    ]
+    assert any(row["_corrupt_record"] is not None for row in corrupt.collect())

--- a/tests/integ/test_xml_reader_row_tag.py
+++ b/tests/integ/test_xml_reader_row_tag.py
@@ -1186,45 +1186,51 @@ def _read_xml_content(session, file_name, row_tag, **options):
         (test_file_malformed_not_self_closing_xml, "record"),
     ],
 )
-def test_read_xml_variant_projection_matches_legacy_pivot(session, file_name, row_tag):
-    """Direct VARIANT projection must be output-equivalent to the flatten+pivot it replaces."""
-    columns, content = _read_xml_content(session, file_name, row_tag)
-    legacy_columns, legacy_content = _read_xml_content(
-        session, file_name, row_tag, _LEGACY_XML_PIVOT=True
+def test_read_xml_variant_projection_matches_default_pivot(session, file_name, row_tag):
+    """Opting into VARIANT projection must not change what is read.
+
+    The default is flatten+pivot, so that is the reference side here.
+    """
+    default_columns, default_content = _read_xml_content(session, file_name, row_tag)
+    columns, content = _read_xml_content(
+        session, file_name, row_tag, useVariantProjection=True
     )
 
-    assert content == legacy_content
-    assert sorted(columns) == sorted(legacy_columns)
-    # Column order is only a contract for the new path; pivot's ordering is incidental.
+    assert content == default_content
+    assert sorted(columns) == sorted(default_columns)
+    # Alphabetical order is a contract of the projection path only; pivot's is incidental.
     assert columns == sorted(columns)
 
 
-def test_read_xml_variant_projection_replaces_pivot_in_generated_sql(session):
-    """The rollback lever must actually switch query plans, not just produce equal output."""
+def test_read_xml_use_variant_projection_switches_the_query_plan(session):
+    """The option must actually switch query plans, not just produce equal output."""
     path = f"@{tmp_stage_name}/{test_file_books_xml}"
 
-    with session.query_history() as projection_history:
+    with session.query_history() as default_history:
         session.read.option("rowTag", "book").xml(path)
-    with session.query_history() as pivot_history:
-        session.read.option("rowTag", "book").option("_LEGACY_XML_PIVOT", True).xml(
+    with session.query_history() as projection_history:
+        session.read.option("rowTag", "book").option("useVariantProjection", True).xml(
             path
         )
 
+    default_sql = " ".join(q.sql_text.upper() for q in default_history.queries)
     projection_sql = " ".join(q.sql_text.upper() for q in projection_history.queries)
-    pivot_sql = " ".join(q.sql_text.upper() for q in pivot_history.queries)
 
-    assert "PIVOT" in pivot_sql
-    assert "OBJECT_KEYS" not in pivot_sql
+    assert "PIVOT" in default_sql
+    assert "OBJECT_KEYS" not in default_sql
     assert "OBJECT_KEYS" in projection_sql
     assert "PIVOT" not in projection_sql
 
 
-def test_read_xml_legacy_pivot_option_preserves_column_names(session):
-    """The lever restores the previous output, including the single-quoted column names."""
-    clean = (
-        session.read.option("rowTag", "book")
-        .option("_LEGACY_XML_PIVOT", True)
-        .xml(f"@{tmp_stage_name}/{test_file_books_xml}")
+def test_read_xml_default_options_preserve_pivot_output(session):
+    """A read with no options set must produce the flatten+pivot output unchanged.
+
+    This is the regression guarantee behind useVariantProjection defaulting to False: the
+    column count, row count, and single-quoted column naming all have to match what this
+    reader produced before the projection path existed.
+    """
+    clean = session.read.option("rowTag", "book").xml(
+        f"@{tmp_stage_name}/{test_file_books_xml}"
     )
     assert len(clean.columns) == 7
     result = clean.collect()
@@ -1232,14 +1238,46 @@ def test_read_xml_legacy_pivot_option_preserves_column_names(session):
     # Records are read by parallel workers, so row order is not deterministic.
     assert '"Gambardella, Matthew"' in {row["'author'"] for row in result}
 
-    malformed = (
-        session.read.option("rowTag", "record")
-        .option("_LEGACY_XML_PIVOT", True)
-        .xml(f"@{tmp_stage_name}/{test_file_malformed_no_closing_tag_xml}")
+    malformed = session.read.option("rowTag", "record").xml(
+        f"@{tmp_stage_name}/{test_file_malformed_no_closing_tag_xml}"
     )
     malformed_result = malformed.collect()
     assert len(malformed_result[0]) == 4
     assert any(row["'_corrupt_record'"] is not None for row in malformed_result)
+
+
+@pytest.mark.parametrize(
+    "file_name,row_tag,expected_row_count,expected_column_count",
+    [
+        (test_file_books_xml, "book", 12, 7),
+        (test_file_books2_xml, "book", 2, 6),
+        (test_file_dblp_xml, "mastersthesis", 6, 8),
+        (test_file_books_attr_val_xml, "book", 5, 6),
+    ],
+)
+def test_read_xml_default_options_match_pre_projection_shape(
+    session, file_name, row_tag, expected_row_count, expected_column_count
+):
+    """A read with no options set must produce the shape it produced before the projection
+    path existed, and must not reach that path at all.
+
+    The expected counts are the ones this reader produced prior to useVariantProjection,
+    so a change of default would show up here rather than only in the differential test.
+    """
+    with session.query_history() as history:
+        df = session.read.option("rowTag", row_tag).xml(
+            f"@{tmp_stage_name}/{file_name}"
+        )
+    result = df.collect()
+
+    assert len(df.columns) == expected_column_count
+    assert len(result) == expected_row_count
+    # Column names keep the single-quoted form dynamic pivot produced.
+    assert all(c.startswith("\"'") and c.endswith("'\"") for c in df.columns)
+
+    executed_sql = " ".join(q.sql_text.upper() for q in history.queries)
+    assert "PIVOT" in executed_sql
+    assert "OBJECT_KEYS" not in executed_sql
 
 
 def test_read_xml_corrupt_record_column_omitted_when_no_corrupt_record(session):

--- a/tests/unit/test_xml_reader.py
+++ b/tests/unit/test_xml_reader.py
@@ -8,12 +8,22 @@ import tempfile
 import os
 import lxml.etree as ET
 import html.entities
+from unittest import mock
 from unittest.mock import patch
 import pytest
 
+from snowflake.snowpark._internal.analyzer.analyzer import Analyzer
 from snowflake.snowpark._internal.analyzer.analyzer_utils import (
     attribute_to_schema_string_deep,
+    single_quote,
 )
+from snowflake.snowpark._internal.utils import (
+    quote_name,
+    use_xml_variant_projection,
+    xml_variant_projection,
+)
+from snowflake.snowpark.dataframe_reader import DataFrameReader
+from snowflake.snowpark.exceptions import SnowparkDataframeReaderException
 from snowflake.snowpark._internal.xml_reader import (
     replace_entity,
     element_to_dict_or_str,
@@ -1347,3 +1357,147 @@ def test_xml_reader_process_with_scos_compatible_param():
         )
     assert len(results) == 1
     assert results[0][0]["a"] == "1"
+
+
+#
+# Output projection: direct VARIANT key projection instead of flatten + dynamic pivot.
+#
+
+
+def _render(column) -> str:
+    """Render a Column to SQL without needing a Snowflake connection.
+
+    A real Analyzer is used rather than a mocked one so the assertions below pin the
+    SQL that actually reaches the server, including identifier/literal escaping.
+    """
+    return Analyzer(mock.MagicMock()).analyze(column._expression, {})
+
+
+def _reader(**options) -> DataFrameReader:
+    reader = DataFrameReader.__new__(DataFrameReader)
+    reader._cur_options = {k.upper(): v for k, v in options.items()}
+    reader._file_path = "@stage/test.xml"
+    return reader
+
+
+@pytest.mark.parametrize(
+    "key,expected",
+    [
+        ("author", "\"ROW_DATA\"['author'] AS \"'author'\""),
+        # A namespace prefix must stay part of the key: ROW_DATA:px:name would parse the
+        # colon as a further path segment, so subfield notation is used instead.
+        ("px:name", "\"ROW_DATA\"['px:name'] AS \"'px:name'\""),
+        (
+            "{http://example.com/px}item",
+            "\"ROW_DATA\"['{http://example.com/px}item'] "
+            "AS \"'{http://example.com/px}item'\"",
+        ),
+        ("_corrupt_record", "\"ROW_DATA\"['_corrupt_record'] AS \"'_corrupt_record'\""),
+        ("_VALUE", "\"ROW_DATA\"['_VALUE'] AS \"'_VALUE'\""),
+        # A quote in the key must not terminate the literal or the alias early.
+        ("a'b", "\"ROW_DATA\"['a''b'] AS \"'a''b'\""),
+        ('a"b', '"ROW_DATA"[\'a"b\'] AS "\'a""b\'"'),
+    ],
+)
+def test_xml_variant_projection_sql(key, expected):
+    assert _render(xml_variant_projection(key)) == expected
+
+
+def test_xml_variant_projection_alias_matches_pivot_naming():
+    """The alias must keep the single-quoted names dynamic pivot produced, since
+    _apply_xml_schema looks columns up via single_quote(field name)."""
+    assert _render(xml_variant_projection("author")).endswith(
+        f"AS {quote_name(single_quote('author'))}"
+    )
+
+
+@pytest.mark.parametrize(
+    "options,schema_known,expected",
+    [
+        # Default (cacheResult=True): projection applies whether or not a schema is known.
+        ({}, True, True),
+        ({}, False, True),
+        # cacheResult=False leaves nothing materialized: no keys to discover, and no cheap
+        # way to test for corrupt records, so flatten+pivot keeps .xml() lazy.
+        ({"CACHERESULT": False}, False, False),
+        ({"CACHERESULT": False}, True, False),
+        # ... except when no corrupt-record probe is needed, i.e. outside PERMISSIVE mode.
+        ({"CACHERESULT": False, "MODE": "FAILFAST"}, True, True),
+        ({"CACHERESULT": False, "MODE": "DROPMALFORMED"}, True, True),
+        ({"CACHERESULT": False, "MODE": "failfast"}, True, True),
+        # Without a schema there are still no keys to discover, whatever the mode.
+        ({"CACHERESULT": False, "MODE": "FAILFAST"}, False, False),
+        # The rollback lever wins over everything else.
+        ({"_LEGACY_XML_PIVOT": True}, True, False),
+        ({"_LEGACY_XML_PIVOT": True}, False, False),
+        ({"_LEGACY_XML_PIVOT": True, "CACHERESULT": True}, True, False),
+    ],
+)
+def test_use_xml_variant_projection(options, schema_known, expected):
+    assert use_xml_variant_projection(options, schema_known) is expected
+
+
+def _project_from_keys(keys, **options):
+    """Drive _xml_project_from_variant_cache over a DataFrame whose key discovery
+    returns *keys*, and return (rendered projections, projected DataFrame)."""
+    discovery = mock.MagicMock()
+    discovery.select.return_value.distinct.return_value.collect.return_value = [
+        (k,) for k in keys
+    ]
+    projected = mock.MagicMock()
+    df = mock.MagicMock()
+    df.select.side_effect = [discovery, projected]
+
+    result = _reader(rowtag="record", **options)._xml_project_from_variant_cache(df)
+
+    assert result is projected
+    projections = [_render(c) for c in df.select.call_args_list[1].args]
+    return projections, projected
+
+
+def test_xml_project_from_variant_cache_projects_discovered_keys():
+    projections, projected = _project_from_keys(["title", "_id", "author"])
+    # Discovered keys are projected in sorted order for a deterministic column order.
+    assert projections == [
+        "\"ROW_DATA\"['_id'] AS \"'_id'\"",
+        "\"ROW_DATA\"['author'] AS \"'author'\"",
+        "\"ROW_DATA\"['title'] AS \"'title'\"",
+    ]
+    # Preserved so dot-notation (df.select("'nested'.child")) keeps working.
+    assert projected._all_variant_cols is True
+
+
+def test_xml_project_from_variant_cache_deduplicates_and_sorts():
+    projections, _ = _project_from_keys(["b", "a", "b"])
+    assert projections == [
+        "\"ROW_DATA\"['a'] AS \"'a'\"",
+        "\"ROW_DATA\"['b'] AS \"'b'\"",
+        "\"ROW_DATA\"['b'] AS \"'b'\"",
+    ]
+
+
+def test_xml_project_from_variant_cache_projects_namespaced_key():
+    projections, _ = _project_from_keys(["px:name"])
+    assert projections == ["\"ROW_DATA\"['px:name'] AS \"'px:name'\""]
+
+
+def test_xml_project_from_variant_cache_projects_corrupt_record_when_discovered():
+    """Without a schema the corrupt-record column needs no gating: the reader only
+    writes that key for records that fail to parse, so discovering it at all means
+    the data really contains a corrupt record."""
+    projections, _ = _project_from_keys(["id", "_corrupt_record"])
+    assert "\"ROW_DATA\"['_corrupt_record'] AS \"'_corrupt_record'\"" in projections
+
+
+def test_xml_project_from_variant_cache_omits_corrupt_record_when_absent():
+    projections, _ = _project_from_keys(["id", "name"])
+    assert not any("_corrupt_record" in p for p in projections)
+
+
+def test_xml_project_from_variant_cache_no_keys_raises_row_tag_not_found():
+    """An empty result means the row tag matched nothing. Under pivot this surfaced as
+    a "SELECT with no columns" SQL error that was translated into this exception."""
+    with pytest.raises(
+        SnowparkDataframeReaderException, match="Cannot find the row tag"
+    ):
+        _project_from_keys([])

--- a/tests/unit/test_xml_reader.py
+++ b/tests/unit/test_xml_reader.py
@@ -1414,23 +1414,50 @@ def test_xml_variant_projection_alias_matches_pivot_naming():
 @pytest.mark.parametrize(
     "options,schema_known,expected",
     [
-        # Default (cacheResult=True): projection applies whether or not a schema is known.
-        ({}, True, True),
-        ({}, False, True),
-        # cacheResult=False leaves nothing materialized: no keys to discover, and no cheap
-        # way to test for corrupt records, so flatten+pivot keeps .xml() lazy.
+        # Unset: an unconfigured read keeps the flatten+pivot output it always produced,
+        # whatever else is set.
+        ({}, True, False),
+        ({}, False, False),
+        ({"CACHERESULT": True}, True, False),
         ({"CACHERESULT": False}, False, False),
-        ({"CACHERESULT": False}, True, False),
+        ({"MODE": "FAILFAST"}, True, False),
+        # Explicitly off is the same as unset.
+        ({"USEVARIANTPROJECTION": False}, True, False),
+        ({"USEVARIANTPROJECTION": False}, False, False),
+        # Opted in with cacheResult at its default: applies whether or not a schema is known.
+        ({"USEVARIANTPROJECTION": True}, True, True),
+        ({"USEVARIANTPROJECTION": True}, False, True),
+        ({"USEVARIANTPROJECTION": True, "CACHERESULT": True}, True, True),
+        # Opted in, but cacheResult=False leaves nothing materialized: no keys to discover,
+        # and no cheap way to test for corrupt records, so flatten+pivot keeps .xml() lazy.
+        ({"USEVARIANTPROJECTION": True, "CACHERESULT": False}, False, False),
+        ({"USEVARIANTPROJECTION": True, "CACHERESULT": False}, True, False),
         # ... except when no corrupt-record probe is needed, i.e. outside PERMISSIVE mode.
-        ({"CACHERESULT": False, "MODE": "FAILFAST"}, True, True),
-        ({"CACHERESULT": False, "MODE": "DROPMALFORMED"}, True, True),
-        ({"CACHERESULT": False, "MODE": "failfast"}, True, True),
+        (
+            {"USEVARIANTPROJECTION": True, "CACHERESULT": False, "MODE": "FAILFAST"},
+            True,
+            True,
+        ),
+        (
+            {
+                "USEVARIANTPROJECTION": True,
+                "CACHERESULT": False,
+                "MODE": "DROPMALFORMED",
+            },
+            True,
+            True,
+        ),
+        (
+            {"USEVARIANTPROJECTION": True, "CACHERESULT": False, "MODE": "failfast"},
+            True,
+            True,
+        ),
         # Without a schema there are still no keys to discover, whatever the mode.
-        ({"CACHERESULT": False, "MODE": "FAILFAST"}, False, False),
-        # The rollback lever wins over everything else.
-        ({"_LEGACY_XML_PIVOT": True}, True, False),
-        ({"_LEGACY_XML_PIVOT": True}, False, False),
-        ({"_LEGACY_XML_PIVOT": True, "CACHERESULT": True}, True, False),
+        (
+            {"USEVARIANTPROJECTION": True, "CACHERESULT": False, "MODE": "FAILFAST"},
+            False,
+            False,
+        ),
     ],
 )
 def test_use_xml_variant_projection(options, schema_known, expected):


### PR DESCRIPTION
<!---
Please answer these questions before creating your pull request. Thanks!
--->

1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   <!---
   In this section, please add a Snowflake Jira issue number.

   Note that if a corresponding GitHub issue exists, you should still include
   the Snowflake Jira issue number. For example, for GitHub issue
   https://github.com/snowflakedb/snowpark-python/issues/1400, you should
   add "SNOW-1335071" here.
    --->

   Fixes SNOW-3898656

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.
   - [x] I acknowledge that I have ensured my changes to be thread-safe. Follow the link for more information: [Thread-safe Developer Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#thread-safe-development)
   - [x] If adding any arguments to public Snowpark APIs or creating new public Snowpark APIs, I acknowledge that I have ensured my changes include AST support. Follow the link for more information: [AST Support Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#ast-abstract-syntax-tree-support-in-snowpark)

3. Please describe how your code solves the related issue.

   Please write a short description of how your code change solves the related issue.

Adds `useVariantProjection` option for `DataFrameReader.xml()` to enable direct VARIANT-key projection, bypassing the expensive flatten and pivot operations.

### Technique

* **Current behavior:** Reading XML with `rowTag` set produces one VARIANT column (`ROW_DATA`) per record. Turning that into a table uses `flatten()` + a dynamic `pivot()`: flatten expands every record into one row per key, carrying the full data value each time (m×n rows of `{key, value}`), then pivot re-aggregates those m×n rows back into columns. This requires two passes over m×n rows of actual data due to the nature of dynamic pivot.
* **Optimized behavior (`useVariantProjection=True`):** Skips flatten+pivot entirely. It discovers the distinct key names with a single pass over `OBJECT_KEYS(ROW_DATA)` (m×n rows of key-name strings only, no data values), then projects each discovered key directly out of `ROW_DATA` via bracket notation (`ROW_DATA['key']`). This requires only one pass over key names instead of two passes over full values.

### Limitations & Defaults

* **Limitation:** Requires `cacheResult=True` (the default) or a known schema, since key discovery needs a materialized result to scan. With `cacheResult=False` and no schema, it falls back to the existing flatten+pivot behavior.
* **Default:** Opt-in (`False` by default). A plain `.xml()` call is byte-for-byte unchanged.

### Real-Workload Impact & Performance

Measured on the same warehouse:

| XML File | Before | After |
| :--- | :--- | :--- |
| **4GB / 805 cols** | 172.17s | 74.16s (−56.9%) |
| **50GB / 805 cols** | 1648.48s | 643.13s (−61.0%) |

* Row/column output verified identical before and after on both files.
* **SAS impact:** No regression. Verified against `snowpark-connect`'s XML expectation test suite: 12/12 pass, identical to main on every test. Also verified that SCOS XML expectation tests produced exact same DFs if this option is turned on. SCOS can consider opting in to optimize performance, but this is out of scope for this PR.