### PR TITLE
SNOW-3472759: support to_polars() eagerFrame interoperability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 #### New Features
 
+- Added `DataFrame.to_polars()` to convert a Snowpark DataFrame to a Polars DataFrame. Supports an optional `use_parquet=True` mode for large data-transfer-dominated workloads.
 - Added interval type support for Python UDFs and stored procedures. Use `datetime.timedelta` as the type annotation for day-time interval (`DayTimeIntervalType`) parameters and return values, and `YearMonthInterval` (a type annotation sentinel from `snowflake.snowpark.types`) for year-month interval (`YearMonthIntervalType`) parameters and return values.
 - Added support for a `table_properties` key in the `iceberg_config` dictionary of `DataFrameWriter.save_as_table`, which emits a `TABLE_PROPERTIES = ('k'='v', ...)` clause on Iceberg table creation (CREATE / CTAS).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 #### New Features
 
-- Added `DataFrame.to_polars()` to convert a Snowpark DataFrame to a Polars DataFrame. Supports an optional `use_parquet=True` mode for large data-transfer-dominated workloads.
+- Added `DataFrame.to_polars()` to convert a Snowpark DataFrame to a Polars DataFrame. Supports an optional `transport="parquet"` mode for large data-transfer-dominated workloads.
 - Added interval type support for Python UDFs and stored procedures. Use `datetime.timedelta` as the type annotation for day-time interval (`DayTimeIntervalType`) parameters and return values, and `YearMonthInterval` (a type annotation sentinel from `snowflake.snowpark.types`) for year-month interval (`YearMonthIntervalType`) parameters and return values.
 - Added support for a `table_properties` key in the `iceberg_config` dictionary of `DataFrameWriter.save_as_table`, which emits a `TABLE_PROPERTIES = ('k'='v', ...)` clause on Iceberg table creation (CREATE / CTAS).
 

--- a/docs/source/snowpark/dataframe.rst
+++ b/docs/source/snowpark/dataframe.rst
@@ -92,6 +92,7 @@ DataFrame
     DataFrame.to_local_iterator
     DataFrame.to_pandas
     DataFrame.to_pandas_batches
+    DataFrame.to_polars
     DataFrame.to_snowpark_pandas
     DataFrame.union
     DataFrame.unionAll

--- a/setup.py
+++ b/setup.py
@@ -73,6 +73,7 @@ DEVELOPMENT_REQUIREMENTS = [
     "psutil",  # testing for telemetry
     "lxml",  # used in XML reader unit tests
     "pyarrow",  # used in dataframe reader tests
+    "polars>=1.0",  # used in test_df_to_polars integration tests
 ]
 MODIN_DEVELOPMENT_REQUIREMENTS = [
     # Snowpark pandas 3rd party library testing. Cap the scipy version because

--- a/src/snowflake/snowpark/_internal/polars_backend.py
+++ b/src/snowflake/snowpark/_internal/polars_backend.py
@@ -1,0 +1,169 @@
+#
+# Copyright (c) 2012-2025 Snowflake Computing Inc. All rights reserved.
+#
+from __future__ import annotations
+
+import uuid
+from concurrent.futures import ThreadPoolExecutor
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import polars as pl
+    from snowflake.snowpark.dataframe import DataFrame
+
+
+def _empty_frame_from_schema(
+    df: DataFrame, statement_params: dict[str, str] | None
+) -> pl.DataFrame:
+    """Return an empty polars DataFrame with the DataFrame's schema."""
+    import polars as pl
+
+    return pl.from_arrow(
+        df.limit(0).to_arrow(
+            statement_params=statement_params,
+            _emit_ast=False,
+        )
+    )
+
+
+def _open_stage_files_parallel(
+    session,
+    paths: list[str],
+    is_sproc: bool,
+    is_lazy: bool,
+    max_workers: int | None = None,
+) -> list:
+    """Open stage files concurrently.
+
+    * ``is_lazy=True``: return the raw file-like objects for
+      ``pl.scan_parquet`` to consume (Polars owns the handles from that point
+      on and closes them itself).
+    * ``is_lazy=False``: read each file with ``pl.read_parquet`` and return
+      the resulting ``pl.DataFrame`` (``with`` closes the handle after read).
+
+    Uses ``SnowflakeFile.open`` inside a stored procedure and
+    ``session.file.get_stream`` on the client.
+    """
+    if not paths:
+        return []
+
+    import polars as pl
+
+    if is_sproc:
+        from snowflake.snowpark.files import SnowflakeFile
+
+        def opener(p: str):
+            return SnowflakeFile.open(p, "rb", require_scoped_url=False)
+
+    else:
+        opener = session.file.get_stream
+
+    def _work(p: str):
+        if is_lazy:
+            return opener(p)
+        with opener(p) as f:
+            return pl.read_parquet(f)
+
+    with ThreadPoolExecutor(max_workers=max_workers) as ex:
+        return list(ex.map(_work, paths))
+
+
+def _copy_df_to_stage(
+    df: DataFrame,
+    sub_prefix: str,
+    statement_params: dict[str, str] | None = None,
+) -> list[str]:
+    """COPY INTO the session stage as Parquet and return the staged file paths.
+
+    Uses ``DataFrame.write.copy_into_location`` so plan compilation and
+    statement params go through the same path as other write actions. No
+    pre-sort is applied — callers wanting row-group elimination should
+    ``.sort(...)`` before ``to_polars``.
+    """
+    rid = uuid.uuid4().hex[:12]
+    stage = df._session.get_session_stage().rstrip("/")
+    sub = f"{stage}/{sub_prefix}/{rid}/"
+    df.write.copy_into_location(
+        sub,
+        file_format_type="parquet",
+        format_type_options={"COMPRESSION": "SNAPPY"},
+        header=True,
+        overwrite=True,
+        statement_params=statement_params,
+    )
+    rows = df._session.sql(f"LIST '{sub}'").collect(statement_params=statement_params)
+    # `sub` is fully qualified; LIST returns stage-relative names. Construct fully-qualified paths.
+    return [sub + row["name"].rsplit("/", 1)[-1] for row in rows]
+
+
+def arrow_eager(
+    df: DataFrame,
+    statement_params: dict[str, str] | None = None,
+) -> pl.DataFrame:
+    """Fetch the result as Arrow batches and return a polars DataFrame.
+
+    Backs the default ``to_polars()`` path (``lazy=False, use_parquet=False``).
+    Preserves full Snowflake type fidelity.
+    """
+    import polars as pl
+
+    parts = [
+        pl.from_arrow(batch)
+        for batch in df.to_arrow_batches(
+            statement_params=statement_params, _emit_ast=False
+        )
+    ]
+    if not parts:
+        return _empty_frame_from_schema(df, statement_params)
+    return pl.concat(parts) if len(parts) > 1 else parts[0]
+
+
+def parquet_eager(
+    df: DataFrame,
+    is_sproc: bool = False,
+    statement_params: dict[str, str] | None = None,
+    max_workers: int | None = None,
+) -> pl.DataFrame:
+    """COPY INTO Parquet, read the staged files in parallel, return a polars DataFrame.
+
+    Backs ``to_polars(use_parquet=True)``. Subject to the Parquet type-fidelity
+    caveats documented on ``DataFrame.to_polars``.
+    """
+    import polars as pl
+
+    paths = _copy_df_to_stage(df, "to_polars_parquet_eager", statement_params)
+    if not paths:
+        return _empty_frame_from_schema(df, statement_params)
+    frames = _open_stage_files_parallel(
+        df._session, paths, is_sproc, is_lazy=False, max_workers=max_workers
+    )
+    if not frames:
+        return _empty_frame_from_schema(df, statement_params)
+    return pl.concat(frames) if len(frames) > 1 else frames[0]
+
+
+def parquet_lazy(
+    df: DataFrame,
+    is_sproc: bool = False,
+    statement_params: dict[str, str] | None = None,
+    max_workers: int | None = None,
+) -> pl.LazyFrame:
+    """COPY INTO Parquet, open the staged files, return a ``pl.scan_parquet`` LazyFrame.
+
+    Backs ``to_polars(lazy=True)``. COPY INTO runs synchronously; only the
+    scan/decode is deferred. Subject to the Parquet type-fidelity caveats
+    documented on ``DataFrame.to_polars``.
+    """
+    import polars as pl
+
+    paths = _copy_df_to_stage(df, "to_polars_parquet_lazy", statement_params)
+    if not paths:
+        return pl.LazyFrame(
+            schema=_empty_frame_from_schema(df, statement_params).schema
+        )
+    # The stream objects are owned by the returned LazyFrame; Polars closes them
+    # when the scan is materialized (or if the LazyFrame is discarded).
+    streams = _open_stage_files_parallel(
+        df._session, paths, is_sproc, is_lazy=True, max_workers=max_workers
+    )
+    return pl.scan_parquet(streams)

--- a/src/snowflake/snowpark/_internal/polars_backend.py
+++ b/src/snowflake/snowpark/_internal/polars_backend.py
@@ -30,16 +30,11 @@ def _open_stage_files_parallel(
     session,
     paths: list[str],
     is_sproc: bool,
-    is_lazy: bool,
     max_workers: int | None = None,
 ) -> list:
-    """Open stage files concurrently.
-
-    * ``is_lazy=True``: return the raw file-like objects for
-      ``pl.scan_parquet`` to consume (Polars owns the handles from that point
-      on and closes them itself).
-    * ``is_lazy=False``: read each file with ``pl.read_parquet`` and return
-      the resulting ``pl.DataFrame`` (``with`` closes the handle after read).
+    """Open stage files concurrently, reading each with ``pl.read_parquet``
+    and returning the resulting ``pl.DataFrame`` (``with`` closes the handle
+    after read).
 
     Uses ``SnowflakeFile.open`` inside a stored procedure and
     ``session.file.get_stream`` on the client.
@@ -59,8 +54,6 @@ def _open_stage_files_parallel(
         opener = session.file.get_stream
 
     def _work(p: str):
-        if is_lazy:
-            return opener(p)
         with opener(p) as f:
             return pl.read_parquet(f)
 
@@ -102,7 +95,7 @@ def arrow_eager(
 ) -> pl.DataFrame:
     """Fetch the result as Arrow batches and return a polars DataFrame.
 
-    Backs the default ``to_polars()`` path (``lazy=False, use_parquet=False``).
+    Backs the default ``to_polars()`` path (``use_parquet=False``).
     Preserves full Snowflake type fidelity.
     """
     import polars as pl
@@ -135,35 +128,8 @@ def parquet_eager(
     if not paths:
         return _empty_frame_from_schema(df, statement_params)
     frames = _open_stage_files_parallel(
-        df._session, paths, is_sproc, is_lazy=False, max_workers=max_workers
+        df._session, paths, is_sproc, max_workers=max_workers
     )
     if not frames:
         return _empty_frame_from_schema(df, statement_params)
     return pl.concat(frames) if len(frames) > 1 else frames[0]
-
-
-def parquet_lazy(
-    df: DataFrame,
-    is_sproc: bool = False,
-    statement_params: dict[str, str] | None = None,
-    max_workers: int | None = None,
-) -> pl.LazyFrame:
-    """COPY INTO Parquet, open the staged files, return a ``pl.scan_parquet`` LazyFrame.
-
-    Backs ``to_polars(lazy=True)``. COPY INTO runs synchronously; only the
-    scan/decode is deferred. Subject to the Parquet type-fidelity caveats
-    documented on ``DataFrame.to_polars``.
-    """
-    import polars as pl
-
-    paths = _copy_df_to_stage(df, "to_polars_parquet_lazy", statement_params)
-    if not paths:
-        return pl.LazyFrame(
-            schema=_empty_frame_from_schema(df, statement_params).schema
-        )
-    # The stream objects are owned by the returned LazyFrame; Polars closes them
-    # when the scan is materialized (or if the LazyFrame is discarded).
-    streams = _open_stage_files_parallel(
-        df._session, paths, is_sproc, is_lazy=True, max_workers=max_workers
-    )
-    return pl.scan_parquet(streams)

--- a/src/snowflake/snowpark/_internal/polars_backend.py
+++ b/src/snowflake/snowpark/_internal/polars_backend.py
@@ -95,7 +95,7 @@ def arrow_eager(
 ) -> pl.DataFrame:
     """Fetch the result as Arrow batches and return a polars DataFrame.
 
-    Backs the default ``to_polars()`` path (``use_parquet=False``).
+    Backs the default ``to_polars()`` path (``transport="arrow"``).
     Preserves full Snowflake type fidelity.
     """
     import polars as pl
@@ -119,7 +119,7 @@ def parquet_eager(
 ) -> pl.DataFrame:
     """COPY INTO Parquet, read the staged files in parallel, return a polars DataFrame.
 
-    Backs ``to_polars(use_parquet=True)``. Subject to the Parquet type-fidelity
+    Backs ``to_polars(transport="parquet")``. Subject to the Parquet type-fidelity
     caveats documented on ``DataFrame.to_polars``.
     """
     import polars as pl

--- a/src/snowflake/snowpark/dataframe.py
+++ b/src/snowflake/snowpark/dataframe.py
@@ -20,6 +20,7 @@ from typing import (
     Dict,
     Iterator,
     List,
+    Literal as TypeLiteral,
     Optional,
     Set,
     Tuple,
@@ -161,6 +162,7 @@ from snowflake.snowpark._internal.utils import (
     experimental,
     generate_random_alphanumeric,
     get_copy_into_table_options,
+    is_in_stored_procedure,
     is_snowflake_quoted_id_case_insensitive,
     is_snowflake_unquoted_suffix_case_insensitive,
     is_sql_select_statement,
@@ -238,6 +240,7 @@ from collections.abc import Iterable
 
 if TYPE_CHECKING:
     import modin.pandas  # pragma: no cover
+    import polars  # pragma: no cover
     from table import Table  # pragma: no cover
 
 _logger = getLogger(__name__)
@@ -1369,6 +1372,163 @@ class DataFrame:
                 ),
             ),
             **kwargs,
+        )
+
+    @publicapi
+    @overload
+    def to_polars(
+        self,
+        *,
+        lazy: TypeLiteral[False] = False,
+        use_parquet: bool = False,
+        max_workers: Optional[int] = None,
+        statement_params: Optional[Dict[str, str]] = None,
+        _emit_ast: bool = False,
+    ) -> "polars.DataFrame":
+        ...  # pragma: no cover
+
+    @publicapi
+    @overload
+    def to_polars(
+        self,
+        *,
+        lazy: TypeLiteral[True],
+        use_parquet: bool = False,
+        max_workers: Optional[int] = None,
+        statement_params: Optional[Dict[str, str]] = None,
+        _emit_ast: bool = False,
+    ) -> "polars.LazyFrame":
+        ...  # pragma: no cover
+
+    @experimental(version="1.55.0")
+    @df_collect_api_telemetry
+    @publicapi
+    def to_polars(
+        self,
+        *,
+        lazy: bool = False,
+        use_parquet: bool = False,
+        max_workers: Optional[int] = None,
+        statement_params: Optional[Dict[str, str]] = None,
+        _emit_ast: bool = False,
+    ) -> Union["polars.DataFrame", "polars.LazyFrame"]:
+        """
+        Executes the query representing this DataFrame and returns the result
+        as a `polars DataFrame <https://docs.pola.rs/py-polars/html/reference/dataframe/index.html>`_,
+        or a `polars LazyFrame <https://docs.pola.rs/py-polars/html/reference/lazyframe/index.html>`_
+        when ``lazy=True``.
+
+        The transport is selected by ``(lazy, use_parquet)``:
+
+        =====  ============  ============================================
+        lazy   use_parquet   Transport
+        =====  ============  ============================================
+        False  False         Arrow (default; full Snowflake type fidelity)
+        False  True          Parquet unload + eager parallel read
+        True   False         Parquet unload + lazy scan
+        True   True          Parquet unload + lazy scan
+        =====  ============  ============================================
+
+        Usage Notes:
+            - **Transport selection**:
+                - **Parquet** (``use_parquet=True`` or ``lazy=True``):
+                  Recommended when the result set is large and the type-fidelity
+                  caveats are acceptable. Snowflake's ``COPY INTO`` splits the
+                  result into multiple Parquet files that are opened and read
+                  concurrently. In server-side environments such as stored
+                  procedures, each file open is a parallelizable I/O operation,
+                  so the concurrent access substantially reduces wall-clock time
+                  compared to the Arrow path. On a local client, connection
+                  bandwidth is the primary constraint, and the benefit is more
+                  modest; for small or medium result sets the ``COPY INTO``
+                  setup cost may outweigh the gain, making Arrow the more
+                  efficient choice.
+                - **Arrow** (default, ``lazy=False, use_parquet=False``):
+                  Streams result batches directly from the cursor without
+                  staging to disk. Preserves full Snowflake type fidelity.
+                  Use when type accuracy is required, or when the result set is
+                  small enough that the Parquet paths' ``COPY INTO`` overhead
+                  is not justified.
+            - **Lazy evaluation** (``lazy=True``): ``COPY INTO`` runs
+              synchronously at call time; the Parquet scan and any downstream
+              Polars operations are deferred to ``.collect()``. Use when
+              Polars plan optimization — such as column projection or row-group
+              filtering — is desired. The ``use_parquet`` argument has no
+              effect when ``lazy=True``; the Parquet transport is always used.
+            - **Parallelism tuning**: ``max_workers`` controls the thread pool
+              for opening and reading staged Parquet files. Only applies to
+              the Parquet paths; ignored for the Arrow path. The default
+              (``None``) defers to
+              :class:`~concurrent.futures.ThreadPoolExecutor`.
+
+        Example::
+
+            >>> df = session.create_dataframe([[1, 2], [3, 4]], schema=["a", "b"])
+            >>> df.to_polars().shape  # doctest: +SKIP
+            (2, 2)
+            >>> lf = df.to_polars(lazy=True)  # doctest: +SKIP
+            >>> lf.collect().sort("A").to_dicts()  # doctest: +SKIP
+            [{'A': 1, 'B': 2}, {'A': 3, 'B': 4}]
+
+        Args:
+            lazy: When ``True``, return a ``polars.LazyFrame`` and defer the
+                Parquet scan and downstream Polars operations until
+                ``.collect()``. Defaults to ``False``.
+            use_parquet: When ``True`` (and ``lazy=False``), unload the result
+                to Parquet on the session stage and read the files back in
+                parallel. Can be faster than the Arrow path for large,
+                data-transfer-dominated workloads — especially in a stored
+                procedure — but subject to the type-fidelity limits below. Has
+                no effect when ``lazy=True``. Defaults to ``False``.
+            max_workers: Maximum number of threads for parallel stage-file
+                opens and reads. Only applies to the Parquet paths
+                (``use_parquet=True`` or ``lazy=True``). Defaults to ``None``.
+            statement_params: Dictionary of statement level parameters to be
+                set while executing this action.
+
+        Note:
+            1. Requires ``polars>=1.0``.
+
+            2. The Parquet paths (``use_parquet=True`` or ``lazy=True``)
+            do not fully preserve Snowflake types because ``COPY INTO``
+            has restrictions on Parquet unload:
+
+               - ``TIMESTAMP_LTZ`` and ``TIMESTAMP_TZ`` columns cause the
+                 unload to error.
+               - ``TIMESTAMP_NTZ`` values with nanosecond precision are
+                 truncated to milliseconds.
+               - ``FLOAT`` (double) columns are downcast to ``float32``.
+
+            See the `COPY INTO <location> usage notes
+            <https://docs.snowflake.com/en/sql-reference/sql/copy-into-location#usage-notes>`_
+            for the full unload type mapping. Use the Arrow default when
+            full type fidelity is required.
+        """
+        from snowflake.snowpark._internal.polars_backend import (
+            arrow_eager as _arrow_eager,
+            parquet_eager as _parquet_eager,
+            parquet_lazy as _parquet_lazy,
+        )
+
+        is_sproc = is_in_stored_procedure()
+
+        if lazy:
+            return _parquet_lazy(
+                self,
+                is_sproc=is_sproc,
+                statement_params=statement_params,
+                max_workers=max_workers,
+            )
+        if use_parquet:
+            return _parquet_eager(
+                self,
+                is_sproc=is_sproc,
+                statement_params=statement_params,
+                max_workers=max_workers,
+            )
+        return _arrow_eager(
+            self,
+            statement_params=statement_params,
         )
 
     @df_api_usage

--- a/src/snowflake/snowpark/dataframe.py
+++ b/src/snowflake/snowpark/dataframe.py
@@ -1382,7 +1382,6 @@ class DataFrame:
         use_parquet: bool = False,
         max_workers: Optional[int] = None,
         statement_params: Optional[Dict[str, str]] = None,
-        _emit_ast: bool = False,
     ) -> "polars.DataFrame":
         """
         Executes the query representing this DataFrame and returns the result

--- a/src/snowflake/snowpark/dataframe.py
+++ b/src/snowflake/snowpark/dataframe.py
@@ -20,7 +20,6 @@ from typing import (
     Dict,
     Iterator,
     List,
-    Literal as TypeLiteral,
     Optional,
     Set,
     Tuple,
@@ -1374,64 +1373,33 @@ class DataFrame:
             **kwargs,
         )
 
-    @publicapi
-    @overload
-    def to_polars(
-        self,
-        *,
-        lazy: TypeLiteral[False] = False,
-        use_parquet: bool = False,
-        max_workers: Optional[int] = None,
-        statement_params: Optional[Dict[str, str]] = None,
-        _emit_ast: bool = False,
-    ) -> "polars.DataFrame":
-        ...  # pragma: no cover
-
-    @publicapi
-    @overload
-    def to_polars(
-        self,
-        *,
-        lazy: TypeLiteral[True],
-        use_parquet: bool = False,
-        max_workers: Optional[int] = None,
-        statement_params: Optional[Dict[str, str]] = None,
-        _emit_ast: bool = False,
-    ) -> "polars.LazyFrame":
-        ...  # pragma: no cover
-
     @experimental(version="1.55.0")
     @df_collect_api_telemetry
     @publicapi
     def to_polars(
         self,
         *,
-        lazy: bool = False,
         use_parquet: bool = False,
         max_workers: Optional[int] = None,
         statement_params: Optional[Dict[str, str]] = None,
         _emit_ast: bool = False,
-    ) -> Union["polars.DataFrame", "polars.LazyFrame"]:
+    ) -> "polars.DataFrame":
         """
         Executes the query representing this DataFrame and returns the result
-        as a `polars DataFrame <https://docs.pola.rs/py-polars/html/reference/dataframe/index.html>`_,
-        or a `polars LazyFrame <https://docs.pola.rs/py-polars/html/reference/lazyframe/index.html>`_
-        when ``lazy=True``.
+        as a `Polars DataFrame <https://docs.pola.rs/py-polars/html/reference/dataframe/index.html>`_.
 
-        The transport is selected by ``(lazy, use_parquet)``:
+        The transport is selected by ``use_parquet``:
 
-        =====  ============  ============================================
-        lazy   use_parquet   Transport
-        =====  ============  ============================================
-        False  False         Arrow (default; full Snowflake type fidelity)
-        False  True          Parquet unload + eager parallel read
-        True   False         Parquet unload + lazy scan
-        True   True          Parquet unload + lazy scan
-        =====  ============  ============================================
+        ============  ============================================
+        use_parquet   Transport
+        ============  ============================================
+        False         Arrow (default; full Snowflake type fidelity)
+        True          Parquet unload + eager parallel read
+        ============  ============================================
 
         Usage Notes:
             - **Transport selection**:
-                - **Parquet** (``use_parquet=True`` or ``lazy=True``):
+                - **Parquet** (``use_parquet=True``):
                   Recommended when the result set is large and the type-fidelity
                   caveats are acceptable. Snowflake's ``COPY INTO`` splits the
                   result into multiple Parquet files that are opened and read
@@ -1443,21 +1411,15 @@ class DataFrame:
                   modest; for small or medium result sets the ``COPY INTO``
                   setup cost may outweigh the gain, making Arrow the more
                   efficient choice.
-                - **Arrow** (default, ``lazy=False, use_parquet=False``):
+                - **Arrow** (default, ``use_parquet=False``):
                   Streams result batches directly from the cursor without
                   staging to disk. Preserves full Snowflake type fidelity.
                   Use when type accuracy is required, or when the result set is
-                  small enough that the Parquet paths' ``COPY INTO`` overhead
+                  small enough that the Parquet path's ``COPY INTO`` overhead
                   is not justified.
-            - **Lazy evaluation** (``lazy=True``): ``COPY INTO`` runs
-              synchronously at call time; the Parquet scan and any downstream
-              Polars operations are deferred to ``.collect()``. Use when
-              Polars plan optimization — such as column projection or row-group
-              filtering — is desired. The ``use_parquet`` argument has no
-              effect when ``lazy=True``; the Parquet transport is always used.
             - **Parallelism tuning**: ``max_workers`` controls the thread pool
               for opening and reading staged Parquet files. Only applies to
-              the Parquet paths; ignored for the Arrow path. The default
+              the Parquet path; ignored for the Arrow path. The default
               (``None``) defers to
               :class:`~concurrent.futures.ThreadPoolExecutor`.
 
@@ -1466,31 +1428,25 @@ class DataFrame:
             >>> df = session.create_dataframe([[1, 2], [3, 4]], schema=["a", "b"])
             >>> df.to_polars().shape  # doctest: +SKIP
             (2, 2)
-            >>> lf = df.to_polars(lazy=True)  # doctest: +SKIP
-            >>> lf.collect().sort("A").to_dicts()  # doctest: +SKIP
-            [{'A': 1, 'B': 2}, {'A': 3, 'B': 4}]
 
         Args:
-            lazy: When ``True``, return a ``polars.LazyFrame`` and defer the
-                Parquet scan and downstream Polars operations until
-                ``.collect()``. Defaults to ``False``.
-            use_parquet: When ``True`` (and ``lazy=False``), unload the result
+            use_parquet: When ``True``, unload the result
                 to Parquet on the session stage and read the files back in
                 parallel. Can be faster than the Arrow path for large,
                 data-transfer-dominated workloads — especially in a stored
-                procedure — but subject to the type-fidelity limits below. Has
-                no effect when ``lazy=True``. Defaults to ``False``.
+                procedure — but subject to the type-fidelity limits below.
+                Defaults to ``False``.
             max_workers: Maximum number of threads for parallel stage-file
-                opens and reads. Only applies to the Parquet paths
-                (``use_parquet=True`` or ``lazy=True``). Defaults to ``None``.
+                opens and reads. Only applies to the Parquet path
+                (``use_parquet=True``). Defaults to ``None``.
             statement_params: Dictionary of statement level parameters to be
                 set while executing this action.
 
         Note:
             1. Requires ``polars>=1.0``.
 
-            2. The Parquet paths (``use_parquet=True`` or ``lazy=True``)
-            do not fully preserve Snowflake types because ``COPY INTO``
+            2. The Parquet path (``use_parquet=True``)
+            does not fully preserve Snowflake types because ``COPY INTO``
             has restrictions on Parquet unload:
 
                - ``TIMESTAMP_LTZ`` and ``TIMESTAMP_TZ`` columns cause the
@@ -1507,18 +1463,10 @@ class DataFrame:
         from snowflake.snowpark._internal.polars_backend import (
             arrow_eager as _arrow_eager,
             parquet_eager as _parquet_eager,
-            parquet_lazy as _parquet_lazy,
         )
 
         is_sproc = is_in_stored_procedure()
 
-        if lazy:
-            return _parquet_lazy(
-                self,
-                is_sproc=is_sproc,
-                statement_params=statement_params,
-                max_workers=max_workers,
-            )
         if use_parquet:
             return _parquet_eager(
                 self,

--- a/src/snowflake/snowpark/dataframe.py
+++ b/src/snowflake/snowpark/dataframe.py
@@ -8,6 +8,7 @@ import datetime
 import itertools
 import random
 import re
+import typing
 from collections import Counter
 from decimal import Decimal
 from functools import cached_property, reduce
@@ -1379,7 +1380,7 @@ class DataFrame:
     def to_polars(
         self,
         *,
-        use_parquet: bool = False,
+        transport: typing.Literal["arrow", "parquet"] = "arrow",
         max_workers: Optional[int] = None,
         statement_params: Optional[Dict[str, str]] = None,
     ) -> "polars.DataFrame":
@@ -1387,18 +1388,18 @@ class DataFrame:
         Executes the query representing this DataFrame and returns the result
         as a `Polars DataFrame <https://docs.pola.rs/py-polars/html/reference/dataframe/index.html>`_.
 
-        The transport is selected by ``use_parquet``:
+        The transport is selected by ``transport``:
 
-        ============  ============================================
-        use_parquet   Transport
-        ============  ============================================
-        False         Arrow (default; full Snowflake type fidelity)
-        True          Parquet unload + eager parallel read
-        ============  ============================================
+        ==========  ============================================
+        transport   Description
+        ==========  ============================================
+        "arrow"     Arrow (default; full Snowflake type fidelity)
+        "parquet"   Parquet unload + eager parallel read
+        ==========  ============================================
 
         Usage Notes:
             - **Transport selection**:
-                - **Parquet** (``use_parquet=True``):
+                - ``"parquet"``:
                   Recommended when the result set is large and the type-fidelity
                   caveats are acceptable. Snowflake's ``COPY INTO`` splits the
                   result into multiple Parquet files that are opened and read
@@ -1410,7 +1411,7 @@ class DataFrame:
                   modest; for small or medium result sets the ``COPY INTO``
                   setup cost may outweigh the gain, making Arrow the more
                   efficient choice.
-                - **Arrow** (default, ``use_parquet=False``):
+                - ``"arrow"`` (default):
                   Streams result batches directly from the cursor without
                   staging to disk. Preserves full Snowflake type fidelity.
                   Use when type accuracy is required, or when the result set is
@@ -1418,7 +1419,7 @@ class DataFrame:
                   is not justified.
             - **Parallelism tuning**: ``max_workers`` controls the thread pool
               for opening and reading staged Parquet files. Only applies to
-              the Parquet path; ignored for the Arrow path. The default
+              the ``"parquet"`` transport; ignored for ``"arrow"``. The default
               (``None``) defers to
               :class:`~concurrent.futures.ThreadPoolExecutor`.
 
@@ -1429,22 +1430,22 @@ class DataFrame:
             (2, 2)
 
         Args:
-            use_parquet: When ``True``, unload the result
-                to Parquet on the session stage and read the files back in
-                parallel. Can be faster than the Arrow path for large,
-                data-transfer-dominated workloads — especially in a stored
-                procedure — but subject to the type-fidelity limits below.
-                Defaults to ``False``.
+            transport: Either ``"arrow"`` (default) or ``"parquet"``. When
+                ``"parquet"``, unload the result to Parquet on the session
+                stage and read the files back in parallel. Can be faster than
+                the ``"arrow"`` transport for large, data-transfer-dominated
+                workloads — especially in a stored procedure — but subject to
+                the type-fidelity limits below.
             max_workers: Maximum number of threads for parallel stage-file
-                opens and reads. Only applies to the Parquet path
-                (``use_parquet=True``). Defaults to ``None``.
+                opens and reads. Only applies to the ``"parquet"`` transport
+                (``transport="parquet"``). Defaults to ``None``.
             statement_params: Dictionary of statement level parameters to be
                 set while executing this action.
 
         Note:
             1. Requires ``polars>=1.0``.
 
-            2. The Parquet path (``use_parquet=True``)
+            2. The ``"parquet"`` transport
             does not fully preserve Snowflake types because ``COPY INTO``
             has restrictions on Parquet unload:
 
@@ -1465,17 +1466,23 @@ class DataFrame:
         )
 
         is_sproc = is_in_stored_procedure()
+        normalized_transport = transport.strip().lower()
 
-        if use_parquet:
+        if normalized_transport == "parquet":
             return _parquet_eager(
                 self,
                 is_sproc=is_sproc,
                 statement_params=statement_params,
                 max_workers=max_workers,
             )
-        return _arrow_eager(
-            self,
-            statement_params=statement_params,
+        elif normalized_transport == "arrow":
+            return _arrow_eager(
+                self,
+                statement_params=statement_params,
+            )
+        raise ValueError(
+            f"Unsupported transport {transport!r} for to_polars(). "
+            'Expected "arrow" or "parquet".'
         )
 
     @df_api_usage

--- a/tests/integ/test_df_to_polars.py
+++ b/tests/integ/test_df_to_polars.py
@@ -1,0 +1,901 @@
+#!/usr/bin/env python3
+#
+# Copyright (c) 2012-2025 Snowflake Computing Inc. All rights reserved.
+#
+
+import uuid
+from datetime import date, datetime
+from decimal import Decimal
+from unittest import mock
+
+import pytest
+
+from snowflake.snowpark import Session
+from snowflake.snowpark.functions import col
+from snowflake.snowpark.types import DecimalType
+
+from tests.utils import TestData, Utils
+
+try:
+    import polars as pl
+
+    _polars_available = True
+except ImportError:
+    pl = None  # type: ignore[assignment]
+    _polars_available = False
+
+# Shorthand for tests that require a live Snowflake connection + Arrow support.
+_skip_local = pytest.mark.skipif(
+    "config.getoption('local_testing_mode', default=False)",
+    reason="arrow not fully supported by local testing.",
+)
+
+
+@pytest.fixture
+def _no_polars_required():
+    """Request this fixture to opt out of the polars-availability skip."""
+
+
+@pytest.fixture(autouse=True)
+def _require_polars(request):
+    """Skip tests that need polars when it is not installed.
+
+    Tests that mock polars or test the missing-dep path should request
+    the ``_no_polars_required`` fixture to opt out.
+    """
+    if not _polars_available and "_no_polars_required" not in request.fixturenames:
+        pytest.skip("polars not available")
+
+
+def polars_to_pydict(df: "pl.DataFrame") -> dict:
+    return df.to_arrow().to_pydict()
+
+
+# ---------------------------------------------------------------------------
+# Fixtures / helpers
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def local_session():
+    """Local-testing session — no Snowflake connection required."""
+    with Session.builder.config("local_testing", True).create() as s:
+        yield s
+
+
+# ---------------------------------------------------------------------------
+# Type correctness (eager)
+# ---------------------------------------------------------------------------
+
+
+@_skip_local
+@pytest.mark.parametrize(
+    "example,expected",
+    [
+        (TestData.integer1, {"A": [1, 2, 3]}),
+        (
+            TestData.null_data1,
+            {"A": [None, Decimal("2"), Decimal("1"), Decimal("3"), None]},
+        ),
+        (
+            TestData.double1,
+            {"A": [Decimal("1.111"), Decimal("2.222"), Decimal("3.333")]},
+        ),
+        (TestData.string1, {"A": ["test1", "test2", "test3"], "B": ["a", "b", "c"]}),
+        pytest.param(
+            TestData.array1,
+            {
+                "ARR1": ["[\n  1,\n  2,\n  3\n]", "[\n  6,\n  7,\n  8\n]"],
+                "ARR2": ["[\n  3,\n  4,\n  5\n]", "[\n  9,\n  0,\n  1\n]"],
+            },
+            id="semi-structured array",
+        ),
+        pytest.param(
+            TestData.object2,
+            {
+                "OBJ": [
+                    '{\n  "age": 21,\n  "name": "Joe",\n  "zip": 21021\n}',
+                    '{\n  "age": 26,\n  "name": "Jay",\n  "zip": 94021\n}',
+                ],
+                "K": ["age", "key"],
+                "V": [Decimal("0"), Decimal("0")],
+                "FLAG": [True, False],
+            },
+            id="semi-structured object",
+        ),
+        (
+            TestData.datetime_primitives2,
+            {
+                "TIMESTAMP": [
+                    datetime(9999, 12, 31, 0, 0, 0, 123456),
+                    datetime(1583, 1, 1, 23, 59, 59, 567890),
+                ]
+            },
+        ),
+        (
+            TestData.date1,
+            {
+                "A": [date(2020, 8, 1), date(2010, 12, 1)],
+                "B": [Decimal("1"), Decimal("2")],
+            },
+        ),
+    ],
+)
+def test_to_polars_type_correctness(session, example, expected):
+    assert polars_to_pydict(example(session).to_polars()) == expected
+
+
+@_skip_local
+def test_to_polars_decimal_precision(session):
+    data = [
+        [1111111111111111111, 222222222222222222],
+        [3333333333333333333, 444444444444444444],
+        [5555555555555555555, 666666666666666666],
+        [7777777777777777777, 888888888888888888],
+        [9223372036854775807, 111111111111111111],
+        [2222222222222222222, 333333333333333333],
+        [4444444444444444444, 555555555555555555],
+        [6666666666666666666, 777777777777777777],
+        [-9223372036854775808, 999999999999999999],
+    ]
+    df = session.create_dataframe(data, schema=["A", "B"]).select(
+        col("A").cast(DecimalType(38, 0)).alias("A"),
+        col("B").cast(DecimalType(18, 0)).alias("B"),
+    )
+    pa_df = df.to_polars().to_arrow()
+    assert str(pa_df.schema[0].type) == "decimal128(38, 0)"
+    assert str(pa_df.schema[1].type) == "int64"
+    assert [[int(x) for x in row.values()] for row in pa_df.to_pylist()] == data
+
+
+# ---------------------------------------------------------------------------
+# NULL handling
+# ---------------------------------------------------------------------------
+
+
+@_skip_local
+def test_to_polars_null_handling(session):
+    # Nullable integer column
+    col_values = (
+        session.create_dataframe([[0], [1], [None]], schema=["A"])
+        .to_polars()["A"]
+        .to_list()
+    )
+    assert col_values == [0, 1, None]
+
+    # All-null column
+    pl_df = session.create_dataframe([[None], [None], [None]], schema=["A"]).to_polars()
+    assert pl_df.height == 3
+    assert all(v is None for v in pl_df["A"].to_list())
+
+
+# ---------------------------------------------------------------------------
+# Eager path
+# ---------------------------------------------------------------------------
+
+
+@_skip_local
+def test_to_polars_eager_multi_batch(session):
+    """Exercises the pl.concat(parts) path when the result spans multiple Arrow batches."""
+    pl_df = session.range(100_000).to_polars()
+    assert isinstance(pl_df, pl.DataFrame)
+    assert pl_df.height == 100_000
+    assert pl_df.columns == ["ID"]
+
+
+@_skip_local
+def test_to_polars_empty_dataframe(session):
+    pl_df = (
+        session.create_dataframe([[1, 2]], schema=["A", "B"])
+        .filter(col("A") > 100)
+        .to_polars()
+    )
+    assert isinstance(pl_df, pl.DataFrame)
+    assert pl_df.height == 0
+    assert set(pl_df.columns) == {"A", "B"}
+
+
+@_skip_local
+def test_to_polars_timestamp_ltz_and_tz(session):
+    """TIMESTAMP_LTZ and TIMESTAMP_TZ survive the Arrow path as tz-aware datetimes."""
+    pl_df = session.sql(
+        "SELECT TO_TIMESTAMP_LTZ('2024-01-15 12:00:00 -0800') AS ts_ltz,"
+        "       TO_TIMESTAMP_TZ('2024-01-15 20:00:00 +0530')  AS ts_tz"
+    ).to_polars()
+    assert (
+        pl_df["TS_LTZ"][0] is not None and pl_df["TS_LTZ"].dtype.time_zone is not None
+    )
+    assert pl_df["TS_TZ"][0] is not None and pl_df["TS_TZ"].dtype.time_zone is not None
+
+
+@_skip_local
+def test_to_polars_eager_matches_to_arrow(session):
+    df = session.sql(
+        "SELECT 42::INT AS i, 3.14::FLOAT AS f, 'hello'::VARCHAR AS s,"
+        "       TRUE AS b, DATE '2024-01-01' AS d,"
+        "       TO_TIMESTAMP_NTZ('2024-01-01 12:00:00') AS t"
+    )
+    assert polars_to_pydict(df.to_polars()) == df.to_arrow().to_pydict()
+
+
+# ---------------------------------------------------------------------------
+# Lazy path
+# ---------------------------------------------------------------------------
+
+
+@_skip_local
+def test_to_polars_lazy_collect_matches_eager(session):
+    df = session.create_dataframe(
+        [[1, "a", 1.5], [2, "b", 2.5], [3, "c", 3.5]], schema=["A", "B", "C"]
+    )
+    lf = df.to_polars(lazy=True)
+    assert isinstance(lf, pl.LazyFrame)
+    assert df.to_polars().sort("A").equals(lf.collect().sort("A"))
+
+
+@_skip_local
+def test_to_polars_lazy_projection_pushdown(session):
+    """Projection on the returned LazyFrame yields correct columns/rows.
+
+    Under the current parquet-lazy implementation, projection pushdown
+    happens inside pl.scan_parquet at read time, not through a callback
+    to the Snowpark DataFrame. We assert the resulting column set + row
+    count rather than the specific plumbing.
+    """
+    df = session.create_dataframe(
+        [[i, str(i), i * 1.5] for i in range(20)], schema=["A", "B", "C"]
+    )
+    result = df.to_polars(lazy=True).select("A").collect()
+    assert result.columns == ["A"]
+    assert result.height == 20
+
+    result = df.to_polars(lazy=True).select("A", "B").collect()
+    assert set(result.columns) == {"A", "B"}
+    assert result.height == 20
+
+
+@_skip_local
+def test_to_polars_lazy_projection_pushdown_quoted_identifiers(session):
+    """Mixed-case quoted identifiers survive projection pushdown without being uppercased."""
+    result = (
+        session.sql('SELECT 1 AS "myInt", \'hello\' AS "myStr"')
+        .to_polars(lazy=True)
+        .select("myInt")
+        .collect()
+    )
+    assert result.columns == ["myInt"] and result.height == 1 and result[0, 0] == 1
+
+
+@_skip_local
+def test_to_polars_lazy_limit_pushdown(session):
+    df = session.create_dataframe([[i, str(i)] for i in range(50)], schema=["A", "B"])
+    assert df.to_polars(lazy=True).head(5).collect().height == 5
+
+
+@_skip_local
+def test_to_polars_lazy_returns_lazyframe(session):
+    """Lazy mode returns a polars.LazyFrame; collect() materializes correct data."""
+    df = session.create_dataframe([[1, 2], [3, 4]], schema=["A", "B"])
+    lf = df.to_polars(lazy=True)
+    assert isinstance(lf, pl.LazyFrame)
+    collected = lf.collect().sort("A")
+    assert collected.shape == (2, 2)
+    assert collected["A"].to_list() == [1, 3]
+    assert collected["B"].to_list() == [2, 4]
+
+
+@_skip_local
+def test_to_polars_statement_params(session):
+    """statement_params must reach Snowflake on every to_polars path,
+    including the raw-cursor Arrow path. Regression guard: earlier the Arrow
+    path forwarded the params only on the (rare) empty-batch fallback and
+    silently dropped them on the main query.
+
+    The ``query_history()`` context manager doubles as a check that the
+    raw-cursor Arrow path still triggers session-level query listeners.
+    """
+    df = session.create_dataframe([[1]], schema=["A"])
+
+    tag = "polars_integ_test_" + uuid.uuid4().hex[:8]
+    with session.query_history() as history:
+        result = df.to_polars(statement_params={"QUERY_TAG": tag})
+    assert isinstance(result, pl.DataFrame)
+    assert history.queries, "no queries captured by the query listener"
+    Utils.assert_executed_with_query_tag(session, tag)
+
+    tag_lazy = "polars_integ_test_lazy_" + uuid.uuid4().hex[:8]
+    with session.query_history() as history_lazy:
+        result_lazy = df.to_polars(
+            lazy=True, statement_params={"QUERY_TAG": tag_lazy}
+        ).collect()
+    assert isinstance(result_lazy, pl.DataFrame)
+    assert history_lazy.queries, "no queries captured on the lazy path"
+    Utils.assert_executed_with_query_tag(session, tag_lazy)
+
+
+# ---------------------------------------------------------------------------
+# use_parquet=True (eager parquet)
+# ---------------------------------------------------------------------------
+
+
+@_skip_local
+def test_to_polars_use_parquet_basic_types(session):
+    """Common primitive types round-trip through the eager Parquet path."""
+    df = session.sql(
+        "SELECT 42::INT AS i, 'hello'::VARCHAR AS s, TRUE AS b,"
+        "       DATE '2024-01-01' AS d"
+    )
+    pl_df = df.to_polars(use_parquet=True)
+    assert isinstance(pl_df, pl.DataFrame)
+    assert pl_df.height == 1
+    row = pl_df.to_dicts()[0]
+    assert row["I"] == 42
+    assert row["S"] == "hello"
+    assert row["B"] is True
+    assert row["D"] == date(2024, 1, 1)
+
+
+@_skip_local
+def test_to_polars_use_parquet_matches_arrow_shape(session):
+    """Eager Parquet and eager Arrow return the same shape on a non-trivial
+    dataset. Values are compared in a downcast-aware way: FLOAT is compared
+    at float32 precision on both sides."""
+    df = session.create_dataframe(
+        [[i, str(i), i * 1.5] for i in range(500)], schema=["ID", "S", "F"]
+    )
+    pq = df.to_polars(use_parquet=True)
+    arrow = df.to_polars()
+    assert pq.height == arrow.height == 500
+    assert set(pq.columns) == set(arrow.columns)
+    # FLOAT is downcast to float32 by the Parquet unload, so cast both sides
+    # before comparing to avoid a precision-driven false negative.
+    assert (
+        pq.sort("ID")["F"]
+        .cast(pl.Float32)
+        .equals(arrow.sort("ID")["F"].cast(pl.Float32))
+    )
+
+
+@_skip_local
+def test_to_polars_use_parquet_timestamp_ltz_raises(session):
+    """TIMESTAMP_LTZ / TIMESTAMP_TZ can't be unloaded to Parquet — locks in
+    the documented behavior so a future change to the doc or code is caught."""
+    df = session.sql("SELECT TO_TIMESTAMP_LTZ('2024-01-15 12:00:00 -0800') AS ts_ltz")
+    with pytest.raises(Exception, match="(?i)timestamp"):
+        df.to_polars(use_parquet=True)
+
+
+@_skip_local
+def test_to_polars_use_parquet_empty(session):
+    """Empty result from the Parquet path returns a schema-preserving DataFrame."""
+    pl_df = (
+        session.create_dataframe([[1, 2]], schema=["A", "B"])
+        .filter(col("A") > 100)
+        .to_polars(use_parquet=True)
+    )
+    assert isinstance(pl_df, pl.DataFrame)
+    assert pl_df.height == 0
+    assert set(pl_df.columns) == {"A", "B"}
+
+
+@_skip_local
+def test_to_polars_use_parquet_ignored_when_lazy(session):
+    """use_parquet=True with lazy=True returns a LazyFrame (parquet is always
+    used for lazy; passing use_parquet is a no-op, not an error)."""
+    df = session.create_dataframe([[1, 2], [3, 4]], schema=["A", "B"])
+    lf = df.to_polars(lazy=True, use_parquet=True)
+    assert isinstance(lf, pl.LazyFrame)
+    assert lf.collect().sort("A").shape == (2, 2)
+
+
+# ---------------------------------------------------------------------------
+# Predicate correctness — regression coverage
+#
+# Under the parquet-lazy implementation, predicates are applied by Polars on
+# top of scan_parquet; row-group pruning may or may not kick in depending on
+# clustering, but the collected result must always match the eager result.
+# These tests catch any regression where predicate application drops or
+# leaks rows.
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def _predicate_df(session):
+    """24-row dataset used across predicate/DML tests."""
+    rows = [
+        [i, i * 10, ["A", "B", "C", "D"][i % 4], round(i * 1.5, 1)] for i in range(24)
+    ]
+    return session.create_dataframe(rows, schema=["ID", "VAL", "CAT", "SCORE"])
+
+
+@_skip_local
+def test_to_polars_lazy_predicate_applied(_predicate_df):
+    """Simple filter: lazy result must match eager result."""
+    lf = _predicate_df.to_polars(lazy=True)
+    eager = _predicate_df.to_polars()
+    got = lf.filter(pl.col("VAL") > 100).collect().sort("ID")
+    want = eager.filter(pl.col("VAL") > 100).sort("ID")
+    assert got.equals(want)
+
+
+@_skip_local
+def test_to_polars_lazy_filter_then_limit_correctness(_predicate_df):
+    """lf.filter().limit(n) — must return up to n rows where the predicate holds.
+
+    Correctness rule: filter().limit(n) → up to n rows where predicate holds.
+    """
+    lf = _predicate_df.to_polars(lazy=True)
+    filtered = lf.filter(pl.col("VAL") > 100).collect()
+    limited = lf.filter(pl.col("VAL") > 100).head(3).collect()
+    assert limited.height <= 3
+    # Every returned row must satisfy the predicate.
+    assert (limited["VAL"] > 100).all()
+    # Every returned row must be a subset of the full filter result.
+    assert set(limited["ID"].to_list()).issubset(set(filtered["ID"].to_list()))
+
+
+@_skip_local
+def test_to_polars_lazy_limit_then_filter_differs(_predicate_df):
+    """lf.head(n).filter(pred) vs lf.filter(pred).head(n) — order matters.
+
+    Semantic contract:
+      lf.head(10).filter(VAL>100)  → 0 rows  (first 10 rows all have VAL≤90)
+      lf.filter(VAL>100).head(10)  → 10 rows (IDs 11-20)
+
+    Verify both actual row content (not just count) matches native Polars.
+    """
+    lf = _predicate_df.to_polars(lazy=True)
+    eager = _predicate_df.to_polars()
+
+    # Case: head(n).filter(p) — order-sensitive; limit must happen first.
+    lazy_limit_first = lf.head(10).filter(pl.col("VAL") > 100).collect().sort("ID")
+    eager_limit_first = eager.head(10).filter(pl.col("VAL") > 100).sort("ID")
+    assert lazy_limit_first.equals(eager_limit_first)
+    assert lazy_limit_first.height == 0  # swapped order would return 10
+
+    # Case: filter(p).head(n) — filter first, then slice.
+    lazy_filter_first = lf.filter(pl.col("VAL") > 100).head(10).collect().sort("ID")
+    eager_filter_first = eager.filter(pl.col("VAL") > 100).head(10).sort("ID")
+    assert lazy_filter_first.equals(eager_filter_first)
+    assert lazy_filter_first.height == 10
+
+    # Regression guard: the two orderings must not accidentally converge.
+    assert lazy_limit_first.height != lazy_filter_first.height
+
+
+@_skip_local
+@pytest.mark.parametrize(
+    "predicate_fn",
+    [
+        lambda: (pl.col("VAL") > 100) & (pl.col("CAT") == "A"),
+        lambda: (pl.col("VAL") < 50) | (pl.col("VAL") > 180),
+        lambda: pl.col("CAT").is_in(["B", "D"]),
+        lambda: pl.col("SCORE").is_between(10.0, 25.0),
+        lambda: pl.col("CAT") != "A",
+    ],
+    ids=["and", "or", "is_in", "between", "not_eq"],
+)
+def test_to_polars_lazy_predicate_variety(_predicate_df, predicate_fn):
+    """Every predicate type must round-trip through the lazy path correctly."""
+    predicate = predicate_fn()
+    lazy = _predicate_df.to_polars(lazy=True).filter(predicate).collect().sort("ID")
+    eager = _predicate_df.to_polars().filter(predicate).sort("ID")
+    assert lazy.equals(eager)
+
+
+# ---------------------------------------------------------------------------
+# DML operations Polars applies on top of the parquet scan
+#
+# group_by, agg, sort, join, distinct, window etc. are executed by the Polars
+# engine on the rows the scan produces. These tests verify the lazy result
+# matches the eager result for those operations.
+# ---------------------------------------------------------------------------
+
+
+@_skip_local
+def test_to_polars_lazy_group_by_agg(_predicate_df):
+    """group_by + agg on the lazy result matches the eager result."""
+    lazy = (
+        _predicate_df.to_polars(lazy=True)
+        .group_by("CAT")
+        .agg(
+            pl.col("VAL").sum().alias("TOTAL"),
+            pl.col("SCORE").mean().alias("AVG"),
+            pl.len().alias("CNT"),
+        )
+        .collect()
+        .sort("CAT")
+    )
+    eager = (
+        _predicate_df.to_polars()
+        .group_by("CAT")
+        .agg(
+            pl.col("VAL").sum().alias("TOTAL"),
+            pl.col("SCORE").mean().alias("AVG"),
+            pl.len().alias("CNT"),
+        )
+        .sort("CAT")
+    )
+    assert lazy.equals(eager)
+
+
+@_skip_local
+def test_to_polars_lazy_filter_then_group_by(_predicate_df):
+    """filter + group_by on the lazy result matches the eager result."""
+    lazy = (
+        _predicate_df.to_polars(lazy=True)
+        .filter(pl.col("VAL") > 50)
+        .group_by("CAT")
+        .agg(pl.len().alias("CNT"))
+        .collect()
+        .sort("CAT")
+    )
+    eager = (
+        _predicate_df.to_polars()
+        .filter(pl.col("VAL") > 50)
+        .group_by("CAT")
+        .agg(pl.len().alias("CNT"))
+        .sort("CAT")
+    )
+    assert lazy.equals(eager)
+
+
+@_skip_local
+def test_to_polars_lazy_group_by_then_filter_on_agg(_predicate_df):
+    """Filter on an aggregated column — Polars keeps this filter in its own plan
+    because the column doesn't exist in the scan source."""
+    lazy = (
+        _predicate_df.to_polars(lazy=True)
+        .group_by("CAT")
+        .agg(pl.col("VAL").sum().alias("TOTAL"))
+        .filter(pl.col("TOTAL") > 500)
+        .collect()
+        .sort("CAT")
+    )
+    eager = (
+        _predicate_df.to_polars()
+        .group_by("CAT")
+        .agg(pl.col("VAL").sum().alias("TOTAL"))
+        .filter(pl.col("TOTAL") > 500)
+        .sort("CAT")
+    )
+    assert lazy.equals(eager)
+
+
+@_skip_local
+def test_to_polars_lazy_window_over(_predicate_df):
+    """Window/partition_by via .over() — Polars applies these post-scan."""
+    lazy = (
+        _predicate_df.to_polars(lazy=True)
+        .with_columns(
+            pl.col("VAL").sum().over("CAT").alias("CAT_TOTAL"),
+            pl.col("VAL").rank().over("CAT").alias("RANK_IN_CAT"),
+        )
+        .collect()
+        .sort("ID")
+    )
+    eager = (
+        _predicate_df.to_polars()
+        .with_columns(
+            pl.col("VAL").sum().over("CAT").alias("CAT_TOTAL"),
+            pl.col("VAL").rank().over("CAT").alias("RANK_IN_CAT"),
+        )
+        .sort("ID")
+    )
+    assert lazy.equals(eager)
+
+
+@_skip_local
+def test_to_polars_lazy_unique_and_sort(_predicate_df):
+    """unique + sort are executed by Polars on scan output."""
+    lazy = (
+        _predicate_df.to_polars(lazy=True).select("CAT").unique().sort("CAT").collect()
+    )
+    eager = _predicate_df.to_polars().select("CAT").unique().sort("CAT")
+    assert lazy.equals(eager)
+
+
+@_skip_local
+def test_to_polars_lazy_join_between_lazyframes(session, _predicate_df):
+    """Two LazyFrames from separate Snowpark scans, joined by Polars."""
+    lookup = session.create_dataframe(
+        [["A", "alpha"], ["B", "beta"], ["C", "gamma"], ["D", "delta"]],
+        schema=["CAT", "LABEL"],
+    )
+    left = _predicate_df.to_polars(lazy=True)
+    right = lookup.to_polars(lazy=True)
+    lazy = left.join(right, on="CAT", how="inner").collect().sort("ID")
+
+    left_e = _predicate_df.to_polars()
+    right_e = lookup.to_polars()
+    eager = left_e.join(right_e, on="CAT", how="inner").sort("ID")
+    assert lazy.equals(eager)
+
+
+@_skip_local
+def test_to_polars_lazy_multi_step_chain(_predicate_df):
+    """Chain touching projection, filter, group_by, agg, filter, sort together."""
+    lazy = (
+        _predicate_df.to_polars(lazy=True)
+        .select("ID", "VAL", "CAT", "SCORE")
+        .filter(pl.col("VAL") > 20)
+        .group_by("CAT")
+        .agg(
+            pl.col("SCORE").mean().alias("AVG_SCORE"),
+            pl.col("VAL").max().alias("MAX_VAL"),
+        )
+        .filter(pl.col("AVG_SCORE") > 15.0)
+        .sort("CAT")
+        .collect()
+    )
+    eager = (
+        _predicate_df.to_polars()
+        .select("ID", "VAL", "CAT", "SCORE")
+        .filter(pl.col("VAL") > 20)
+        .group_by("CAT")
+        .agg(
+            pl.col("SCORE").mean().alias("AVG_SCORE"),
+            pl.col("VAL").max().alias("MAX_VAL"),
+        )
+        .filter(pl.col("AVG_SCORE") > 15.0)
+        .sort("CAT")
+    )
+    assert lazy.equals(eager)
+
+
+# ---------------------------------------------------------------------------
+# Column identifier casing (unquoted / quoted lowercase / quoted mixed-case)
+#
+# Snowflake folds unquoted identifiers to UPPERCASE, but preserves the exact
+# case of quoted identifiers. Both the Arrow output names and the Parquet
+# column names emitted by COPY INTO must respect this — Polars is
+# case-sensitive, so any mismatch would surface as ColumnNotFoundError on
+# downstream ops.
+# ---------------------------------------------------------------------------
+
+
+@_skip_local
+@pytest.mark.parametrize(
+    "sql, expected_columns, pushdown_col",
+    [
+        # unquoted → Snowflake folds to uppercase
+        ("SELECT 1 AS revenue, 'US' AS region", ["REVENUE", "REGION"], "REVENUE"),
+        # quoted lowercase → preserved
+        ('SELECT 1 AS "revenue", \'US\' AS "region"', ["revenue", "region"], "revenue"),
+        # quoted mixed-case → preserved
+        (
+            'SELECT 1 AS "myRevenue", \'US\' AS "myRegion"',
+            ["myRevenue", "myRegion"],
+            "myRevenue",
+        ),
+    ],
+    ids=["unquoted_folds_uppercase", "quoted_lowercase", "quoted_mixed_case"],
+)
+def test_to_polars_column_identifier_casing(
+    session, sql, expected_columns, pushdown_col
+):
+    """Casing is preserved end-to-end through eager Arrow, lazy Parquet scan,
+    and column-name-based projection on the LazyFrame."""
+    df = session.sql(sql)
+
+    eager = df.to_polars()
+    assert eager.columns == expected_columns
+
+    lf = df.to_polars(lazy=True)
+    assert lf.collect_schema().names() == expected_columns
+
+    # User selects by the Polars column name they see; that name must resolve
+    # against the Parquet schema COPY INTO produced.
+    projected = lf.select(pushdown_col).collect()
+    assert projected.columns == [pushdown_col] and projected.height == 1
+
+
+# ---------------------------------------------------------------------------
+# Missing dependency
+# ---------------------------------------------------------------------------
+
+
+def test_to_polars_raises_when_polars_missing(local_session, _no_polars_required):
+    df = local_session.create_dataframe([[1]], schema=["A"])
+    with mock.patch.dict("sys.modules", {"polars": None}):
+        with pytest.raises(ModuleNotFoundError, match="polars"):
+            df.to_polars()
+
+
+# ---------------------------------------------------------------------------
+# Unit tests for polars_backend helpers
+#
+# These cover branches that either can't be triggered without a stored proc
+# (SnowflakeFile-based opens), or that only fire on transient error paths
+# (close failures, empty result edge cases). They run with polars installed
+# but do not talk to Snowflake.
+# ---------------------------------------------------------------------------
+
+
+def test_open_stage_files_parallel_empty_paths_returns_empty():
+    from snowflake.snowpark._internal.polars_backend import (
+        _open_stage_files_parallel,
+    )
+
+    for is_sproc in (False, True):
+        for is_lazy in (False, True):
+            assert (
+                _open_stage_files_parallel(
+                    mock.MagicMock(), [], is_sproc=is_sproc, is_lazy=is_lazy
+                )
+                == []
+            )
+
+
+def test_open_stage_files_parallel_lazy_sproc_returns_handles():
+    """is_lazy=True + is_sproc=True: returns SnowflakeFile handles without reading."""
+    from snowflake.snowpark._internal.polars_backend import (
+        _open_stage_files_parallel,
+    )
+
+    fake_file = mock.MagicMock()
+    mock_module = mock.MagicMock()
+    mock_module.SnowflakeFile.open.return_value = fake_file
+    with mock.patch.dict("sys.modules", {"snowflake.snowpark.files": mock_module}):
+        result = _open_stage_files_parallel(
+            None,
+            ["@stg/a.parquet", "@stg/b.parquet"],
+            is_sproc=True,
+            is_lazy=True,
+        )
+
+    assert result == [fake_file, fake_file]
+    assert mock_module.SnowflakeFile.open.call_count == 2
+    mock_module.SnowflakeFile.open.assert_any_call(
+        "@stg/a.parquet", "rb", require_scoped_url=False
+    )
+
+
+def test_open_stage_files_parallel_eager_sproc_reads_and_closes():
+    """is_lazy=False + is_sproc=True: reads via pl.read_parquet inside a
+    ``with`` block so the file handle is closed after decode."""
+    from snowflake.snowpark._internal.polars_backend import (
+        _open_stage_files_parallel,
+    )
+
+    fake_file = mock.MagicMock()
+    fake_file.__enter__.return_value = fake_file  # `with f as x: x is f`
+    fake_frame = mock.MagicMock()
+    mock_files_module = mock.MagicMock()
+    mock_files_module.SnowflakeFile.open.return_value = fake_file
+    with mock.patch.dict(
+        "sys.modules", {"snowflake.snowpark.files": mock_files_module}
+    ), mock.patch("polars.read_parquet", return_value=fake_frame) as mock_read:
+        result = _open_stage_files_parallel(
+            None, ["@stg/a.parquet"], is_sproc=True, is_lazy=False
+        )
+
+    assert result == [fake_frame]
+    mock_read.assert_called_once_with(fake_file)
+    fake_file.__enter__.assert_called_once()
+    fake_file.__exit__.assert_called_once()
+
+
+def test_arrow_eager_empty_result_returns_schema_frame():
+    """When to_arrow_batches yields nothing, we fall back to a schema fetch."""
+    from snowflake.snowpark._internal import polars_backend
+
+    df = mock.MagicMock()
+    df.to_arrow_batches.return_value = iter([])
+    empty = mock.MagicMock(name="empty_pl_df")
+    with mock.patch.object(
+        polars_backend, "_empty_frame_from_schema", return_value=empty
+    ) as m:
+        result = polars_backend.arrow_eager(df, statement_params=None)
+    assert result is empty
+    m.assert_called_once()
+
+
+def test_arrow_eager_uses_to_arrow_batches():
+    """arrow_eager delegates entirely to to_arrow_batches (no raw cursor)."""
+    import pyarrow as pa
+    from snowflake.snowpark._internal import polars_backend
+
+    batch = pa.RecordBatch.from_pydict({"A": [1, 2], "B": [3, 4]})
+    df = mock.MagicMock()
+    df.to_arrow_batches.return_value = iter([batch])
+    result = polars_backend.arrow_eager(df, statement_params=None)
+    df.to_arrow_batches.assert_called_once()
+    assert result.shape == (2, 2)
+
+
+def test_parquet_eager_no_paths_returns_schema_frame():
+    """COPY INTO produced no files → schema-preserving empty frame."""
+    from snowflake.snowpark._internal import polars_backend
+
+    df = mock.MagicMock()
+    empty = mock.MagicMock(name="empty_pl_df")
+    with mock.patch.object(
+        polars_backend, "_copy_df_to_stage", return_value=[]
+    ), mock.patch.object(
+        polars_backend, "_empty_frame_from_schema", return_value=empty
+    ) as m:
+        result = polars_backend.parquet_eager(df)
+    assert result is empty
+    m.assert_called_once()
+
+
+def test_parquet_eager_no_frames_returns_schema_frame():
+    """Paths exist but all reads produce empty list → schema frame."""
+    from snowflake.snowpark._internal import polars_backend
+
+    df = mock.MagicMock()
+    empty = mock.MagicMock(name="empty_pl_df")
+    with mock.patch.object(
+        polars_backend, "_copy_df_to_stage", return_value=["@a.parquet"]
+    ), mock.patch.object(
+        polars_backend, "_open_stage_files_parallel", return_value=[]
+    ), mock.patch.object(
+        polars_backend, "_empty_frame_from_schema", return_value=empty
+    ) as m:
+        result = polars_backend.parquet_eager(df)
+    assert result is empty
+    m.assert_called_once()
+
+
+def test_parquet_lazy_no_paths_returns_empty_lazyframe():
+    """COPY INTO produced no files → empty LazyFrame with the DataFrame's schema."""
+    from snowflake.snowpark._internal import polars_backend
+
+    df = mock.MagicMock()
+    empty_df = mock.MagicMock()
+    empty_df.schema = {"A": pl.Int64}
+    with mock.patch.object(
+        polars_backend, "_copy_df_to_stage", return_value=[]
+    ), mock.patch.object(
+        polars_backend, "_empty_frame_from_schema", return_value=empty_df
+    ):
+        result = polars_backend.parquet_lazy(df)
+    assert isinstance(result, pl.LazyFrame)
+    assert result.collect_schema().names() == ["A"]
+
+
+def test_max_workers_forwarded_to_open_helper():
+    """max_workers passed to parquet_eager / parquet_lazy reaches _open_stage_files_parallel
+    with the correct is_lazy flag."""
+    from snowflake.snowpark._internal import polars_backend
+
+    df = mock.MagicMock()
+    fake_frame = mock.MagicMock()
+
+    # parquet_eager: is_lazy=False, max_workers forwarded
+    with mock.patch.object(
+        polars_backend, "_copy_df_to_stage", return_value=["@a.parquet"]
+    ), mock.patch.object(
+        polars_backend,
+        "_open_stage_files_parallel",
+        return_value=[fake_frame],
+    ) as mock_open:
+        polars_backend.parquet_eager(df, max_workers=4)
+    mock_open.assert_called_once()
+    assert mock_open.call_args.kwargs.get("max_workers") == 4
+    assert mock_open.call_args.kwargs.get("is_lazy") is False
+
+    # parquet_lazy: is_lazy=True, max_workers forwarded
+    with mock.patch.object(
+        polars_backend, "_copy_df_to_stage", return_value=["@a.parquet"]
+    ), mock.patch.object(
+        polars_backend, "_open_stage_files_parallel", return_value=[mock.MagicMock()]
+    ) as mock_open, mock.patch(
+        "polars.scan_parquet", return_value=mock.MagicMock()
+    ):
+        polars_backend.parquet_lazy(df, max_workers=4)
+    mock_open.assert_called_once()
+    assert mock_open.call_args.kwargs.get("max_workers") == 4
+    assert mock_open.call_args.kwargs.get("is_lazy") is True
+    assert mock_open.call_args.kwargs.get("max_workers") == 4
+
+
+@_skip_local
+def test_to_polars_max_workers_param(session):
+    """max_workers is accepted and produces correct results on the parquet paths."""
+    df = session.create_dataframe([[1, 2], [3, 4]], schema=["A", "B"])
+    pq = df.to_polars(use_parquet=True, max_workers=2)
+    assert isinstance(pq, pl.DataFrame) and pq.height == 2
+    lf = df.to_polars(lazy=True, max_workers=2)
+    assert isinstance(lf, pl.LazyFrame) and lf.collect().height == 2

--- a/tests/integ/test_df_to_polars.py
+++ b/tests/integ/test_df_to_polars.py
@@ -218,72 +218,6 @@ def test_to_polars_eager_matches_to_arrow(session):
     assert polars_to_pydict(df.to_polars()) == df.to_arrow().to_pydict()
 
 
-# ---------------------------------------------------------------------------
-# Lazy path
-# ---------------------------------------------------------------------------
-
-
-@_skip_local
-def test_to_polars_lazy_collect_matches_eager(session):
-    df = session.create_dataframe(
-        [[1, "a", 1.5], [2, "b", 2.5], [3, "c", 3.5]], schema=["A", "B", "C"]
-    )
-    lf = df.to_polars(lazy=True)
-    assert isinstance(lf, pl.LazyFrame)
-    assert df.to_polars().sort("A").equals(lf.collect().sort("A"))
-
-
-@_skip_local
-def test_to_polars_lazy_projection_pushdown(session):
-    """Projection on the returned LazyFrame yields correct columns/rows.
-
-    Under the current parquet-lazy implementation, projection pushdown
-    happens inside pl.scan_parquet at read time, not through a callback
-    to the Snowpark DataFrame. We assert the resulting column set + row
-    count rather than the specific plumbing.
-    """
-    df = session.create_dataframe(
-        [[i, str(i), i * 1.5] for i in range(20)], schema=["A", "B", "C"]
-    )
-    result = df.to_polars(lazy=True).select("A").collect()
-    assert result.columns == ["A"]
-    assert result.height == 20
-
-    result = df.to_polars(lazy=True).select("A", "B").collect()
-    assert set(result.columns) == {"A", "B"}
-    assert result.height == 20
-
-
-@_skip_local
-def test_to_polars_lazy_projection_pushdown_quoted_identifiers(session):
-    """Mixed-case quoted identifiers survive projection pushdown without being uppercased."""
-    result = (
-        session.sql('SELECT 1 AS "myInt", \'hello\' AS "myStr"')
-        .to_polars(lazy=True)
-        .select("myInt")
-        .collect()
-    )
-    assert result.columns == ["myInt"] and result.height == 1 and result[0, 0] == 1
-
-
-@_skip_local
-def test_to_polars_lazy_limit_pushdown(session):
-    df = session.create_dataframe([[i, str(i)] for i in range(50)], schema=["A", "B"])
-    assert df.to_polars(lazy=True).head(5).collect().height == 5
-
-
-@_skip_local
-def test_to_polars_lazy_returns_lazyframe(session):
-    """Lazy mode returns a polars.LazyFrame; collect() materializes correct data."""
-    df = session.create_dataframe([[1, 2], [3, 4]], schema=["A", "B"])
-    lf = df.to_polars(lazy=True)
-    assert isinstance(lf, pl.LazyFrame)
-    collected = lf.collect().sort("A")
-    assert collected.shape == (2, 2)
-    assert collected["A"].to_list() == [1, 3]
-    assert collected["B"].to_list() == [2, 4]
-
-
 @_skip_local
 def test_to_polars_statement_params(session):
     """statement_params must reach Snowflake on every to_polars path,
@@ -302,15 +236,6 @@ def test_to_polars_statement_params(session):
     assert isinstance(result, pl.DataFrame)
     assert history.queries, "no queries captured by the query listener"
     Utils.assert_executed_with_query_tag(session, tag)
-
-    tag_lazy = "polars_integ_test_lazy_" + uuid.uuid4().hex[:8]
-    with session.query_history() as history_lazy:
-        result_lazy = df.to_polars(
-            lazy=True, statement_params={"QUERY_TAG": tag_lazy}
-        ).collect()
-    assert isinstance(result_lazy, pl.DataFrame)
-    assert history_lazy.queries, "no queries captured on the lazy path"
-    Utils.assert_executed_with_query_tag(session, tag_lazy)
 
 
 # ---------------------------------------------------------------------------
@@ -378,271 +303,6 @@ def test_to_polars_use_parquet_empty(session):
     assert set(pl_df.columns) == {"A", "B"}
 
 
-@_skip_local
-def test_to_polars_use_parquet_ignored_when_lazy(session):
-    """use_parquet=True with lazy=True returns a LazyFrame (parquet is always
-    used for lazy; passing use_parquet is a no-op, not an error)."""
-    df = session.create_dataframe([[1, 2], [3, 4]], schema=["A", "B"])
-    lf = df.to_polars(lazy=True, use_parquet=True)
-    assert isinstance(lf, pl.LazyFrame)
-    assert lf.collect().sort("A").shape == (2, 2)
-
-
-# ---------------------------------------------------------------------------
-# Predicate correctness — regression coverage
-#
-# Under the parquet-lazy implementation, predicates are applied by Polars on
-# top of scan_parquet; row-group pruning may or may not kick in depending on
-# clustering, but the collected result must always match the eager result.
-# These tests catch any regression where predicate application drops or
-# leaks rows.
-# ---------------------------------------------------------------------------
-
-
-@pytest.fixture(scope="module")
-def _predicate_df(session):
-    """24-row dataset used across predicate/DML tests."""
-    rows = [
-        [i, i * 10, ["A", "B", "C", "D"][i % 4], round(i * 1.5, 1)] for i in range(24)
-    ]
-    return session.create_dataframe(rows, schema=["ID", "VAL", "CAT", "SCORE"])
-
-
-@_skip_local
-def test_to_polars_lazy_predicate_applied(_predicate_df):
-    """Simple filter: lazy result must match eager result."""
-    lf = _predicate_df.to_polars(lazy=True)
-    eager = _predicate_df.to_polars()
-    got = lf.filter(pl.col("VAL") > 100).collect().sort("ID")
-    want = eager.filter(pl.col("VAL") > 100).sort("ID")
-    assert got.equals(want)
-
-
-@_skip_local
-def test_to_polars_lazy_filter_then_limit_correctness(_predicate_df):
-    """lf.filter().limit(n) — must return up to n rows where the predicate holds.
-
-    Correctness rule: filter().limit(n) → up to n rows where predicate holds.
-    """
-    lf = _predicate_df.to_polars(lazy=True)
-    filtered = lf.filter(pl.col("VAL") > 100).collect()
-    limited = lf.filter(pl.col("VAL") > 100).head(3).collect()
-    assert limited.height <= 3
-    # Every returned row must satisfy the predicate.
-    assert (limited["VAL"] > 100).all()
-    # Every returned row must be a subset of the full filter result.
-    assert set(limited["ID"].to_list()).issubset(set(filtered["ID"].to_list()))
-
-
-@_skip_local
-def test_to_polars_lazy_limit_then_filter_differs(_predicate_df):
-    """lf.head(n).filter(pred) vs lf.filter(pred).head(n) — order matters.
-
-    Semantic contract:
-      lf.head(10).filter(VAL>100)  → 0 rows  (first 10 rows all have VAL≤90)
-      lf.filter(VAL>100).head(10)  → 10 rows (IDs 11-20)
-
-    Verify both actual row content (not just count) matches native Polars.
-    """
-    lf = _predicate_df.to_polars(lazy=True)
-    eager = _predicate_df.to_polars()
-
-    # Case: head(n).filter(p) — order-sensitive; limit must happen first.
-    lazy_limit_first = lf.head(10).filter(pl.col("VAL") > 100).collect().sort("ID")
-    eager_limit_first = eager.head(10).filter(pl.col("VAL") > 100).sort("ID")
-    assert lazy_limit_first.equals(eager_limit_first)
-    assert lazy_limit_first.height == 0  # swapped order would return 10
-
-    # Case: filter(p).head(n) — filter first, then slice.
-    lazy_filter_first = lf.filter(pl.col("VAL") > 100).head(10).collect().sort("ID")
-    eager_filter_first = eager.filter(pl.col("VAL") > 100).head(10).sort("ID")
-    assert lazy_filter_first.equals(eager_filter_first)
-    assert lazy_filter_first.height == 10
-
-    # Regression guard: the two orderings must not accidentally converge.
-    assert lazy_limit_first.height != lazy_filter_first.height
-
-
-@_skip_local
-@pytest.mark.parametrize(
-    "predicate_fn",
-    [
-        lambda: (pl.col("VAL") > 100) & (pl.col("CAT") == "A"),
-        lambda: (pl.col("VAL") < 50) | (pl.col("VAL") > 180),
-        lambda: pl.col("CAT").is_in(["B", "D"]),
-        lambda: pl.col("SCORE").is_between(10.0, 25.0),
-        lambda: pl.col("CAT") != "A",
-    ],
-    ids=["and", "or", "is_in", "between", "not_eq"],
-)
-def test_to_polars_lazy_predicate_variety(_predicate_df, predicate_fn):
-    """Every predicate type must round-trip through the lazy path correctly."""
-    predicate = predicate_fn()
-    lazy = _predicate_df.to_polars(lazy=True).filter(predicate).collect().sort("ID")
-    eager = _predicate_df.to_polars().filter(predicate).sort("ID")
-    assert lazy.equals(eager)
-
-
-# ---------------------------------------------------------------------------
-# DML operations Polars applies on top of the parquet scan
-#
-# group_by, agg, sort, join, distinct, window etc. are executed by the Polars
-# engine on the rows the scan produces. These tests verify the lazy result
-# matches the eager result for those operations.
-# ---------------------------------------------------------------------------
-
-
-@_skip_local
-def test_to_polars_lazy_group_by_agg(_predicate_df):
-    """group_by + agg on the lazy result matches the eager result."""
-    lazy = (
-        _predicate_df.to_polars(lazy=True)
-        .group_by("CAT")
-        .agg(
-            pl.col("VAL").sum().alias("TOTAL"),
-            pl.col("SCORE").mean().alias("AVG"),
-            pl.len().alias("CNT"),
-        )
-        .collect()
-        .sort("CAT")
-    )
-    eager = (
-        _predicate_df.to_polars()
-        .group_by("CAT")
-        .agg(
-            pl.col("VAL").sum().alias("TOTAL"),
-            pl.col("SCORE").mean().alias("AVG"),
-            pl.len().alias("CNT"),
-        )
-        .sort("CAT")
-    )
-    assert lazy.equals(eager)
-
-
-@_skip_local
-def test_to_polars_lazy_filter_then_group_by(_predicate_df):
-    """filter + group_by on the lazy result matches the eager result."""
-    lazy = (
-        _predicate_df.to_polars(lazy=True)
-        .filter(pl.col("VAL") > 50)
-        .group_by("CAT")
-        .agg(pl.len().alias("CNT"))
-        .collect()
-        .sort("CAT")
-    )
-    eager = (
-        _predicate_df.to_polars()
-        .filter(pl.col("VAL") > 50)
-        .group_by("CAT")
-        .agg(pl.len().alias("CNT"))
-        .sort("CAT")
-    )
-    assert lazy.equals(eager)
-
-
-@_skip_local
-def test_to_polars_lazy_group_by_then_filter_on_agg(_predicate_df):
-    """Filter on an aggregated column — Polars keeps this filter in its own plan
-    because the column doesn't exist in the scan source."""
-    lazy = (
-        _predicate_df.to_polars(lazy=True)
-        .group_by("CAT")
-        .agg(pl.col("VAL").sum().alias("TOTAL"))
-        .filter(pl.col("TOTAL") > 500)
-        .collect()
-        .sort("CAT")
-    )
-    eager = (
-        _predicate_df.to_polars()
-        .group_by("CAT")
-        .agg(pl.col("VAL").sum().alias("TOTAL"))
-        .filter(pl.col("TOTAL") > 500)
-        .sort("CAT")
-    )
-    assert lazy.equals(eager)
-
-
-@_skip_local
-def test_to_polars_lazy_window_over(_predicate_df):
-    """Window/partition_by via .over() — Polars applies these post-scan."""
-    lazy = (
-        _predicate_df.to_polars(lazy=True)
-        .with_columns(
-            pl.col("VAL").sum().over("CAT").alias("CAT_TOTAL"),
-            pl.col("VAL").rank().over("CAT").alias("RANK_IN_CAT"),
-        )
-        .collect()
-        .sort("ID")
-    )
-    eager = (
-        _predicate_df.to_polars()
-        .with_columns(
-            pl.col("VAL").sum().over("CAT").alias("CAT_TOTAL"),
-            pl.col("VAL").rank().over("CAT").alias("RANK_IN_CAT"),
-        )
-        .sort("ID")
-    )
-    assert lazy.equals(eager)
-
-
-@_skip_local
-def test_to_polars_lazy_unique_and_sort(_predicate_df):
-    """unique + sort are executed by Polars on scan output."""
-    lazy = (
-        _predicate_df.to_polars(lazy=True).select("CAT").unique().sort("CAT").collect()
-    )
-    eager = _predicate_df.to_polars().select("CAT").unique().sort("CAT")
-    assert lazy.equals(eager)
-
-
-@_skip_local
-def test_to_polars_lazy_join_between_lazyframes(session, _predicate_df):
-    """Two LazyFrames from separate Snowpark scans, joined by Polars."""
-    lookup = session.create_dataframe(
-        [["A", "alpha"], ["B", "beta"], ["C", "gamma"], ["D", "delta"]],
-        schema=["CAT", "LABEL"],
-    )
-    left = _predicate_df.to_polars(lazy=True)
-    right = lookup.to_polars(lazy=True)
-    lazy = left.join(right, on="CAT", how="inner").collect().sort("ID")
-
-    left_e = _predicate_df.to_polars()
-    right_e = lookup.to_polars()
-    eager = left_e.join(right_e, on="CAT", how="inner").sort("ID")
-    assert lazy.equals(eager)
-
-
-@_skip_local
-def test_to_polars_lazy_multi_step_chain(_predicate_df):
-    """Chain touching projection, filter, group_by, agg, filter, sort together."""
-    lazy = (
-        _predicate_df.to_polars(lazy=True)
-        .select("ID", "VAL", "CAT", "SCORE")
-        .filter(pl.col("VAL") > 20)
-        .group_by("CAT")
-        .agg(
-            pl.col("SCORE").mean().alias("AVG_SCORE"),
-            pl.col("VAL").max().alias("MAX_VAL"),
-        )
-        .filter(pl.col("AVG_SCORE") > 15.0)
-        .sort("CAT")
-        .collect()
-    )
-    eager = (
-        _predicate_df.to_polars()
-        .select("ID", "VAL", "CAT", "SCORE")
-        .filter(pl.col("VAL") > 20)
-        .group_by("CAT")
-        .agg(
-            pl.col("SCORE").mean().alias("AVG_SCORE"),
-            pl.col("VAL").max().alias("MAX_VAL"),
-        )
-        .filter(pl.col("AVG_SCORE") > 15.0)
-        .sort("CAT")
-    )
-    assert lazy.equals(eager)
-
-
 # ---------------------------------------------------------------------------
 # Column identifier casing (unquoted / quoted lowercase / quoted mixed-case)
 #
@@ -674,19 +334,19 @@ def test_to_polars_lazy_multi_step_chain(_predicate_df):
 def test_to_polars_column_identifier_casing(
     session, sql, expected_columns, pushdown_col
 ):
-    """Casing is preserved end-to-end through eager Arrow, lazy Parquet scan,
-    and column-name-based projection on the LazyFrame."""
+    """Casing is preserved end-to-end through eager Arrow and eager Parquet,
+    and column-name-based selection on the Parquet result."""
     df = session.sql(sql)
 
     eager = df.to_polars()
     assert eager.columns == expected_columns
 
-    lf = df.to_polars(lazy=True)
-    assert lf.collect_schema().names() == expected_columns
+    pq = df.to_polars(use_parquet=True)
+    assert pq.columns == expected_columns
 
     # User selects by the Polars column name they see; that name must resolve
     # against the Parquet schema COPY INTO produced.
-    projected = lf.select(pushdown_col).collect()
+    projected = pq.select(pushdown_col)
     assert projected.columns == [pushdown_col] and projected.height == 1
 
 
@@ -718,42 +378,12 @@ def test_open_stage_files_parallel_empty_paths_returns_empty():
     )
 
     for is_sproc in (False, True):
-        for is_lazy in (False, True):
-            assert (
-                _open_stage_files_parallel(
-                    mock.MagicMock(), [], is_sproc=is_sproc, is_lazy=is_lazy
-                )
-                == []
-            )
-
-
-def test_open_stage_files_parallel_lazy_sproc_returns_handles():
-    """is_lazy=True + is_sproc=True: returns SnowflakeFile handles without reading."""
-    from snowflake.snowpark._internal.polars_backend import (
-        _open_stage_files_parallel,
-    )
-
-    fake_file = mock.MagicMock()
-    mock_module = mock.MagicMock()
-    mock_module.SnowflakeFile.open.return_value = fake_file
-    with mock.patch.dict("sys.modules", {"snowflake.snowpark.files": mock_module}):
-        result = _open_stage_files_parallel(
-            None,
-            ["@stg/a.parquet", "@stg/b.parquet"],
-            is_sproc=True,
-            is_lazy=True,
-        )
-
-    assert result == [fake_file, fake_file]
-    assert mock_module.SnowflakeFile.open.call_count == 2
-    mock_module.SnowflakeFile.open.assert_any_call(
-        "@stg/a.parquet", "rb", require_scoped_url=False
-    )
+        assert _open_stage_files_parallel(mock.MagicMock(), [], is_sproc=is_sproc) == []
 
 
 def test_open_stage_files_parallel_eager_sproc_reads_and_closes():
-    """is_lazy=False + is_sproc=True: reads via pl.read_parquet inside a
-    ``with`` block so the file handle is closed after decode."""
+    """is_sproc=True: reads via pl.read_parquet inside a ``with`` block so the
+    file handle is closed after decode."""
     from snowflake.snowpark._internal.polars_backend import (
         _open_stage_files_parallel,
     )
@@ -766,9 +396,7 @@ def test_open_stage_files_parallel_eager_sproc_reads_and_closes():
     with mock.patch.dict(
         "sys.modules", {"snowflake.snowpark.files": mock_files_module}
     ), mock.patch("polars.read_parquet", return_value=fake_frame) as mock_read:
-        result = _open_stage_files_parallel(
-            None, ["@stg/a.parquet"], is_sproc=True, is_lazy=False
-        )
+        result = _open_stage_files_parallel(None, ["@stg/a.parquet"], is_sproc=True)
 
     assert result == [fake_frame]
     mock_read.assert_called_once_with(fake_file)
@@ -838,32 +466,13 @@ def test_parquet_eager_no_frames_returns_schema_frame():
     m.assert_called_once()
 
 
-def test_parquet_lazy_no_paths_returns_empty_lazyframe():
-    """COPY INTO produced no files → empty LazyFrame with the DataFrame's schema."""
-    from snowflake.snowpark._internal import polars_backend
-
-    df = mock.MagicMock()
-    empty_df = mock.MagicMock()
-    empty_df.schema = {"A": pl.Int64}
-    with mock.patch.object(
-        polars_backend, "_copy_df_to_stage", return_value=[]
-    ), mock.patch.object(
-        polars_backend, "_empty_frame_from_schema", return_value=empty_df
-    ):
-        result = polars_backend.parquet_lazy(df)
-    assert isinstance(result, pl.LazyFrame)
-    assert result.collect_schema().names() == ["A"]
-
-
 def test_max_workers_forwarded_to_open_helper():
-    """max_workers passed to parquet_eager / parquet_lazy reaches _open_stage_files_parallel
-    with the correct is_lazy flag."""
+    """max_workers passed to parquet_eager reaches _open_stage_files_parallel."""
     from snowflake.snowpark._internal import polars_backend
 
     df = mock.MagicMock()
     fake_frame = mock.MagicMock()
 
-    # parquet_eager: is_lazy=False, max_workers forwarded
     with mock.patch.object(
         polars_backend, "_copy_df_to_stage", return_value=["@a.parquet"]
     ), mock.patch.object(
@@ -874,28 +483,11 @@ def test_max_workers_forwarded_to_open_helper():
         polars_backend.parquet_eager(df, max_workers=4)
     mock_open.assert_called_once()
     assert mock_open.call_args.kwargs.get("max_workers") == 4
-    assert mock_open.call_args.kwargs.get("is_lazy") is False
-
-    # parquet_lazy: is_lazy=True, max_workers forwarded
-    with mock.patch.object(
-        polars_backend, "_copy_df_to_stage", return_value=["@a.parquet"]
-    ), mock.patch.object(
-        polars_backend, "_open_stage_files_parallel", return_value=[mock.MagicMock()]
-    ) as mock_open, mock.patch(
-        "polars.scan_parquet", return_value=mock.MagicMock()
-    ):
-        polars_backend.parquet_lazy(df, max_workers=4)
-    mock_open.assert_called_once()
-    assert mock_open.call_args.kwargs.get("max_workers") == 4
-    assert mock_open.call_args.kwargs.get("is_lazy") is True
-    assert mock_open.call_args.kwargs.get("max_workers") == 4
 
 
 @_skip_local
 def test_to_polars_max_workers_param(session):
-    """max_workers is accepted and produces correct results on the parquet paths."""
+    """max_workers is accepted and produces correct results on the parquet path."""
     df = session.create_dataframe([[1, 2], [3, 4]], schema=["A", "B"])
     pq = df.to_polars(use_parquet=True, max_workers=2)
     assert isinstance(pq, pl.DataFrame) and pq.height == 2
-    lf = df.to_polars(lazy=True, max_workers=2)
-    assert isinstance(lf, pl.LazyFrame) and lf.collect().height == 2

--- a/tests/integ/test_df_to_polars.py
+++ b/tests/integ/test_df_to_polars.py
@@ -239,18 +239,18 @@ def test_to_polars_statement_params(session):
 
 
 # ---------------------------------------------------------------------------
-# use_parquet=True (eager parquet)
+# transport="parquet" (eager parquet)
 # ---------------------------------------------------------------------------
 
 
 @_skip_local
-def test_to_polars_use_parquet_basic_types(session):
+def test_to_polars_transport_parquet_basic_types(session):
     """Common primitive types round-trip through the eager Parquet path."""
     df = session.sql(
         "SELECT 42::INT AS i, 'hello'::VARCHAR AS s, TRUE AS b,"
         "       DATE '2024-01-01' AS d"
     )
-    pl_df = df.to_polars(use_parquet=True)
+    pl_df = df.to_polars(transport="parquet")
     assert isinstance(pl_df, pl.DataFrame)
     assert pl_df.height == 1
     row = pl_df.to_dicts()[0]
@@ -261,14 +261,14 @@ def test_to_polars_use_parquet_basic_types(session):
 
 
 @_skip_local
-def test_to_polars_use_parquet_matches_arrow_shape(session):
+def test_to_polars_transport_parquet_matches_arrow_shape(session):
     """Eager Parquet and eager Arrow return the same shape on a non-trivial
     dataset. Values are compared in a downcast-aware way: FLOAT is compared
     at float32 precision on both sides."""
     df = session.create_dataframe(
         [[i, str(i), i * 1.5] for i in range(500)], schema=["ID", "S", "F"]
     )
-    pq = df.to_polars(use_parquet=True)
+    pq = df.to_polars(transport="parquet")
     arrow = df.to_polars()
     assert pq.height == arrow.height == 500
     assert set(pq.columns) == set(arrow.columns)
@@ -282,21 +282,21 @@ def test_to_polars_use_parquet_matches_arrow_shape(session):
 
 
 @_skip_local
-def test_to_polars_use_parquet_timestamp_ltz_raises(session):
+def test_to_polars_transport_parquet_timestamp_ltz_raises(session):
     """TIMESTAMP_LTZ / TIMESTAMP_TZ can't be unloaded to Parquet — locks in
     the documented behavior so a future change to the doc or code is caught."""
     df = session.sql("SELECT TO_TIMESTAMP_LTZ('2024-01-15 12:00:00 -0800') AS ts_ltz")
     with pytest.raises(Exception, match="(?i)timestamp"):
-        df.to_polars(use_parquet=True)
+        df.to_polars(transport="parquet")
 
 
 @_skip_local
-def test_to_polars_use_parquet_empty(session):
+def test_to_polars_transport_parquet_empty(session):
     """Empty result from the Parquet path returns a schema-preserving DataFrame."""
     pl_df = (
         session.create_dataframe([[1, 2]], schema=["A", "B"])
         .filter(col("A") > 100)
-        .to_polars(use_parquet=True)
+        .to_polars(transport="parquet")
     )
     assert isinstance(pl_df, pl.DataFrame)
     assert pl_df.height == 0
@@ -341,7 +341,7 @@ def test_to_polars_column_identifier_casing(
     eager = df.to_polars()
     assert eager.columns == expected_columns
 
-    pq = df.to_polars(use_parquet=True)
+    pq = df.to_polars(transport="parquet")
     assert pq.columns == expected_columns
 
     # User selects by the Polars column name they see; that name must resolve
@@ -489,5 +489,5 @@ def test_max_workers_forwarded_to_open_helper():
 def test_to_polars_max_workers_param(session):
     """max_workers is accepted and produces correct results on the parquet path."""
     df = session.create_dataframe([[1, 2], [3, 4]], schema=["A", "B"])
-    pq = df.to_polars(use_parquet=True, max_workers=2)
+    pq = df.to_polars(transport="parquet", max_workers=2)
     assert isinstance(pq, pl.DataFrame) and pq.height == 2


### PR DESCRIPTION
<!---
Please answer these questions before creating your pull request. Thanks!
--->

1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   <!---
   In this section, please add a Snowflake Jira issue number.

   Note that if a corresponding GitHub issue exists, you should still include
   the Snowflake Jira issue number. For example, for GitHub issue
   https://github.com/snowflakedb/snowpark-python/issues/1400, you should
   add "SNOW-1335071" here.
    --->

   Fixes SNOW-3472759

2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
      - [x] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.
   - [x] I acknowledge that I have ensured my changes to be thread-safe. Follow the link for more information: [Thread-safe Developer Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#thread-safe-development)
   - [x] If adding any arguments to public Snowpark APIs or creating new public Snowpark APIs, I acknowledge that I have ensured my changes include AST support. Follow the link for more information: [AST Support Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#ast-abstract-syntax-tree-support-in-snowpark)

3. Please describe how your code solves the related issue.

   Please write a short description of how your code change solves the related issue.

This PR adds DataFrame.to_polars() to enable direct conversion from a Snowpark DataFrame to a Polars eager DataFrame. Cherry-picked from https://github.com/snowflakedb/snowpark-python/pull/4288 and removed LazyFrame implementation. LazyFrame will be a follow-up work upon remote data pruning becoming available.

- Finalized benchmark evaluation: https://docs.google.com/document/d/1jABNlY-zNEMvQZKGg-wKdwu4r7-XpxIGnWE50Vjxiyg/edit?usp=sharing
- Complementary Design doc: https://docs.google.com/document/d/1FKeSB5K9HIHG-aQwcP_2oPRmT7Pd4hcj03l8tictEPM/edit?usp=sharing
- Tests passed on sproc (params1 `test_df_`): https://buildkite.com/snowflake/snowflake--snowpark-python-sp-integ-tests/builds/246/tests?tags=new_failure%3A%21true%2Cinconclusive%3A%21true&query=test_python_sp_integ_dataframe


On an XL warehouse:
Env | Size | DF (default arrow) | DF (use_parquet)
-- | -- | -- | --
local | 100,000 | 4.01s | 2.50s
local | 1,000,000 | 7.60s | 6.81s
local | 10,000,000 | 21.13s | 10.86s
sproc | 100,000 | 2.23s | 1.56s
sproc | 1,000,000 | 7.12s | 4.54s
sproc | 10,000,000 | 12.63s | 4.20s
