### PR TITLE
SNOW-3898656: XML perf optimization to expose numWorkers option (stacked 2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Added interval type support for Python UDFs and stored procedures. Use `datetime.timedelta` as the type annotation for day-time interval (`DayTimeIntervalType`) parameters and return values, and `YearMonthInterval` (a type annotation sentinel from `snowflake.snowpark.types`) for year-month interval (`YearMonthIntervalType`) parameters and return values.
 
 - Added a `useVariantProjection` option to `DataFrameReader.xml` that speeds up XML ingestion. The default is `False`; setting it to `True` requires `cacheResult` to also be `True` (the default).
+- Added a `numWorkers` option to `DataFrameReader.xml` for reads that specify `rowTag`, capping how many parallel workers a file is split across (per file, not in total; default `16`, previously a hardcoded cap of `16`).
 
 ## 1.54.0 (2026-07-29)
 

--- a/src/snowflake/snowpark/_internal/analyzer/snowflake_plan.py
+++ b/src/snowflake/snowpark/_internal/analyzer/snowflake_plan.py
@@ -150,6 +150,28 @@ from collections.abc import Iterable
 
 _logger = getLogger(__name__)
 
+# Default for numWorkers.
+# TODO SNOW-1983360: revisit once the UDTF scalability issue is resolved.
+DEFAULT_MAX_WORKERS: int = 16
+
+
+def _positive_int_option(options: Dict[str, Any], name: str, default: int) -> int:
+    """Read a positive-integer reader option, rejecting values that would produce a
+    degenerate work split (no workers at all, or a division by zero)."""
+    if name not in options:
+        return default
+    try:
+        value = int(options[name])
+    except (TypeError, ValueError):
+        raise ValueError(
+            f"Invalid value for option {name}: {options[name]!r}. Must be a positive integer."
+        )
+    if value < 1:
+        raise ValueError(
+            f"Invalid value for option {name}: {value}. Must be a positive integer."
+        )
+    return value
+
 
 class SnowflakePlan(LogicalPlan):
     class Decorator:
@@ -1864,13 +1886,12 @@ class SnowflakePlanBuilder:
                 f"Invalid mode: {mode}. Must be one of PERMISSIVE, DROPMALFORMED, FAILFAST."
             )
 
-        # TODO SNOW-1983360: make it an configurable option once the UDTF scalability issue is resolved.
-        # Currently it's capped at 16.
+        max_workers = _positive_int_option(options, "NUMWORKERS", DEFAULT_MAX_WORKERS)
         try:
             file_size = int(self.session.sql(f"ls {file_path}", _emit_ast=False).collect(_emit_ast=False)[0]["size"])  # type: ignore
         except IndexError:
             raise ValueError(f"{file_path} does not exist")
-        num_workers = min(16, file_size // DEFAULT_CHUNK_SIZE + 1)
+        num_workers = min(max_workers, file_size // DEFAULT_CHUNK_SIZE + 1)
 
         # Create a range from 0 to N-1
         df = self.session.range(num_workers).to_df(worker_column_name)

--- a/src/snowflake/snowpark/dataframe_reader.py
+++ b/src/snowflake/snowpark/dataframe_reader.py
@@ -1319,6 +1319,11 @@ class DataFrameReader:
                 Rows that do not match the XSD schema will be considered corrupt records and handled according to
                 the specified ``mode`` option.
 
+              + ``numWorkers``: The maximum number of parallel workers used to read the file. The default value is ``16``.
+                The file is split into at most this many byte ranges, each read by one worker. This is a **per-file**
+                cap, not a total: when reading N files, the number of workers scales with N rather than being
+                limited to ``numWorkers`` overall.
+
               + ``cacheResult``: Whether to cache the result DataFrame of the XML reader to a temporary table after calling :meth:`xml`.
                 When set to ``True`` (default), the result is cached and all subsequent operations on the DataFrame are performed on the cached data.
                 This means the actual computation occurs before :meth:`DataFrame.collect` is called.

--- a/tests/integ/test_xml_reader_row_tag.py
+++ b/tests/integ/test_xml_reader_row_tag.py
@@ -1380,3 +1380,33 @@ def test_read_xml_variant_projection_with_schema_and_dropmalformed(
     assert "Frank" not in names
     for r in result:
         assert r["value"] is not None
+
+
+#
+# Byte-range worker count: the numWorkers option.
+#
+
+
+@pytest.mark.parametrize("num_workers", [1, 16, 32])
+def test_read_xml_num_workers_parity(session, num_workers):
+    """How many workers a file is split across must not change what is read out of it.
+
+    fias_house.large.xml is ~352KB, so every value here splits it across more than
+    one worker except numWorkers=1.
+    """
+    default_columns, default_content = _read_xml_content(
+        session, test_file_house_large_xml, "House"
+    )
+    columns, content = _read_xml_content(
+        session, test_file_house_large_xml, "House", numWorkers=num_workers
+    )
+    assert columns == default_columns
+    assert content == default_content
+
+
+@pytest.mark.parametrize("value", [0, -1, "not-a-number"])
+def test_read_xml_rejects_degenerate_num_workers(session, value):
+    with pytest.raises(ValueError, match="Must be a positive integer"):
+        session.read.option("rowTag", "book").option("numWorkers", value).xml(
+            f"@{tmp_stage_name}/{test_file_books_xml}"
+        )

--- a/tests/unit/test_xml_reader.py
+++ b/tests/unit/test_xml_reader.py
@@ -17,6 +17,7 @@ from snowflake.snowpark._internal.analyzer.analyzer_utils import (
     attribute_to_schema_string_deep,
     single_quote,
 )
+from snowflake.snowpark._internal.analyzer.snowflake_plan import _positive_int_option
 from snowflake.snowpark._internal.utils import (
     quote_name,
     use_xml_variant_projection,
@@ -1528,3 +1529,22 @@ def test_xml_project_from_variant_cache_no_keys_raises_row_tag_not_found():
         SnowparkDataframeReaderException, match="Cannot find the row tag"
     ):
         _project_from_keys([])
+
+
+@pytest.mark.parametrize(
+    "options,expected",
+    [
+        ({}, 16),
+        ({"NUMWORKERS": 4}, 4),
+        ({"NUMWORKERS": "4"}, 4),
+        ({"NUMWORKERS": 1}, 1),
+    ],
+)
+def test_positive_int_option_accepts_valid_values(options, expected):
+    assert _positive_int_option(options, "NUMWORKERS", 16) == expected
+
+
+@pytest.mark.parametrize("value", [0, -1, "not-a-number"])
+def test_positive_int_option_rejects_degenerate_values(value):
+    with pytest.raises(ValueError, match="Must be a positive integer"):
+        _positive_int_option({"NUMWORKERS": value}, "NUMWORKERS", 16)


### PR DESCRIPTION
<!---
Please answer these questions before creating your pull request. Thanks!
--->

1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   <!---
   In this section, please add a Snowflake Jira issue number.

   Note that if a corresponding GitHub issue exists, you should still include
   the Snowflake Jira issue number. For example, for GitHub issue
   https://github.com/snowflakedb/snowpark-python/issues/1400, you should
   add "SNOW-1335071" here.
    --->

   Fixes SNOW-3898656

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.
   - [x] I acknowledge that I have ensured my changes to be thread-safe. Follow the link for more information: [Thread-safe Developer Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#thread-safe-development)
   - [x] If adding any arguments to public Snowpark APIs or creating new public Snowpark APIs, I acknowledge that I have ensured my changes include AST support. Follow the link for more information: [AST Support Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#ast-abstract-syntax-tree-support-in-snowpark)

3. Please describe how your code solves the related issue.

   Please write a short description of how your code change solves the related issue.

Exposes `numWorkers` as a `DataFrameReader.xml` option, replacing the previously hardcoded 16-worker cap with a configurable option. 

### Performance: `analytics_50gb.xml` (1,606,916 rows)
perf scales with warehouse size: more workers, more parallelism, faster reads on large files. Below results from SCOS_BENCHMARK_M warehouse

| `numWorkers` | Time (s) | vs `numWorkers=16` |
| :--- | :--- | :--- |
| **16** | 677.62 | — |
| **32** | 508.11 | -25.0% |
| **64** | 489.31 | -27.8% |

**SCOS regression check:** 12/12 pass, 5 skip — exact match to main.
