### PR TITLE
NO SNOW: Fix modin-in-apply error detection for updated server message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 ### Snowpark Python API Updates
 
+### Snowpark pandas API Updates
+
+#### Bug Fixes
+
+- Fixed a bug where referencing `modin.pandas` inside a Snowpark pandas `apply()` function raised a raw `ModuleNotFoundError` instead of the intended guidance message. The detection now also matches the server-side `No module named 'snowflake.snowpark'` error.
+
 ## 1.54.0 (2026-07-29)
 
 ### Snowpark Python API updates

--- a/src/snowflake/snowpark/modin/plugin/compiler/snowflake_query_compiler.py
+++ b/src/snowflake/snowpark/modin/plugin/compiler/snowflake_query_compiler.py
@@ -10465,9 +10465,11 @@ class SnowflakeQueryCompiler(BaseQueryCompiler):
         try:
             ordered_dataframe = cache_result(udtf_dataframe)
         except SnowparkSQLException as e:
-            if "No module named 'snowflake'" in str(
-                e
-            ) or "Modin is not installed" in str(e):
+            if (
+                "No module named 'snowflake'" in str(e)
+                or "No module named 'snowflake.snowpark'" in str(e)
+                or "Modin is not installed" in str(e)
+            ):
                 raise SnowparkSQLException(
                     "modin.pandas cannot be referenced within a Snowpark pandas apply() function. "
                     "You can only use native pandas inside apply(). Please check developer guide for details "


### PR DESCRIPTION
## Summary
- `test_snowpandas_in_apply_negative` was failing deterministically in the merge gate (not flaky).
- Root cause: when `modin.pandas` is referenced inside a Snowpark pandas `apply()`, the UDTF fails server-side with `No module named 'snowflake.snowpark'`. The guard in `snowflake_query_compiler.py` only checked for `No module named 'snowflake'`, so it skipped the friendly guidance message and re-raised the raw `ModuleNotFoundError`, causing the test's `pytest.raises(match=...)` to fail.
- Fix: also match `No module named 'snowflake.snowpark'` explicitly (old string kept for compatibility). Chose an explicit match over a broad prefix to avoid mislabeling unrelated `snowflake.*` import failures (e.g. `snowflake.connector`).

## Test plan
- [x] `test_snowpandas_in_apply_negative` now passes (verified across multiple reruns against a live account).
- [ ] CI merge gate green.

.... Generated with [Cortex Code](https://docs.snowflake.com/en/user-guide/cortex-code/cortex-code)~