### PR TITLE
fix: treat requests as optional opentelemetry extra for event table telemetry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 #### Bug Fixes
 
 - Fixed registering a UDF, UDTF, or stored procedure with an integer optional argument failing with `SQL compilation error: invalid default argument expression`. Integer defaults were emitted as `DEFAULT <value> :: INT`, and a parameter default only accepts a constant expression. The redundant cast is no longer generated.
+- Fixed a bug where importing Snowpark failed if the `requests` package was not installed. Event table telemetry now treats `requests` as an optional dependency of the `opentelemetry` extra.
 
 #### Documentation
 

--- a/setup.py
+++ b/setup.py
@@ -238,6 +238,7 @@ setup(
             "opentelemetry-api>=1.0.0, <2.0.0",
             "opentelemetry-sdk>=1.0.0, <2.0.0",
             "opentelemetry-exporter-otlp>=1.0.0, <2.0.0",
+            "requests",
         ],
     },
     classifiers=[

--- a/src/snowflake/snowpark/_internal/event_table_telemetry.py
+++ b/src/snowflake/snowpark/_internal/event_table_telemetry.py
@@ -10,7 +10,6 @@ from logging import getLogger
 from typing import Dict, Optional, Tuple
 from snowflake.connector.options import MissingOptionalDependency, ModuleLikeObject
 import snowflake.snowpark
-import requests
 
 from snowflake.snowpark._internal.utils import parse_table_name
 
@@ -22,6 +21,10 @@ SERVICE_NAME = "snow.snowpark.client"
 
 class MissingOpenTelemetry(MissingOptionalDependency):
     _dep_name = "opentelemetry"
+
+
+class MissingRequests(MissingOptionalDependency):
+    _dep_name = "requests"
 
 
 def _import_or_missing_opentelemetry() -> Tuple[ModuleLikeObject, bool]:
@@ -39,7 +42,15 @@ def _import_or_missing_opentelemetry() -> Tuple[ModuleLikeObject, bool]:
         return MissingOpenTelemetry(), False
 
 
+def _import_or_missing_requests() -> Tuple[ModuleLikeObject, bool]:
+    try:
+        return importlib.import_module("requests"), True
+    except ImportError:
+        return MissingRequests(), False
+
+
 opentelemetry, installed_opentelemetry = _import_or_missing_opentelemetry()
+requests, installed_requests = _import_or_missing_requests()
 
 BaseLogProvider = opentelemetry._logs.LoggerProvider if installed_opentelemetry else ABC
 BaseTraceProvider = (
@@ -77,48 +88,58 @@ else:
             )
 
 
-class RetryWithTokenRefreshAdapter(requests.adapters.HTTPAdapter):
-    def __init__(
-        self,
-        session_instance: "snowflake.snowpark.Session",
-        header: Dict,
-        max_retries: int = 3,
-    ) -> None:
-        super().__init__()
-        self.snowpark_session = session_instance
-        self.max_retries = max_retries
-        self.header = header
-        self.retryable_status_code = [401]
+if installed_requests:
 
-    def send(self, request, **kwargs):
-        """Send request with retry logic and token refresh on failure"""
-        for attempt in range(self.max_retries + 1):
-            try:
-                request.headers.update(self.header)
+    class RetryWithTokenRefreshAdapter(requests.adapters.HTTPAdapter):
+        def __init__(
+            self,
+            session_instance: "snowflake.snowpark.Session",
+            header: Dict,
+            max_retries: int = 3,
+        ) -> None:
+            super().__init__()
+            self.snowpark_session = session_instance
+            self.max_retries = max_retries
+            self.header = header
+            self.retryable_status_code = [401]
 
-                response = super().send(request, **kwargs)
+        def send(self, request, **kwargs):
+            """Send request with retry logic and token refresh on failure"""
+            for attempt in range(self.max_retries + 1):
+                try:
+                    request.headers.update(self.header)
 
-                # If successful, return the response
-                if (
-                    response.status_code in self.retryable_status_code
-                    and attempt < self.max_retries
-                ):
-                    self.header = (
-                        self.snowpark_session._get_external_telemetry_auth_token()
-                    )
-                    continue
-                else:
-                    return response
+                    response = super().send(request, **kwargs)
 
-            except (requests.exceptions.RequestException, Exception) as e:
-                if attempt < self.max_retries:
-                    self.header = (
-                        self.snowpark_session._get_external_telemetry_auth_token()
-                    )
-                    continue
-                else:
-                    # Re-raise the exception if we've exhausted retries
-                    raise e
+                    # If successful, return the response
+                    if (
+                        response.status_code in self.retryable_status_code
+                        and attempt < self.max_retries
+                    ):
+                        self.header = (
+                            self.snowpark_session._get_external_telemetry_auth_token()
+                        )
+                        continue
+                    else:
+                        return response
+
+                except (requests.exceptions.RequestException, Exception) as e:
+                    if attempt < self.max_retries:
+                        self.header = (
+                            self.snowpark_session._get_external_telemetry_auth_token()
+                        )
+                        continue
+                    else:
+                        # Re-raise the exception if we've exhausted retries
+                        raise e
+
+else:
+
+    class RetryWithTokenRefreshAdapter:
+        def __init__(self, *args, **kwargs) -> None:
+            raise NotImplementedError(
+                'opentelemetry extra from Snowpark is required, install with: pip install "snowflake-snowpark-python[opentelemetry]" '
+            )
 
 
 class ProxyTracerProvider(BaseTraceProvider):
@@ -286,7 +307,7 @@ class EventTableTelemetry:
             ext.disable_event_table_telemetry_collection()
 
         """
-        if not installed_opentelemetry:
+        if not installed_opentelemetry or not installed_requests:
             _logger.debug(
                 f"Opentelemetry dependencies are missing, no telemetry export into event table: {event_table}"
             )

--- a/tests/integ/test_external_telemetry.py
+++ b/tests/integ/test_external_telemetry.py
@@ -205,17 +205,21 @@ def test_negative_case(session, caplog):
     )
     assert "Input event table is converted to fully qualified name:" in caplog.text
 
-    with patch(
-        "snowflake.snowpark._internal.event_table_telemetry.installed_opentelemetry",
-        False,
-    ):
-        external_telemetry.enable_event_table_telemetry_collection(
-            "db.sc.tb", logging.INFO, True
-        )
-        assert (
-            "Opentelemetry dependencies are missing, no telemetry export into event table:"
-            in caplog.text
-        )
+    # both opentelemetry and requests are optional dependencies of the
+    # opentelemetry extra, and a missing one disables telemetry collection
+    for missing_dependency in ("installed_opentelemetry", "installed_requests"):
+        caplog.clear()
+        with patch(
+            f"snowflake.snowpark._internal.event_table_telemetry.{missing_dependency}",
+            False,
+        ):
+            external_telemetry.enable_event_table_telemetry_collection(
+                "db.sc.tb", logging.INFO, True
+            )
+            assert (
+                "Opentelemetry dependencies are missing, no telemetry export into event table:"
+                in caplog.text
+            )
 
 
 def test_external_telemetry_adapter(session):

--- a/tests/unit/test_external_telemetry.py
+++ b/tests/unit/test_external_telemetry.py
@@ -4,9 +4,16 @@
 
 # Copyright (c) 2012-2025 Snowflake Computing Inc. All rights reserved.
 
+import importlib
+import logging
+import sys
 import types
 
+import pytest
+
 from snowflake.snowpark._internal import event_table_telemetry as ett
+
+MODULE_NAME = "snowflake.snowpark._internal.event_table_telemetry"
 
 
 def test_import_or_missing_opentelemetry_imports_resources(monkeypatch):
@@ -101,3 +108,84 @@ def test_import_or_missing_opentelemetry_returns_missing_on_importerror(monkeypa
 
     assert installed is False
     assert isinstance(otel, ett.MissingOpenTelemetry)
+
+
+def test_import_or_missing_requests_imports_requests(monkeypatch):
+    requests_mod = types.ModuleType("requests")
+
+    def fake_import_module(name):
+        if name == "requests":
+            return requests_mod
+        raise ImportError(name)
+
+    monkeypatch.setattr(ett.importlib, "import_module", fake_import_module)
+
+    requests, installed = ett._import_or_missing_requests()
+
+    assert installed is True
+    assert requests is requests_mod
+
+
+def test_import_or_missing_requests_returns_missing_on_importerror(monkeypatch):
+    def always_fail(_name):
+        raise ImportError("missing")
+
+    monkeypatch.setattr(ett.importlib, "import_module", always_fail)
+
+    requests, installed = ett._import_or_missing_requests()
+
+    assert installed is False
+    assert isinstance(requests, ett.MissingRequests)
+
+
+def test_retry_adapter_requires_requests_extra(monkeypatch):
+    # requests is an optional dependency of the opentelemetry extra, so importing
+    # the module must succeed without it and only fail when the adapter is used.
+    original_module = sys.modules.get(MODULE_NAME)
+
+    real_import_module = importlib.import_module
+
+    def import_module_raising_for_requests(name, package=None):
+        if name == "requests" or name.startswith("requests."):
+            raise ImportError("forced ImportError for test coverage")
+        return real_import_module(name, package=package)
+
+    monkeypatch.setattr(importlib, "import_module", import_module_raising_for_requests)
+
+    sys.modules.pop(MODULE_NAME, None)
+    try:
+        event_table_telemetry = real_import_module(MODULE_NAME)
+        assert event_table_telemetry.installed_requests is False
+        assert isinstance(
+            event_table_telemetry.requests, event_table_telemetry.MissingRequests
+        )
+        with pytest.raises(
+            NotImplementedError,
+            match=r'opentelemetry extra from Snowpark is required, install with: pip install "snowflake-snowpark-python\[opentelemetry\]"',
+        ):
+            event_table_telemetry.RetryWithTokenRefreshAdapter(
+                session_instance=None, header={}
+            )
+    finally:
+        sys.modules.pop(MODULE_NAME, None)
+        if original_module is not None:
+            sys.modules[MODULE_NAME] = original_module
+
+
+def test_enable_event_table_telemetry_collection_skips_without_requests(
+    monkeypatch, caplog
+):
+    monkeypatch.setattr(ett, "installed_requests", False)
+    monkeypatch.setattr(ett, "installed_opentelemetry", True)
+
+    telemetry = ett.EventTableTelemetry(session=None)
+
+    with caplog.at_level(logging.DEBUG, logger=ett._logger.name):
+        telemetry.enable_event_table_telemetry_collection(
+            "db.sc.tb", logging.INFO, True
+        )
+
+    assert (
+        "Opentelemetry dependencies are missing, no telemetry export into event table: db.sc.tb"
+        in caplog.text
+    )


### PR DESCRIPTION
## Summary
- Declare `requests` on the `[opentelemetry]` extra instead of relying on a hard import in `event_table_telemetry`.
- Gate `requests` the same way as OpenTelemetry so importing Snowpark still works when it is not installed.
- Cover the missing-`requests` path in unit and integ telemetry tests.

## Test plan
- [ ] `pytest tests/unit/test_external_telemetry.py`
- [ ] `pytest tests/integ/test_external_telemetry.py` (needs a live Snowflake session)
- [ ] Confirm `import snowflake.snowpark` succeeds without `requests` installed
- [ ] Confirm `pip install "snowflake-snowpark-python[opentelemetry]"` pulls in `requests`


Made with [Cursor](https://cursor.com)