### PR TITLE
SNOW-3902758 adding semantic view support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,6 @@
 - Added support for a `table_properties` key in the `iceberg_config` dictionary of `DataFrameWriter.save_as_table`, which emits a `TABLE_PROPERTIES = ('k'='v', ...)` clause on Iceberg table creation (CREATE / CTAS).
 - Added `Session.semantic_view()` to query a semantic view. Pass the semantic view name plus any of `dimensions`, `metrics`, `facts`, and `where`; it returns a `DataFrame`.
 
-
 #### Bug Fixes
 
 - Fixed registering a UDF, UDTF, or stored procedure with an integer optional argument failing with `SQL compilation error: invalid default argument expression`. Integer defaults were emitted as `DEFAULT <value> :: INT`, and a parameter default only accepts a constant expression. The redundant cast is no longer generated.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 - Added interval type support for Python UDFs and stored procedures. Use `datetime.timedelta` as the type annotation for day-time interval (`DayTimeIntervalType`) parameters and return values, and `YearMonthInterval` (a type annotation sentinel from `snowflake.snowpark.types`) for year-month interval (`YearMonthIntervalType`) parameters and return values.
 - Added support for a `table_properties` key in the `iceberg_config` dictionary of `DataFrameWriter.save_as_table`, which emits a `TABLE_PROPERTIES = ('k'='v', ...)` clause on Iceberg table creation (CREATE / CTAS).
+- Added `Session.semantic_view()` to query a semantic view. Pass the semantic view name plus any of `dimensions`, `metrics`, `facts`, and `where`; it returns a `DataFrame`.
+
 
 #### Bug Fixes
 

--- a/docs/source/snowpark/session.rst
+++ b/docs/source/snowpark/session.rst
@@ -71,6 +71,7 @@ Snowpark Session
       Session.remove_package
       Session.replicate_local_environment
       Session.rollback
+      Session.semantic_view
       Session.sql
       Session.table
       Session.table_function

--- a/src/snowflake/snowpark/session.py
+++ b/src/snowflake/snowpark/session.py
@@ -6,7 +6,6 @@
 import atexit
 import datetime
 import decimal
-import importlib.metadata
 import inspect
 import json
 import os
@@ -36,6 +35,7 @@ from typing import (
 )
 
 import cloudpickle
+import importlib.metadata
 from packaging.requirements import Requirement
 from packaging.version import parse as parse_version
 
@@ -44,11 +44,11 @@ import snowflake.snowpark.context as context
 from snowflake.connector import ProgrammingError, SnowflakeConnection
 from snowflake.connector.options import installed_pandas, pandas, pyarrow
 from snowflake.connector.pandas_tools import write_pandas
+
 from snowflake.snowpark import UDFProfiler
 from snowflake.snowpark._internal.analyzer import analyzer_utils
 from snowflake.snowpark._internal.analyzer.analyzer import Analyzer
 from snowflake.snowpark._internal.analyzer.analyzer_utils import (
-    quote_name_without_upper_casing,
     result_scan_statement,
     write_arrow,
 )
@@ -68,6 +68,9 @@ from snowflake.snowpark._internal.analyzer.table_function import (
     FlattenFunction,
     GeneratorTableFunction,
     TableFunctionRelation,
+)
+from snowflake.snowpark._internal.analyzer.analyzer_utils import (
+    quote_name_without_upper_casing,
 )
 from snowflake.snowpark._internal.analyzer.unary_expression import Cast
 from snowflake.snowpark._internal.ast.batch import AstBatch
@@ -111,10 +114,8 @@ from snowflake.snowpark._internal.utils import (
     MODULE_NAME_TO_PACKAGE_NAME_MAP,
     STAGE_PREFIX,
     SUPPORTED_TABLE_TYPES,
-    XPATH_HANDLER_MAP,
     XPATH_HANDLERS_FILE_PATH,
-    AstFlagSource,
-    AstMode,
+    XPATH_HANDLER_MAP,
     PythonObjJSONEncoder,
     TempObjectType,
     calculate_checksum,
@@ -132,17 +133,14 @@ from snowflake.snowpark._internal.utils import (
     get_temp_type_for_object,
     get_version,
     import_or_missing_modin_pandas,
-    is_ast_enabled,
     is_in_stored_procedure,
     normalize_local_file,
     normalize_remote_file_or_dir,
     parse_positional_args_to_list,
     parse_positional_args_to_list_variadic,
-    private_preview,
     publicapi,
     quote_name,
     random_name_for_temp_object,
-    set_ast_state,
     strip_double_quotes_in_like_statement_in_table_name,
     unwrap_single_quote,
     unwrap_stage_location_single_quote,
@@ -150,17 +148,21 @@ from snowflake.snowpark._internal.utils import (
     warn_session_config_update_in_multithreaded_mode,
     warning,
     zip_file_or_directory_to_stream,
+    set_ast_state,
+    is_ast_enabled,
+    AstFlagSource,
+    AstMode,
+    private_preview,
 )
 from snowflake.snowpark.async_job import AsyncJob, _AsyncResultType
 from snowflake.snowpark.column import Column
 from snowflake.snowpark.context import (
-    _ANACONDA_SHARED_REPOSITORY,
-    _DEFAULT_ARTIFACT_REPOSITORY,
     _is_execution_environment_sandboxed_for_client,
     _use_scoped_temp_objects,
+    _ANACONDA_SHARED_REPOSITORY,
+    _DEFAULT_ARTIFACT_REPOSITORY,
 )
 from snowflake.snowpark.dataframe import DataFrame
-from snowflake.snowpark.dataframe_profiler import DataframeProfiler
 from snowflake.snowpark.dataframe_reader import DataFrameReader
 from snowflake.snowpark.exceptions import (
     SnowparkClientException,
@@ -168,6 +170,7 @@ from snowflake.snowpark.exceptions import (
 )
 from snowflake.snowpark.file_operation import FileOperation
 from snowflake.snowpark.functions import (
+    to_file,
     array_agg,
     col,
     column,
@@ -175,7 +178,6 @@ from snowflake.snowpark.functions import (
     parse_json,
     to_date,
     to_decimal,
-    to_file,
     to_geography,
     to_geometry,
     to_time,
@@ -203,6 +205,7 @@ from snowflake.snowpark.query_history import AstListener, QueryHistory
 from snowflake.snowpark.row import Row
 from snowflake.snowpark.stored_procedure import StoredProcedureRegistration
 from snowflake.snowpark.stored_procedure_profiler import StoredProcedureProfiler
+from snowflake.snowpark.dataframe_profiler import DataframeProfiler
 from snowflake.snowpark.table import Table
 from snowflake.snowpark.table_function import (
     TableFunctionCall,
@@ -214,7 +217,6 @@ from snowflake.snowpark.types import (
     DateType,
     DayTimeIntervalType,
     DecimalType,
-    FileType,
     FloatType,
     GeographyType,
     GeometryType,
@@ -229,6 +231,7 @@ from snowflake.snowpark.types import (
     VariantType,
     VectorType,
     YearMonthIntervalType,
+    FileType,
     _AtomicType,
 )
 from snowflake.snowpark.udaf import UDAFRegistration
@@ -364,31 +367,41 @@ def _remove_session(session: "Session") -> None:
 
 
 def _render_semantic_view_clause(
-    keyword: str, param: str, value: Union[str, Iterable[MemberRef]]
+    keyword: str, value: Union[str, List[MemberRef]]
 ) -> str:
     """Renders one clause of a ``SEMANTIC_VIEW(...)`` call.
 
     A ``str`` is emitted verbatim: the clause grammar already accepts a comma list,
     and splitting would break a member such as ``TO_CHAR(d,'YY')``.
     """
+    param = keyword.lower()
     if isinstance(value, str):
-        return f"{keyword} {value}"
+        if not value.strip():
+            raise ValueError(f"{param} is empty; omit it instead.")
+        # Concatenated, not interpolated: a str subclass such as ``class X(str, Enum)``
+        # formats as its repr but concatenates as its value.
+        return keyword + " " + value
     if isinstance(value, tuple):
-        raise TypeError(
-            f"{param} does not accept a tuple at the top level, because "
-            f'{param}=("a", "b") is ambiguous. Pass a list for several members '
-            f'({param}=["a", "b"]), or wrap the pair to mean one dotted member '
-            f'({param}=[("a", "b")]).'
+        hint = (
+            f'Pass a list for several members ({param}=["a", "b"]), or wrap the pair '
+            f'to mean one dotted member ({param}=[("a", "b")]).'
+            if len(value) == 2
+            else f"Pass a list of members instead ({param}=[...])."
         )
+        raise TypeError(f"{param} does not accept a tuple at the top level. {hint}")
     if not isinstance(value, list):
         raise TypeError(
             f"{param} should be a string, or a list of members, not "
             f"{type(value).__name__}."
         )
+    if not value:
+        raise ValueError(f"{param} is an empty list; omit it instead.")
 
     members = []
     for i, member in enumerate(value):
         if isinstance(member, str):
+            if not member.strip():
+                raise ValueError(f"{param}[{i}] is an empty member name.")
             members.append(member)
         elif isinstance(member, tuple):
             if len(member) != 2:
@@ -396,13 +409,21 @@ def _render_semantic_view_clause(
                     f"{param}[{i}] is a {len(member)}-tuple; a tuple member must be "
                     f"(table, attribute)."
                 )
-            members.append(".".join(member))
+            table, attribute = member
+            if not isinstance(table, str) or not isinstance(attribute, str):
+                raise TypeError(
+                    f"{param}[{i}] must be a (table, attribute) tuple of two strings, "
+                    f"not ({type(table).__name__}, {type(attribute).__name__})."
+                )
+            if not table.strip() or not attribute.strip():
+                raise ValueError(f"{param}[{i}] has an empty table or attribute.")
+            members.append(".".join((table, attribute)))
         else:
             raise TypeError(
                 f"{param}[{i}] should be a string or a (table, attribute) tuple, "
                 f"not {type(member).__name__}."
             )
-    return f"{keyword} {', '.join(members)}"
+    return keyword + " " + ", ".join(members)
 
 
 class Session:
@@ -642,9 +663,9 @@ class Session:
         # due to server side accessing private session members, this cannot be merged with _artifact_repository_packages
         self._packages: Dict[str, str] = {}
         # map of artifact repository name -> packages that should be added to functions under that repository
-        self._artifact_repository_packages: DefaultDict[str, Dict[str, str]] = (
-            defaultdict(dict)
-        )
+        self._artifact_repository_packages: DefaultDict[
+            str, Dict[str, str]
+        ] = defaultdict(dict)
         # Single-entry cache for the default artifact repository value.
         # Stores a tuple of ((database, schema), cached_value).  Only one entry is
         # kept at a time – switching to a different database/schema will evict the old
@@ -800,8 +821,8 @@ class Session:
 
         # development features require AST to be enabled
         from snowflake.snowpark.context import (
-            _enable_dataframe_trace_on_error,
             _enable_trace_sql_errors_to_dataframe,
+            _enable_dataframe_trace_on_error,
         )
 
         if _enable_trace_sql_errors_to_dataframe or _enable_dataframe_trace_on_error:
@@ -834,10 +855,10 @@ class Session:
             try:
                 from modin.config import AutoSwitchBackend
 
-                pandas_hybrid_execution_enabled: Union[bool, None] = (
-                    self._conn._get_client_side_session_parameter(
-                        _SNOWPARK_PANDAS_HYBRID_EXECUTION_ENABLED, None
-                    )
+                pandas_hybrid_execution_enabled: Union[
+                    bool, None
+                ] = self._conn._get_client_side_session_parameter(
+                    _SNOWPARK_PANDAS_HYBRID_EXECUTION_ENABLED, None
                 )
                 # Only set AutoSwitchBackend if the session parameter was already set.
                 # snowflake.snowpark.modin.plugin sets AutoSwitchBackend to True if it was
@@ -1962,7 +1983,7 @@ class Session:
 
     @staticmethod
     def _parse_packages(
-        packages: List[Union[str, ModuleType]],
+        packages: List[Union[str, ModuleType]]
     ) -> Dict[str, Tuple[str, bool, Requirement]]:
         package_dict = dict()
         for package in packages:
@@ -2508,14 +2529,12 @@ class Session:
                 entity_selector_args = (
                     f"'schema', '{schema}'"
                     if schema
-                    else (
-                        f"'database', '{database}'"
-                        if database
-                        # self.get_current_account uses a cached connector field that may not be properly cased, so we need to
-                        # explicitly issue a query for it.
-                        # Since this issues a query, we should compute it only if database/schema are unset.
-                        else f"""'account', '{quote_name_without_upper_casing(self._conn._get_string_datum("SELECT CURRENT_ACCOUNT()"))}'"""
-                    )
+                    else f"'database', '{database}'"
+                    if database
+                    # self.get_current_account uses a cached connector field that may not be properly cased, so we need to
+                    # explicitly issue a query for it.
+                    # Since this issues a query, we should compute it only if database/schema are unset.
+                    else f"""'account', '{quote_name_without_upper_casing(self._conn._get_string_datum("SELECT CURRENT_ACCOUNT()"))}'"""
                 )
                 result = self._run_query(
                     f"SELECT SYSTEM$GET_DEFAULT_PYTHON_ARTIFACT_REPOSITORY('{python_version}', {entity_selector_args})"
@@ -3211,14 +3230,16 @@ class Session:
         return d
 
     @experimental(version="1.55.0")
+    @publicapi
     def semantic_view(
         self,
-        name: Union[str, Iterable[str]],
+        name: Union[str, List[str], Tuple[str, ...]],
         *,
-        dimensions: Optional[Union[str, Iterable[MemberRef]]] = None,
-        metrics: Optional[Union[str, Iterable[MemberRef]]] = None,
-        facts: Optional[Union[str, Iterable[MemberRef]]] = None,
+        dimensions: Optional[Union[str, List[MemberRef]]] = None,
+        metrics: Optional[Union[str, List[MemberRef]]] = None,
+        facts: Optional[Union[str, List[MemberRef]]] = None,
         where: Optional[str] = None,
+        _emit_ast: bool = True,
     ) -> DataFrame:
         """Returns a :class:`DataFrame` for a query against a semantic view.
 
@@ -3230,10 +3251,14 @@ class Session:
         order ``DIMENSIONS``, ``METRICS``, ``FACTS``, ``WHERE``, which sets the
         default column order; reorder with :meth:`DataFrame.select`.
 
+        Note:
+            Clause strings are not parameterized. Treat them as trusted SQL and do
+            not build them from untrusted input.
+
         Args:
-            name: A string or list of strings that specify the semantic view name
-                or fully-qualified object identifier (database name, schema name,
-                and semantic view name).
+            name: A string, or a list or tuple of strings, that specifies the
+                semantic view name or fully-qualified object identifier (database
+                name, schema name, and semantic view name).
             dimensions: Members to group by, as a verbatim clause string or a list
                 of members. A list element may be a string, or a
                 ``(table, attribute)`` tuple that is joined with a dot.
@@ -3243,6 +3268,23 @@ class Session:
             where: A condition applied *before* aggregation. It may reference
                 dimensions and facts, but not metrics. Filter on a metric with
                 :meth:`DataFrame.filter` on the returned DataFrame instead.
+
+        Examples::
+
+            >>> df = session.semantic_view(
+            ...     "my_semantic_view",
+            ...     dimensions="customers.region",
+            ...     metrics="orders.revenue",
+            ... )  # doctest: +SKIP
+
+            >>> df = session.semantic_view(
+            ...     "my_db.my_schema.my_semantic_view",
+            ...     dimensions=[("customers", "region"), "customers.customer"],
+            ...     metrics=["orders.revenue", "orders.order_count"],
+            ...     where="customers.region = 'EMEA'",
+            ... )  # doctest: +SKIP
+            >>> from snowflake.snowpark.functions import col  # doctest: +SKIP
+            >>> df.filter(col("REVENUE") > 400).sort(col("REGION")).show()  # doctest: +SKIP
         """
         if isinstance(self._conn, MockServerConnection):
             self._conn.log_not_supported_error(
@@ -3256,22 +3298,41 @@ class Session:
                 "or facts. A where condition alone is not a valid query."
             )
 
-        if not isinstance(name, str) and isinstance(name, Iterable):
+        if not isinstance(name, str):
+            # Not any Iterable: a set would dot-join in an arbitrary order.
+            if not isinstance(name, (list, tuple)):
+                raise TypeError(
+                    "name should be a string, or a list or tuple of name parts, not "
+                    f"{type(name).__name__}."
+                )
+            for i, part in enumerate(name):
+                if not isinstance(part, str):
+                    raise TypeError(
+                        f"name[{i}] should be a string, not {type(part).__name__}."
+                    )
             name = ".".join(name)
         validate_object_name(name)
 
         parts = [name]
-        for keyword, param, value in (
-            ("DIMENSIONS", "dimensions", dimensions),
-            ("METRICS", "metrics", metrics),
-            ("FACTS", "facts", facts),
+        for keyword, value in (
+            ("DIMENSIONS", dimensions),
+            ("METRICS", metrics),
+            ("FACTS", facts),
         ):
             if value is not None:
-                parts.append(_render_semantic_view_clause(keyword, param, value))
+                parts.append(_render_semantic_view_clause(keyword, value))
         if where is not None:
-            parts.append(f"WHERE {where}")
+            if not isinstance(where, str):
+                raise TypeError(
+                    f"where should be a string, not {type(where).__name__}."
+                )
+            if not where.strip():
+                raise ValueError("where is empty; omit it instead.")
+            parts.append("WHERE " + where)
 
-        df = self.sql(f"SELECT * FROM SEMANTIC_VIEW({' '.join(parts)})")
+        df = self.sql(
+            f"SELECT * FROM SEMANTIC_VIEW({' '.join(parts)})", _emit_ast=_emit_ast
+        )
         set_api_call_source(df, "Session.semantic_view")
         return df
 

--- a/src/snowflake/snowpark/session.py
+++ b/src/snowflake/snowpark/session.py
@@ -319,6 +319,7 @@ DEFAULT_COMPLEXITY_SCORE_LOWER_BOUND = 10_000_000
 DEFAULT_COMPLEXITY_SCORE_UPPER_BOUND = 12_000_000
 WRITE_PANDAS_CHUNK_SIZE: int = 100000 if is_in_stored_procedure() else None
 WRITE_ARROW_CHUNK_SIZE: int = 100000 if is_in_stored_procedure() else None
+# A tuple member is (table, attribute), dot-joined -- not (member, alias).
 MemberRef = Union[str, Tuple[str, str]]
 
 
@@ -3261,7 +3262,9 @@ class Session:
                 name, schema name, and semantic view name).
             dimensions: Members to group by, as a verbatim clause string or a list
                 of members. A list element may be a string, or a
-                ``(table, attribute)`` tuple that is joined with a dot.
+                ``(table, attribute)`` tuple that is joined with a dot — the tuple
+                splits one member's name, it is not a member-and-alias pair. Write
+                an alias in the string form, as ``"orders.revenue AS REV"``.
             metrics: Members to aggregate, in the same forms as ``dimensions``.
             facts: Row-level members, in the same forms as ``dimensions``. The
                 server rejects ``facts`` together with ``metrics``.

--- a/src/snowflake/snowpark/session.py
+++ b/src/snowflake/snowpark/session.py
@@ -319,7 +319,6 @@ DEFAULT_COMPLEXITY_SCORE_LOWER_BOUND = 10_000_000
 DEFAULT_COMPLEXITY_SCORE_UPPER_BOUND = 12_000_000
 WRITE_PANDAS_CHUNK_SIZE: int = 100000 if is_in_stored_procedure() else None
 WRITE_ARROW_CHUNK_SIZE: int = 100000 if is_in_stored_procedure() else None
-# A tuple member is (table, attribute), dot-joined -- not (member, alias).
 MemberRef = Union[str, Tuple[str, str]]
 
 
@@ -367,8 +366,76 @@ def _remove_session(session: "Session") -> None:
             pass
 
 
+def _render_semantic_view_member(param: str, i: int, member: MemberRef) -> str:
+    """Renders one member of a ``SEMANTIC_VIEW(...)`` clause.
+
+    A 2-tuple is ``(table, attribute)``, dot-joined -- not ``(member, alias)``.
+    """
+    if isinstance(member, str):
+        if not member.strip():
+            raise ValueError(f"{param}[{i}] is an empty member name.")
+        return member
+    if not isinstance(member, tuple):
+        raise TypeError(
+            f"{param}[{i}] should be a string or a (table, attribute) tuple, "
+            f"not {type(member).__name__}."
+        )
+    if len(member) != 2:
+        raise TypeError(
+            f"{param}[{i}] is a {len(member)}-tuple; a tuple member must be "
+            f"(table, attribute)."
+        )
+    table, attribute = member
+    if not isinstance(table, str) or not isinstance(attribute, str):
+        raise TypeError(
+            f"{param}[{i}] must be a (table, attribute) tuple of two strings, "
+            f"not ({type(table).__name__}, {type(attribute).__name__})."
+        )
+    if not table.strip() or not attribute.strip():
+        raise ValueError(f"{param}[{i}] has an empty table or attribute.")
+    return ".".join((table, attribute))
+
+
+def _render_semantic_view_where(value: Union[str, Sequence[str]]) -> str:
+    """Renders the ``WHERE`` clause of a ``SEMANTIC_VIEW(...)`` call.
+
+    A ``str`` is emitted verbatim.
+
+    ``WHERE`` accepts exactly one expression, so a sequence of conditions is
+    joined with ``AND``. Each one is parenthesized first::
+
+        ["a OR b", "c"]  ->  WHERE (a OR b) AND (c)
+
+    Without the parentheses that reads as ``a OR b AND c``. SQL binds ``AND``
+    tighter, so it means ``a OR (b AND c)``: different rows, no error.
+    """
+    if isinstance(value, str):
+        if not value.strip():
+            raise ValueError("where is empty; omit it instead.")
+        return "WHERE " + value
+    if not isinstance(value, Sequence) or isinstance(
+        value, (bytes, bytearray, memoryview)
+    ):
+        raise TypeError(
+            f"where should be a string, or a sequence of conditions, not "
+            f"{type(value).__name__}."
+        )
+    if not value:
+        raise ValueError(f"where is an empty {type(value).__name__}; omit it instead.")
+    conditions = []
+    for i, condition in enumerate(value):
+        if not isinstance(condition, str):
+            raise TypeError(
+                f"where[{i}] should be a string, not {type(condition).__name__}."
+            )
+        if not condition.strip():
+            raise ValueError(f"where[{i}] is an empty condition.")
+        conditions.append("(" + condition + ")")
+    return "WHERE " + " AND ".join(conditions)
+
+
 def _render_semantic_view_clause(
-    keyword: str, value: Union[str, List[MemberRef]]
+    keyword: str, value: Union[str, Sequence[MemberRef]]
 ) -> str:
     """Renders one clause of a ``SEMANTIC_VIEW(...)`` call.
 
@@ -379,52 +446,29 @@ def _render_semantic_view_clause(
     if isinstance(value, str):
         if not value.strip():
             raise ValueError(f"{param} is empty; omit it instead.")
-        # Concatenated, not interpolated: a str subclass such as ``class X(str, Enum)``
+        # Concatenated, not interpolated: a str subclass such as class X(str, Enum)
         # formats as its repr but concatenates as its value.
         return keyword + " " + value
-    if isinstance(value, tuple):
-        hint = (
-            f'Pass a list for several members ({param}=["a", "b"]), or wrap the pair '
-            f'to mean one dotted member ({param}=[("a", "b")]).'
-            if len(value) == 2
-            else f"Pass a list of members instead ({param}=[...])."
-        )
-        raise TypeError(f"{param} does not accept a tuple at the top level. {hint}")
-    if not isinstance(value, list):
+    # Sequence, not Iterable: a set has no order, so it would render members in an
+    # arbitrary one. bytes/bytearray/memoryview are Sequences of ints, not members.
+    if not isinstance(value, Sequence) or isinstance(
+        value, (bytes, bytearray, memoryview)
+    ):
         raise TypeError(
-            f"{param} should be a string, or a list of members, not "
+            f"{param} should be a string, or a sequence of members, not "
             f"{type(value).__name__}."
         )
     if not value:
-        raise ValueError(f"{param} is an empty list; omit it instead.")
-
-    members = []
-    for i, member in enumerate(value):
-        if isinstance(member, str):
-            if not member.strip():
-                raise ValueError(f"{param}[{i}] is an empty member name.")
-            members.append(member)
-        elif isinstance(member, tuple):
-            if len(member) != 2:
-                raise TypeError(
-                    f"{param}[{i}] is a {len(member)}-tuple; a tuple member must be "
-                    f"(table, attribute)."
-                )
-            table, attribute = member
-            if not isinstance(table, str) or not isinstance(attribute, str):
-                raise TypeError(
-                    f"{param}[{i}] must be a (table, attribute) tuple of two strings, "
-                    f"not ({type(table).__name__}, {type(attribute).__name__})."
-                )
-            if not table.strip() or not attribute.strip():
-                raise ValueError(f"{param}[{i}] has an empty table or attribute.")
-            members.append(".".join((table, attribute)))
-        else:
-            raise TypeError(
-                f"{param}[{i}] should be a string or a (table, attribute) tuple, "
-                f"not {type(member).__name__}."
-            )
-    return keyword + " " + ", ".join(members)
+        raise ValueError(
+            f"{param} is an empty {type(value).__name__}; omit it instead."
+        )
+    return (
+        keyword
+        + " "
+        + ", ".join(
+            _render_semantic_view_member(param, i, m) for i, m in enumerate(value)
+        )
+    )
 
 
 class Session:
@@ -3234,12 +3278,12 @@ class Session:
     @publicapi
     def semantic_view(
         self,
-        name: Union[str, List[str], Tuple[str, ...]],
+        name: Union[str, Sequence[str]],
         *,
-        dimensions: Optional[Union[str, List[MemberRef]]] = None,
-        metrics: Optional[Union[str, List[MemberRef]]] = None,
-        facts: Optional[Union[str, List[MemberRef]]] = None,
-        where: Optional[str] = None,
+        dimensions: Optional[Union[str, Sequence[MemberRef]]] = None,
+        metrics: Optional[Union[str, Sequence[MemberRef]]] = None,
+        facts: Optional[Union[str, Sequence[MemberRef]]] = None,
+        where: Optional[Union[str, Sequence[str]]] = None,
         _emit_ast: bool = True,
     ) -> DataFrame:
         """Returns a :class:`DataFrame` for a query against a semantic view.
@@ -3257,20 +3301,24 @@ class Session:
             not build them from untrusted input.
 
         Args:
-            name: A string, or a list or tuple of strings, that specifies the
+            name: A string, or a sequence of strings, that specifies the
                 semantic view name or fully-qualified object identifier (database
                 name, schema name, and semantic view name).
             dimensions: Members to group by, as a verbatim clause string or a list
-                of members. A list element may be a string, or a
+                of members. A sequence element may be a string, or a
                 ``(table, attribute)`` tuple that is joined with a dot — the tuple
                 splits one member's name, it is not a member-and-alias pair. Write
                 an alias in the string form, as ``"orders.revenue AS REV"``.
             metrics: Members to aggregate, in the same forms as ``dimensions``.
             facts: Row-level members, in the same forms as ``dimensions``. The
                 server rejects ``facts`` together with ``metrics``.
-            where: A condition applied *before* aggregation. It may reference
-                dimensions and facts, but not metrics. Filter on a metric with
-                :meth:`DataFrame.filter` on the returned DataFrame instead.
+            where: A condition applied *before* aggregation. Pass a string, which
+                is emitted verbatim, or a sequence of conditions, which are
+                ``AND``-joined with each one parenthesized. ``WHERE`` takes a
+                single expression, so a sequence is how several conditions
+                compose. A condition may reference dimensions and facts, but not
+                metrics: a metric is filtered *after* aggregation, with
+                :meth:`DataFrame.filter` on the returned DataFrame.
 
         Examples::
 
@@ -3302,10 +3350,13 @@ class Session:
             )
 
         if not isinstance(name, str):
-            # Not any Iterable: a set would dot-join in an arbitrary order.
-            if not isinstance(name, (list, tuple)):
+            # Sequence, not Iterable: a set has no order, so it would dot-join the
+            # parts in an arbitrary one, resolving to a different object.
+            if not isinstance(name, Sequence) or isinstance(
+                name, (bytes, bytearray, memoryview)
+            ):
                 raise TypeError(
-                    "name should be a string, or a list or tuple of name parts, not "
+                    "name should be a string, or a sequence of name parts, not "
                     f"{type(name).__name__}."
                 )
             for i, part in enumerate(name):
@@ -3325,13 +3376,7 @@ class Session:
             if value is not None:
                 parts.append(_render_semantic_view_clause(keyword, value))
         if where is not None:
-            if not isinstance(where, str):
-                raise TypeError(
-                    f"where should be a string, not {type(where).__name__}."
-                )
-            if not where.strip():
-                raise ValueError("where is empty; omit it instead.")
-            parts.append("WHERE " + where)
+            parts.append(_render_semantic_view_where(where))
 
         df = self.sql(
             f"SELECT * FROM SEMANTIC_VIEW({' '.join(parts)})", _emit_ast=_emit_ast

--- a/src/snowflake/snowpark/session.py
+++ b/src/snowflake/snowpark/session.py
@@ -6,6 +6,7 @@
 import atexit
 import datetime
 import decimal
+import importlib.metadata
 import inspect
 import json
 import os
@@ -35,7 +36,6 @@ from typing import (
 )
 
 import cloudpickle
-import importlib.metadata
 from packaging.requirements import Requirement
 from packaging.version import parse as parse_version
 
@@ -44,11 +44,11 @@ import snowflake.snowpark.context as context
 from snowflake.connector import ProgrammingError, SnowflakeConnection
 from snowflake.connector.options import installed_pandas, pandas, pyarrow
 from snowflake.connector.pandas_tools import write_pandas
-
 from snowflake.snowpark import UDFProfiler
 from snowflake.snowpark._internal.analyzer import analyzer_utils
 from snowflake.snowpark._internal.analyzer.analyzer import Analyzer
 from snowflake.snowpark._internal.analyzer.analyzer_utils import (
+    quote_name_without_upper_casing,
     result_scan_statement,
     write_arrow,
 )
@@ -68,9 +68,6 @@ from snowflake.snowpark._internal.analyzer.table_function import (
     FlattenFunction,
     GeneratorTableFunction,
     TableFunctionRelation,
-)
-from snowflake.snowpark._internal.analyzer.analyzer_utils import (
-    quote_name_without_upper_casing,
 )
 from snowflake.snowpark._internal.analyzer.unary_expression import Cast
 from snowflake.snowpark._internal.ast.batch import AstBatch
@@ -114,8 +111,10 @@ from snowflake.snowpark._internal.utils import (
     MODULE_NAME_TO_PACKAGE_NAME_MAP,
     STAGE_PREFIX,
     SUPPORTED_TABLE_TYPES,
-    XPATH_HANDLERS_FILE_PATH,
     XPATH_HANDLER_MAP,
+    XPATH_HANDLERS_FILE_PATH,
+    AstFlagSource,
+    AstMode,
     PythonObjJSONEncoder,
     TempObjectType,
     calculate_checksum,
@@ -133,14 +132,17 @@ from snowflake.snowpark._internal.utils import (
     get_temp_type_for_object,
     get_version,
     import_or_missing_modin_pandas,
+    is_ast_enabled,
     is_in_stored_procedure,
     normalize_local_file,
     normalize_remote_file_or_dir,
     parse_positional_args_to_list,
     parse_positional_args_to_list_variadic,
+    private_preview,
     publicapi,
     quote_name,
     random_name_for_temp_object,
+    set_ast_state,
     strip_double_quotes_in_like_statement_in_table_name,
     unwrap_single_quote,
     unwrap_stage_location_single_quote,
@@ -148,21 +150,17 @@ from snowflake.snowpark._internal.utils import (
     warn_session_config_update_in_multithreaded_mode,
     warning,
     zip_file_or_directory_to_stream,
-    set_ast_state,
-    is_ast_enabled,
-    AstFlagSource,
-    AstMode,
-    private_preview,
 )
 from snowflake.snowpark.async_job import AsyncJob, _AsyncResultType
 from snowflake.snowpark.column import Column
 from snowflake.snowpark.context import (
-    _is_execution_environment_sandboxed_for_client,
-    _use_scoped_temp_objects,
     _ANACONDA_SHARED_REPOSITORY,
     _DEFAULT_ARTIFACT_REPOSITORY,
+    _is_execution_environment_sandboxed_for_client,
+    _use_scoped_temp_objects,
 )
 from snowflake.snowpark.dataframe import DataFrame
+from snowflake.snowpark.dataframe_profiler import DataframeProfiler
 from snowflake.snowpark.dataframe_reader import DataFrameReader
 from snowflake.snowpark.exceptions import (
     SnowparkClientException,
@@ -170,7 +168,6 @@ from snowflake.snowpark.exceptions import (
 )
 from snowflake.snowpark.file_operation import FileOperation
 from snowflake.snowpark.functions import (
-    to_file,
     array_agg,
     col,
     column,
@@ -178,6 +175,7 @@ from snowflake.snowpark.functions import (
     parse_json,
     to_date,
     to_decimal,
+    to_file,
     to_geography,
     to_geometry,
     to_time,
@@ -205,7 +203,6 @@ from snowflake.snowpark.query_history import AstListener, QueryHistory
 from snowflake.snowpark.row import Row
 from snowflake.snowpark.stored_procedure import StoredProcedureRegistration
 from snowflake.snowpark.stored_procedure_profiler import StoredProcedureProfiler
-from snowflake.snowpark.dataframe_profiler import DataframeProfiler
 from snowflake.snowpark.table import Table
 from snowflake.snowpark.table_function import (
     TableFunctionCall,
@@ -217,6 +214,7 @@ from snowflake.snowpark.types import (
     DateType,
     DayTimeIntervalType,
     DecimalType,
+    FileType,
     FloatType,
     GeographyType,
     GeometryType,
@@ -231,7 +229,6 @@ from snowflake.snowpark.types import (
     VariantType,
     VectorType,
     YearMonthIntervalType,
-    FileType,
     _AtomicType,
 )
 from snowflake.snowpark.udaf import UDAFRegistration
@@ -319,6 +316,7 @@ DEFAULT_COMPLEXITY_SCORE_LOWER_BOUND = 10_000_000
 DEFAULT_COMPLEXITY_SCORE_UPPER_BOUND = 12_000_000
 WRITE_PANDAS_CHUNK_SIZE: int = 100000 if is_in_stored_procedure() else None
 WRITE_ARROW_CHUNK_SIZE: int = 100000 if is_in_stored_procedure() else None
+MemberRef = Union[str, Tuple[str, str]]
 
 
 def _get_active_session() -> "Session":
@@ -363,6 +361,48 @@ def _remove_session(session: "Session") -> None:
             _active_sessions.remove(session)
         except KeyError:
             pass
+
+
+def _render_semantic_view_clause(
+    keyword: str, param: str, value: Union[str, Iterable[MemberRef]]
+) -> str:
+    """Renders one clause of a ``SEMANTIC_VIEW(...)`` call.
+
+    A ``str`` is emitted verbatim: the clause grammar already accepts a comma list,
+    and splitting would break a member such as ``TO_CHAR(d,'YY')``.
+    """
+    if isinstance(value, str):
+        return f"{keyword} {value}"
+    if isinstance(value, tuple):
+        raise TypeError(
+            f"{param} does not accept a tuple at the top level, because "
+            f'{param}=("a", "b") is ambiguous. Pass a list for several members '
+            f'({param}=["a", "b"]), or wrap the pair to mean one dotted member '
+            f'({param}=[("a", "b")]).'
+        )
+    if not isinstance(value, list):
+        raise TypeError(
+            f"{param} should be a string, or a list of members, not "
+            f"{type(value).__name__}."
+        )
+
+    members = []
+    for i, member in enumerate(value):
+        if isinstance(member, str):
+            members.append(member)
+        elif isinstance(member, tuple):
+            if len(member) != 2:
+                raise TypeError(
+                    f"{param}[{i}] is a {len(member)}-tuple; a tuple member must be "
+                    f"(table, attribute)."
+                )
+            members.append(".".join(member))
+        else:
+            raise TypeError(
+                f"{param}[{i}] should be a string or a (table, attribute) tuple, "
+                f"not {type(member).__name__}."
+            )
+    return f"{keyword} {', '.join(members)}"
 
 
 class Session:
@@ -602,9 +642,9 @@ class Session:
         # due to server side accessing private session members, this cannot be merged with _artifact_repository_packages
         self._packages: Dict[str, str] = {}
         # map of artifact repository name -> packages that should be added to functions under that repository
-        self._artifact_repository_packages: DefaultDict[
-            str, Dict[str, str]
-        ] = defaultdict(dict)
+        self._artifact_repository_packages: DefaultDict[str, Dict[str, str]] = (
+            defaultdict(dict)
+        )
         # Single-entry cache for the default artifact repository value.
         # Stores a tuple of ((database, schema), cached_value).  Only one entry is
         # kept at a time – switching to a different database/schema will evict the old
@@ -760,8 +800,8 @@ class Session:
 
         # development features require AST to be enabled
         from snowflake.snowpark.context import (
-            _enable_trace_sql_errors_to_dataframe,
             _enable_dataframe_trace_on_error,
+            _enable_trace_sql_errors_to_dataframe,
         )
 
         if _enable_trace_sql_errors_to_dataframe or _enable_dataframe_trace_on_error:
@@ -794,10 +834,10 @@ class Session:
             try:
                 from modin.config import AutoSwitchBackend
 
-                pandas_hybrid_execution_enabled: Union[
-                    bool, None
-                ] = self._conn._get_client_side_session_parameter(
-                    _SNOWPARK_PANDAS_HYBRID_EXECUTION_ENABLED, None
+                pandas_hybrid_execution_enabled: Union[bool, None] = (
+                    self._conn._get_client_side_session_parameter(
+                        _SNOWPARK_PANDAS_HYBRID_EXECUTION_ENABLED, None
+                    )
                 )
                 # Only set AutoSwitchBackend if the session parameter was already set.
                 # snowflake.snowpark.modin.plugin sets AutoSwitchBackend to True if it was
@@ -1922,7 +1962,7 @@ class Session:
 
     @staticmethod
     def _parse_packages(
-        packages: List[Union[str, ModuleType]]
+        packages: List[Union[str, ModuleType]],
     ) -> Dict[str, Tuple[str, bool, Requirement]]:
         package_dict = dict()
         for package in packages:
@@ -2468,12 +2508,14 @@ class Session:
                 entity_selector_args = (
                     f"'schema', '{schema}'"
                     if schema
-                    else f"'database', '{database}'"
-                    if database
-                    # self.get_current_account uses a cached connector field that may not be properly cased, so we need to
-                    # explicitly issue a query for it.
-                    # Since this issues a query, we should compute it only if database/schema are unset.
-                    else f"""'account', '{quote_name_without_upper_casing(self._conn._get_string_datum("SELECT CURRENT_ACCOUNT()"))}'"""
+                    else (
+                        f"'database', '{database}'"
+                        if database
+                        # self.get_current_account uses a cached connector field that may not be properly cased, so we need to
+                        # explicitly issue a query for it.
+                        # Since this issues a query, we should compute it only if database/schema are unset.
+                        else f"""'account', '{quote_name_without_upper_casing(self._conn._get_string_datum("SELECT CURRENT_ACCOUNT()"))}'"""
+                    )
                 )
                 result = self._run_query(
                     f"SELECT SYSTEM$GET_DEFAULT_PYTHON_ARTIFACT_REPOSITORY('{python_version}', {entity_selector_args})"
@@ -3167,6 +3209,71 @@ class Session:
             )
         set_api_call_source(d, "Session.sql")
         return d
+
+    @experimental(version="1.55.0")
+    def semantic_view(
+        self,
+        name: Union[str, Iterable[str]],
+        *,
+        dimensions: Optional[Union[str, Iterable[MemberRef]]] = None,
+        metrics: Optional[Union[str, Iterable[MemberRef]]] = None,
+        facts: Optional[Union[str, Iterable[MemberRef]]] = None,
+        where: Optional[str] = None,
+    ) -> DataFrame:
+        """Returns a :class:`DataFrame` for a query against a semantic view.
+
+        At least one of ``dimensions``, ``metrics``, or ``facts`` is required;
+        ``where`` alone is not a valid query.
+
+        A clause string is emitted verbatim, so several members and inline ``AS``
+        aliases can be written in one string. Clauses are always emitted in the
+        order ``DIMENSIONS``, ``METRICS``, ``FACTS``, ``WHERE``, which sets the
+        default column order; reorder with :meth:`DataFrame.select`.
+
+        Args:
+            name: A string or list of strings that specify the semantic view name
+                or fully-qualified object identifier (database name, schema name,
+                and semantic view name).
+            dimensions: Members to group by, as a verbatim clause string or a list
+                of members. A list element may be a string, or a
+                ``(table, attribute)`` tuple that is joined with a dot.
+            metrics: Members to aggregate, in the same forms as ``dimensions``.
+            facts: Row-level members, in the same forms as ``dimensions``. The
+                server rejects ``facts`` together with ``metrics``.
+            where: A condition applied *before* aggregation. It may reference
+                dimensions and facts, but not metrics. Filter on a metric with
+                :meth:`DataFrame.filter` on the returned DataFrame instead.
+        """
+        if isinstance(self._conn, MockServerConnection):
+            self._conn.log_not_supported_error(
+                external_feature_name="Session.semantic_view",
+                raise_error=NotImplementedError,
+            )
+
+        if dimensions is None and metrics is None and facts is None:
+            raise ValueError(
+                "semantic_view() requires at least one of dimensions, metrics, "
+                "or facts. A where condition alone is not a valid query."
+            )
+
+        if not isinstance(name, str) and isinstance(name, Iterable):
+            name = ".".join(name)
+        validate_object_name(name)
+
+        parts = [name]
+        for keyword, param, value in (
+            ("DIMENSIONS", "dimensions", dimensions),
+            ("METRICS", "metrics", metrics),
+            ("FACTS", "facts", facts),
+        ):
+            if value is not None:
+                parts.append(_render_semantic_view_clause(keyword, param, value))
+        if where is not None:
+            parts.append(f"WHERE {where}")
+
+        df = self.sql(f"SELECT * FROM SEMANTIC_VIEW({' '.join(parts)})")
+        set_api_call_source(df, "Session.semantic_view")
+        return df
 
     @property
     def read(self) -> "DataFrameReader":

--- a/tests/integ/test_semantic_view.py
+++ b/tests/integ/test_semantic_view.py
@@ -23,51 +23,62 @@ def semantic_view(session):
     orders = Utils.random_table_name()
     view = Utils.random_view_name()
 
-    Utils.create_table(
-        session, customers, "customer_id INT, customer_name STRING, region STRING"
-    )
-    session._run_query(
-        f"INSERT INTO {customers} VALUES "
-        "(1,'Ada','EMEA'),(2,'Blake','AMER'),(3,'Chen','APAC'),(4,'Dara','EMEA')"
-    )
-    Utils.create_table(
-        session, orders, "order_id INT, customer_id INT, order_date DATE, amount INT"
-    )
-    session._run_query(
-        f"INSERT INTO {orders} VALUES "
-        "(10,1,'2026-01-05',200),(11,1,'2026-02-11',150),(12,2,'2026-01-20',350),"
-        "(13,3,'2026-03-02',300),(14,3,'2026-03-09',350),(15,4,'2026-03-15',450)"
-    )
-    session._run_query(
-        f"""
-        CREATE OR REPLACE SEMANTIC VIEW {view}
-          TABLES (
-            customers AS {customers} PRIMARY KEY (customer_id),
-            orders    AS {orders}    PRIMARY KEY (order_id)
-          )
-          RELATIONSHIPS (
-            orders (customer_id) REFERENCES customers
-          )
-          FACTS (
-            orders.order_amount      AS amount,
-            customers.customer_total AS SUM(orders.order_amount)
-          )
-          DIMENSIONS (
-            customers.customer AS customer_name,
-            customers.region   AS region
-          )
-          METRICS (
-            orders.revenue           AS SUM(amount),
-            customers.customer_count AS COUNT(customer_id)
-          )
-        """
-    )
+    # The tables are permanent, so teardown must run even if the DDL below fails.
+    try:
+        Utils.create_table(
+            session, customers, "customer_id INT, customer_name STRING, region STRING"
+        )
+        session._run_query(
+            f"INSERT INTO {customers} VALUES "
+            "(1,'Ada','EMEA'),(2,'Blake','AMER'),(3,'Chen','APAC'),(4,'Dara','EMEA')"
+        )
+        Utils.create_table(
+            session,
+            orders,
+            "order_id INT, customer_id INT, order_date DATE, amount INT",
+        )
+        session._run_query(
+            f"INSERT INTO {orders} VALUES "
+            "(10,1,'2026-01-05',200),(11,1,'2026-02-11',150),(12,2,'2026-01-20',350),"
+            "(13,3,'2026-03-02',300),(14,3,'2026-03-09',350),(15,4,'2026-03-15',450)"
+        )
+        session._run_query(
+            f"""
+            CREATE OR REPLACE SEMANTIC VIEW {view}
+              TABLES (
+                customers AS {customers} PRIMARY KEY (customer_id),
+                orders    AS {orders}    PRIMARY KEY (order_id)
+              )
+              RELATIONSHIPS (
+                orders (customer_id) REFERENCES customers
+              )
+              FACTS (
+                orders.order_amount      AS amount,
+                customers.customer_total AS SUM(orders.order_amount)
+              )
+              DIMENSIONS (
+                customers.customer AS customer_name,
+                customers.region   AS region
+              )
+              METRICS (
+                orders.revenue           AS SUM(amount),
+                customers.customer_count AS COUNT(customer_id)
+              )
+            """
+        )
 
-    yield view
-
-    session._run_query(f"DROP SEMANTIC VIEW IF EXISTS {view}")
-    Utils.drop_table(session, orders)
-    Utils.drop_table(session, customers)
+        yield view
+    finally:
+        # Each drop is independent: a failing one must not strand the others.
+        for drop in (
+            lambda: session._run_query(f"DROP SEMANTIC VIEW IF EXISTS {view}"),
+            lambda: Utils.drop_table(session, orders),
+            lambda: Utils.drop_table(session, customers),
+        ):
+            try:
+                drop()
+            except Exception:  # noqa: BLE001 - teardown is best effort
+                pass
 
 
 def test_metrics_only(session, semantic_view):

--- a/tests/integ/test_semantic_view.py
+++ b/tests/integ/test_semantic_view.py
@@ -2,6 +2,8 @@
 # Copyright (c) 2012-2025 Snowflake Computing Inc. All rights reserved.
 #
 
+import logging
+
 import pytest
 
 from snowflake.snowpark import Row
@@ -69,16 +71,17 @@ def semantic_view(session):
 
         yield view
     finally:
-        # Each drop is independent: a failing one must not strand the others.
-        for drop in (
-            lambda: session._run_query(f"DROP SEMANTIC VIEW IF EXISTS {view}"),
-            lambda: Utils.drop_table(session, orders),
-            lambda: Utils.drop_table(session, customers),
+        # Each drop is independent: a failing one must not strand the others, and a
+        # silent failure would leave permanent tables behind with a green test run.
+        for what, drop in (
+            (view, lambda: session._run_query(f"DROP SEMANTIC VIEW IF EXISTS {view}")),
+            (orders, lambda: Utils.drop_table(session, orders)),
+            (customers, lambda: Utils.drop_table(session, customers)),
         ):
             try:
                 drop()
-            except Exception:  # noqa: BLE001 - teardown is best effort
-                pass
+            except Exception as e:  # noqa: BLE001 - teardown is best effort
+                logging.getLogger(__name__).warning("failed to drop %s: %s", what, e)
 
 
 def test_metrics_only(session, semantic_view):
@@ -106,6 +109,30 @@ def test_where_is_applied_before_aggregation(session, semantic_view):
         metrics="orders.revenue",
         where="customers.region = 'EMEA'",
     ).collect() == [Row(REGION="EMEA", REVENUE=800)]
+
+
+def test_where_sequence_parentheses_change_the_rows(session, semantic_view):
+    """The parentheses are a semantic guarantee, so pin it against the server.
+
+    Without them ``AND`` binds tighter than the ``OR`` inside the first element and
+    three rows come back instead of one.
+    """
+    assert session.semantic_view(
+        semantic_view,
+        dimensions=["customers.customer", "customers.region"],
+        where=[
+            "customers.region = 'EMEA' OR customers.region = 'APAC'",
+            "customers.customer = 'Chen'",
+        ],
+    ).collect() == [Row(CUSTOMER="Chen", REGION="APAC")]
+
+    unparenthesized = session.sql(
+        f"SELECT * FROM SEMANTIC_VIEW({semantic_view} "
+        "DIMENSIONS customers.customer, customers.region "
+        "WHERE customers.region = 'EMEA' OR customers.region = 'APAC' "
+        "AND customers.customer = 'Chen')"
+    )
+    assert unparenthesized.count() == 3
 
 
 def test_tuple_member_is_table_dot_attribute(session, semantic_view):
@@ -142,6 +169,7 @@ def test_facts_are_row_level(session, semantic_view):
     assert sorted(r[0] for r in rows.collect()) == [350, 350, 450, 650]
 
 
-def test_where_alone_raises_before_any_query(session, semantic_view):
+def test_where_alone_raises_before_any_query(session):
+    """No fixture: this raises client-side, so it must not create objects to prove it."""
     with pytest.raises(ValueError, match="at least one"):
-        session.semantic_view(semantic_view, where="customers.region = 'EMEA'")
+        session.semantic_view("NO_SUCH_VIEW", where="customers.region = 'EMEA'")

--- a/tests/integ/test_semantic_view.py
+++ b/tests/integ/test_semantic_view.py
@@ -1,0 +1,136 @@
+#
+# Copyright (c) 2012-2025 Snowflake Computing Inc. All rights reserved.
+#
+
+import pytest
+
+from snowflake.snowpark import Row
+from snowflake.snowpark.functions import col
+from tests.utils import Utils
+
+pytestmark = [
+    pytest.mark.xfail(
+        "config.getoption('local_testing_mode', default=False)",
+        reason="semantic views are a SQL feature",
+        run=False,
+    )
+]
+
+
+@pytest.fixture(scope="module")
+def semantic_view(session):
+    customers = Utils.random_table_name()
+    orders = Utils.random_table_name()
+    view = Utils.random_view_name()
+
+    Utils.create_table(
+        session, customers, "customer_id INT, customer_name STRING, region STRING"
+    )
+    session._run_query(
+        f"INSERT INTO {customers} VALUES "
+        "(1,'Ada','EMEA'),(2,'Blake','AMER'),(3,'Chen','APAC'),(4,'Dara','EMEA')"
+    )
+    Utils.create_table(
+        session, orders, "order_id INT, customer_id INT, order_date DATE, amount INT"
+    )
+    session._run_query(
+        f"INSERT INTO {orders} VALUES "
+        "(10,1,'2026-01-05',200),(11,1,'2026-02-11',150),(12,2,'2026-01-20',350),"
+        "(13,3,'2026-03-02',300),(14,3,'2026-03-09',350),(15,4,'2026-03-15',450)"
+    )
+    session._run_query(
+        f"""
+        CREATE OR REPLACE SEMANTIC VIEW {view}
+          TABLES (
+            customers AS {customers} PRIMARY KEY (customer_id),
+            orders    AS {orders}    PRIMARY KEY (order_id)
+          )
+          RELATIONSHIPS (
+            orders (customer_id) REFERENCES customers
+          )
+          FACTS (
+            orders.order_amount      AS amount,
+            customers.customer_total AS SUM(orders.order_amount)
+          )
+          DIMENSIONS (
+            customers.customer AS customer_name,
+            customers.region   AS region
+          )
+          METRICS (
+            orders.revenue           AS SUM(amount),
+            customers.customer_count AS COUNT(customer_id)
+          )
+        """
+    )
+
+    yield view
+
+    session._run_query(f"DROP SEMANTIC VIEW IF EXISTS {view}")
+    Utils.drop_table(session, orders)
+    Utils.drop_table(session, customers)
+
+
+def test_metrics_only(session, semantic_view):
+    assert session.semantic_view(semantic_view, metrics="orders.revenue").collect() == [
+        Row(REVENUE=1800)
+    ]
+
+
+def test_dimensions_and_metrics(session, semantic_view):
+    assert session.semantic_view(
+        semantic_view,
+        dimensions=["customers.region"],
+        metrics=["orders.revenue"],
+    ).sort(col("REGION")).collect() == [
+        Row(REGION="AMER", REVENUE=350),
+        Row(REGION="APAC", REVENUE=650),
+        Row(REGION="EMEA", REVENUE=800),
+    ]
+
+
+def test_where_is_applied_before_aggregation(session, semantic_view):
+    assert session.semantic_view(
+        semantic_view,
+        dimensions="customers.region",
+        metrics="orders.revenue",
+        where="customers.region = 'EMEA'",
+    ).collect() == [Row(REGION="EMEA", REVENUE=800)]
+
+
+def test_tuple_member_is_table_dot_attribute(session, semantic_view):
+    assert session.semantic_view(
+        semantic_view,
+        dimensions=[("customers", "region")],
+        metrics=["orders.revenue"],
+    ).sort(col("REGION")).collect() == [
+        Row(REGION="AMER", REVENUE=350),
+        Row(REGION="APAC", REVENUE=650),
+        Row(REGION="EMEA", REVENUE=800),
+    ]
+
+
+def test_filter_after_the_call_composes(session, semantic_view):
+    """Filtering on a metric happens outside the parens, on the DataFrame."""
+    assert session.semantic_view(
+        semantic_view,
+        dimensions="customers.region",
+        metrics="orders.revenue",
+    ).filter(col("REVENUE") > 400).sort(col("REGION")).collect() == [
+        Row(REGION="APAC", REVENUE=650),
+        Row(REGION="EMEA", REVENUE=800),
+    ]
+
+
+def test_inline_alias_renames_the_column(session, semantic_view):
+    df = session.semantic_view(semantic_view, metrics="orders.revenue AS REV")
+    assert df.columns == ["REV"]
+
+
+def test_facts_are_row_level(session, semantic_view):
+    rows = session.semantic_view(semantic_view, facts="customers.customer_total")
+    assert sorted(r[0] for r in rows.collect()) == [350, 350, 450, 650]
+
+
+def test_where_alone_raises_before_any_query(session, semantic_view):
+    with pytest.raises(ValueError, match="at least one"):
+        session.semantic_view(semantic_view, where="customers.region = 'EMEA'")

--- a/tests/integ/test_semantic_view.py
+++ b/tests/integ/test_semantic_view.py
@@ -80,7 +80,7 @@ def semantic_view(session):
         ):
             try:
                 drop()
-            except Exception as e:  # noqa: BLE001 - teardown is best effort
+            except Exception as e:  # teardown is best effort
                 logging.getLogger(__name__).warning("failed to drop %s: %s", what, e)
 
 
@@ -103,12 +103,18 @@ def test_dimensions_and_metrics(session, semantic_view):
 
 
 def test_where_is_applied_before_aggregation(session, semantic_view):
+    """A fact predicate: EMEA is 450 only if the 200 and 150 orders were dropped
+    before ``SUM``. Filtering the aggregate would leave it at 800."""
     assert session.semantic_view(
         semantic_view,
         dimensions="customers.region",
         metrics="orders.revenue",
-        where="customers.region = 'EMEA'",
-    ).collect() == [Row(REGION="EMEA", REVENUE=800)]
+        where="orders.order_amount > 200",
+    ).sort(col("REGION")).collect() == [
+        Row(REGION="AMER", REVENUE=350),
+        Row(REGION="APAC", REVENUE=650),
+        Row(REGION="EMEA", REVENUE=450),
+    ]
 
 
 def test_where_sequence_parentheses_change_the_rows(session, semantic_view):

--- a/tests/mock/test_not_implemented_error.py
+++ b/tests/mock/test_not_implemented_error.py
@@ -21,3 +21,12 @@ def test_connection(session):
 
     with pytest.raises(NotImplementedError):
         MockServerConnection().get_result_set(None)
+
+
+def test_semantic_view(session):
+    with pytest.raises(NotImplementedError):
+        session.semantic_view("V", metrics="orders.revenue")
+
+    # Unsupported-feature error wins over argument validation.
+    with pytest.raises(NotImplementedError):
+        session.semantic_view("V")

--- a/tests/unit/test_semantic_view.py
+++ b/tests/unit/test_semantic_view.py
@@ -146,9 +146,12 @@ def test_where_alone_does_not_satisfy_the_rule(fake_session):
 # bare keyword: ``SEMANTIC_VIEW(V METRICS )`` is 001003.
 
 
-def test_empty_list_raises_and_sends_no_query(fake_session):
-    with pytest.raises(ValueError, match="metrics is an empty list"):
-        call(fake_session, "V", metrics=[])
+@pytest.mark.parametrize("empty,kind", [([], "list"), ((), "tuple")])
+def test_empty_container_raises_and_sends_no_query(fake_session, empty, kind):
+    """The message names the container type. "Omit it" is wrong advice for a list that
+    came back empty from a comprehension, so the two cases stay distinguishable."""
+    with pytest.raises(ValueError, match=f"metrics is an empty {kind}"):
+        call(fake_session, "V", metrics=empty)
     fake_session.sql.assert_not_called()
 
 
@@ -191,26 +194,26 @@ def test_empty_clause_is_rejected_not_dropped(fake_session):
 # --- rejected clause value types ------------------------------------------
 
 
-def test_top_level_tuple_raises_type_error(fake_session):
-    """Two members and member-with-alias are both plausible, so refuse to guess."""
-    with pytest.raises(TypeError) as exc:
-        call(fake_session, "V", metrics=("a", "b"))
-    message = str(exc.value)
-    assert "metrics" in message
-    assert 'metrics=["a", "b"]' in message
-    assert 'metrics=[("a", "b")]' in message
-    fake_session.sql.assert_not_called()
+@pytest.mark.parametrize(
+    "value,expected",
+    [
+        (("a", "b"), "a, b"),  # a bare pair is simply two members
+        (("a", "b", "c"), "a, b, c"),
+        (("a",), "a"),
+        ((("a", "b"),), "a.b"),  # tuple holding one (table, attribute) pair
+        ((("a", "b"), ("c", "d")), "a.b, c.d"),
+        (("a", ("b", "c")), "a, b.c"),  # mixed
+    ],
+)
+def test_tuple_container_is_accepted(fake_session, value, expected):
+    """A tuple is a container of members, exactly like a list.
 
-
-@pytest.mark.parametrize("arity", [1, 3])
-def test_top_level_tuple_of_other_arity_does_not_claim_ambiguity(fake_session, arity):
-    with pytest.raises(TypeError) as exc:
-        call(fake_session, "V", metrics=tuple("abc"[:arity]))
-    message = str(exc.value)
-    assert "does not accept a tuple at the top level" in message
-    assert "ambiguous" not in message
-    assert "metrics=[...]" in message
-    fake_session.sql.assert_not_called()
+    ``("a", "b")`` and ``[("a", "b")]`` are different objects, so there is nothing to
+    disambiguate, and ``RelationalGroupedDataFrame.agg`` accepts both spellings of its
+    own 2-tuple element for the same reason.
+    """
+    call(fake_session, "V", metrics=value)
+    assert emitted(fake_session) == f"SELECT * FROM SEMANTIC_VIEW(V METRICS {expected})"
 
 
 @pytest.mark.parametrize("bad", [("a",), ("a", "b", "c")])
@@ -251,21 +254,68 @@ def test_set_is_rejected(fake_session):
 @pytest.mark.parametrize("bad", [b"revenue", bytearray(b"revenue")])
 def test_bytes_is_rejected(fake_session, bad):
     """bytes is Iterable, so an ``isinstance(x, str)`` guard alone would let it through."""
-    with pytest.raises(TypeError, match="should be a string, or a list of members"):
+    with pytest.raises(TypeError, match="should be a string, or a sequence of members"):
         call(fake_session, "V", metrics=bad)
     fake_session.sql.assert_not_called()
 
 
 def test_int_is_rejected(fake_session):
-    with pytest.raises(TypeError, match="should be a string, or a list of members"):
+    with pytest.raises(TypeError, match="should be a string, or a sequence of members"):
         call(fake_session, "V", metrics=1)
     fake_session.sql.assert_not_called()
 
 
-@pytest.mark.parametrize("bad", [123, ["x = 1"], ("x = 1",)])
-def test_non_string_where_is_rejected(fake_session, bad):
-    with pytest.raises(TypeError, match="where should be a string"):
+@pytest.mark.parametrize("bad", [123, {"x = 1"}, (c for c in "ab")])
+def test_non_sequence_where_is_rejected(fake_session, bad):
+    with pytest.raises(
+        TypeError, match="where should be a string, or a sequence of conditions"
+    ):
         call(fake_session, "V", metrics="m", where=bad)
+    fake_session.sql.assert_not_called()
+
+
+def test_where_sequence_is_and_joined_with_each_element_parenthesized(fake_session):
+    """``WHERE`` takes one expression, so a sequence must be combined, not comma-joined.
+
+    The parentheses are load-bearing: verified on the server that without them an
+    element containing ``OR`` changes the result (3 rows became 1), because ``AND``
+    binds tighter. Wrapping is semantically neutral, also verified.
+    """
+    call(
+        fake_session,
+        "V",
+        metrics="m",
+        where=["region = 'EMEA' OR region = 'APAC'", "customer = 'Chen'"],
+    )
+    assert emitted(fake_session) == (
+        "SELECT * FROM SEMANTIC_VIEW(V METRICS m "
+        "WHERE (region = 'EMEA' OR region = 'APAC') AND (customer = 'Chen'))"
+    )
+
+
+def test_where_string_is_emitted_verbatim_without_parentheses(fake_session):
+    call(fake_session, "V", metrics="m", where="a = 1 AND b = 2")
+    assert emitted(fake_session) == (
+        "SELECT * FROM SEMANTIC_VIEW(V METRICS m WHERE a = 1 AND b = 2)"
+    )
+
+
+@pytest.mark.parametrize("empty,kind", [([], "list"), ((), "tuple")])
+def test_empty_where_container_is_rejected(fake_session, empty, kind):
+    with pytest.raises(ValueError, match=f"where is an empty {kind}"):
+        call(fake_session, "V", metrics="m", where=empty)
+    fake_session.sql.assert_not_called()
+
+
+def test_blank_condition_in_a_where_sequence_is_rejected(fake_session):
+    with pytest.raises(ValueError, match=r"where\[1\] is an empty condition"):
+        call(fake_session, "V", metrics="m", where=["a = 1", "  "])
+    fake_session.sql.assert_not_called()
+
+
+def test_non_string_condition_is_rejected_with_its_index(fake_session):
+    with pytest.raises(TypeError, match=r"where\[1\] should be a string"):
+        call(fake_session, "V", metrics="m", where=["a = 1", 2])
     fake_session.sql.assert_not_called()
 
 
@@ -294,6 +344,21 @@ def test_set_name_is_rejected(fake_session, bad):
     with pytest.raises(TypeError, match="name should be a string"):
         call(fake_session, bad, metrics="m")
     fake_session.sql.assert_not_called()
+
+
+def test_deque_is_accepted_because_the_annotation_says_sequence(fake_session):
+    """A deque is a Sequence, so the runtime must not reject what the signature allows."""
+    from collections import deque
+
+    call(fake_session, "V", metrics=deque(["a", "b"]))
+    assert emitted(fake_session) == "SELECT * FROM SEMANTIC_VIEW(V METRICS a, b)"
+
+
+def test_blank_name_part_is_passed_through(fake_session):
+    """``DB..V`` is valid Snowflake for ``DB.PUBLIC.V``, and ``Session.table`` passes it
+    through too. The signature is the contract; we do not second-guess a valid name."""
+    call(fake_session, ["DB", "", "V"], metrics="m")
+    assert emitted(fake_session) == "SELECT * FROM SEMANTIC_VIEW(DB..V METRICS m)"
 
 
 @pytest.mark.parametrize("bad", [b"DB", bytearray(b"DB"), 1, None])

--- a/tests/unit/test_semantic_view.py
+++ b/tests/unit/test_semantic_view.py
@@ -221,6 +221,16 @@ def test_tuple_element_of_wrong_arity_raises_type_error(fake_session, bad):
     fake_session.sql.assert_not_called()
 
 
+@pytest.mark.parametrize("bad", [1, None, 1.5, ["nested"], {"k": "v"}])
+def test_member_that_is_neither_string_nor_tuple_is_rejected(fake_session, bad):
+    with pytest.raises(
+        TypeError,
+        match=r"metrics\[1\] should be a string or a \(table, attribute\) tuple",
+    ):
+        call(fake_session, "V", metrics=["ok", bad])
+    fake_session.sql.assert_not_called()
+
+
 @pytest.mark.parametrize("bad", [("a", 1), (1, "b"), ("a", None)])
 def test_tuple_element_contents_must_be_strings(fake_session, bad):
     with pytest.raises(TypeError) as exc:

--- a/tests/unit/test_semantic_view.py
+++ b/tests/unit/test_semantic_view.py
@@ -162,9 +162,11 @@ def test_blank_clause_string_raises_and_sends_no_query(fake_session, blank):
     fake_session.sql.assert_not_called()
 
 
-def test_blank_member_in_a_list_raises_with_its_index(fake_session):
-    with pytest.raises(ValueError, match=r"metrics\[1\] is an empty member name"):
-        call(fake_session, "V", metrics=["orders.revenue", ""])
+@pytest.mark.parametrize("param", ["dimensions", "metrics", "facts"])
+def test_blank_member_in_a_list_raises_with_its_index(fake_session, param):
+    """The message names the caller's parameter, not just the SQL keyword."""
+    with pytest.raises(ValueError, match=rf"{param}\[1\] is an empty member name"):
+        call(fake_session, "V", **{param: ["orders.revenue", ""]})
     fake_session.sql.assert_not_called()
 
 
@@ -206,12 +208,7 @@ def test_empty_clause_is_rejected_not_dropped(fake_session):
     ],
 )
 def test_tuple_container_is_accepted(fake_session, value, expected):
-    """A tuple is a container of members, exactly like a list.
-
-    ``("a", "b")`` and ``[("a", "b")]`` are different objects, so there is nothing to
-    disambiguate, and ``RelationalGroupedDataFrame.agg`` accepts both spellings of its
-    own 2-tuple element for the same reason.
-    """
+    """A tuple is a container of members, exactly like a list."""
     call(fake_session, "V", metrics=value)
     assert emitted(fake_session) == f"SELECT * FROM SEMANTIC_VIEW(V METRICS {expected})"
 
@@ -251,7 +248,9 @@ def test_set_is_rejected(fake_session):
     fake_session.sql.assert_not_called()
 
 
-@pytest.mark.parametrize("bad", [b"revenue", bytearray(b"revenue")])
+@pytest.mark.parametrize(
+    "bad", [b"revenue", bytearray(b"revenue"), memoryview(b"revenue")]
+)
 def test_bytes_is_rejected(fake_session, bad):
     """bytes is Iterable, so an ``isinstance(x, str)`` guard alone would let it through."""
     with pytest.raises(TypeError, match="should be a string, or a sequence of members"):
@@ -265,7 +264,9 @@ def test_int_is_rejected(fake_session):
     fake_session.sql.assert_not_called()
 
 
-@pytest.mark.parametrize("bad", [123, {"x = 1"}, (c for c in "ab")])
+@pytest.mark.parametrize(
+    "bad", [123, {"x = 1"}, (c for c in "ab"), b"x = 1", memoryview(b"x = 1")]
+)
 def test_non_sequence_where_is_rejected(fake_session, bad):
     with pytest.raises(
         TypeError, match="where should be a string, or a sequence of conditions"
@@ -275,12 +276,7 @@ def test_non_sequence_where_is_rejected(fake_session, bad):
 
 
 def test_where_sequence_is_and_joined_with_each_element_parenthesized(fake_session):
-    """``WHERE`` takes one expression, so a sequence must be combined, not comma-joined.
-
-    The parentheses are load-bearing: verified on the server that without them an
-    element containing ``OR`` changes the result (3 rows became 1), because ``AND``
-    binds tighter. Wrapping is semantically neutral, also verified.
-    """
+    """``AND``-joined, each element parenthesized so an inner ``OR`` still binds first."""
     call(
         fake_session,
         "V",
@@ -290,6 +286,13 @@ def test_where_sequence_is_and_joined_with_each_element_parenthesized(fake_sessi
     assert emitted(fake_session) == (
         "SELECT * FROM SEMANTIC_VIEW(V METRICS m "
         "WHERE (region = 'EMEA' OR region = 'APAC') AND (customer = 'Chen'))"
+    )
+
+
+def test_single_condition_sequence_is_still_parenthesized(fake_session):
+    call(fake_session, "V", metrics="m", where=["a = 1"])
+    assert emitted(fake_session) == (
+        "SELECT * FROM SEMANTIC_VIEW(V METRICS m WHERE (a = 1))"
     )
 
 
@@ -354,14 +357,20 @@ def test_deque_is_accepted_because_the_annotation_says_sequence(fake_session):
     assert emitted(fake_session) == "SELECT * FROM SEMANTIC_VIEW(V METRICS a, b)"
 
 
+def test_sequence_name_is_validated_after_joining(fake_session):
+    """The join happens first, so validation must see the joined name."""
+    with pytest.raises(SnowparkInvalidObjectNameException):
+        call(fake_session, ["DB", "a-b", "V"], metrics="m")
+    fake_session.sql.assert_not_called()
+
+
 def test_blank_name_part_is_passed_through(fake_session):
-    """``DB..V`` is valid Snowflake for ``DB.PUBLIC.V``, and ``Session.table`` passes it
-    through too. The signature is the contract; we do not second-guess a valid name."""
+    """``DB..V`` is valid Snowflake for ``DB.PUBLIC.V``."""
     call(fake_session, ["DB", "", "V"], metrics="m")
     assert emitted(fake_session) == "SELECT * FROM SEMANTIC_VIEW(DB..V METRICS m)"
 
 
-@pytest.mark.parametrize("bad", [b"DB", bytearray(b"DB"), 1, None])
+@pytest.mark.parametrize("bad", [b"DB", bytearray(b"DB"), memoryview(b"DB"), 1, None])
 def test_non_sequence_name_is_rejected(fake_session, bad):
     with pytest.raises(TypeError, match="name should be a string"):
         call(fake_session, bad, metrics="m")

--- a/tests/unit/test_semantic_view.py
+++ b/tests/unit/test_semantic_view.py
@@ -2,6 +2,8 @@
 # Copyright (c) 2012-2025 Snowflake Computing Inc. All rights reserved.
 #
 
+import re
+from enum import Enum
 from unittest import mock
 
 import pytest
@@ -69,6 +71,30 @@ def test_tuple_element_is_table_dot_attribute(fake_session):
     )
 
 
+def test_str_subclass_renders_as_its_value(fake_session):
+    """``class X(str, Enum)`` formats as its repr, so clause text is concatenated."""
+
+    class Member(str, Enum):
+        REGION = "customers.region"
+        TABLE = "customers"
+        COLUMN = "region"
+
+    class Condition(str, Enum):
+        EMEA = "customers.region = 'EMEA'"
+
+    call(
+        fake_session,
+        "V",
+        dimensions=Member.REGION,
+        metrics=[(Member.TABLE, Member.COLUMN)],
+        where=Condition.EMEA,
+    )
+    assert emitted(fake_session) == (
+        "SELECT * FROM SEMANTIC_VIEW(V DIMENSIONS customers.region "
+        "METRICS customers.region WHERE customers.region = 'EMEA')"
+    )
+
+
 def test_inline_alias_is_preserved(fake_session):
     call(fake_session, "V", metrics=["orders.revenue AS REV"])
     assert emitted(fake_session) == (
@@ -115,6 +141,53 @@ def test_where_alone_does_not_satisfy_the_rule(fake_session):
     fake_session.sql.assert_not_called()
 
 
+# --- empty values ----------------------------------------------------------
+# An empty value is not None, so it passes the at-least-one rule and renders to a
+# bare keyword: ``SEMANTIC_VIEW(V METRICS )`` is 001003.
+
+
+def test_empty_list_raises_and_sends_no_query(fake_session):
+    with pytest.raises(ValueError, match="metrics is an empty list"):
+        call(fake_session, "V", metrics=[])
+    fake_session.sql.assert_not_called()
+
+
+@pytest.mark.parametrize("blank", ["", "   ", "\t\n"])
+def test_blank_clause_string_raises_and_sends_no_query(fake_session, blank):
+    with pytest.raises(ValueError, match="metrics is empty"):
+        call(fake_session, "V", metrics=blank)
+    fake_session.sql.assert_not_called()
+
+
+def test_blank_member_in_a_list_raises_with_its_index(fake_session):
+    with pytest.raises(ValueError, match=r"metrics\[1\] is an empty member name"):
+        call(fake_session, "V", metrics=["orders.revenue", ""])
+    fake_session.sql.assert_not_called()
+
+
+@pytest.mark.parametrize("bad", [("", "region"), ("customers", ""), ("  ", " ")])
+def test_blank_tuple_part_raises_instead_of_emitting_a_dangling_dot(fake_session, bad):
+    """``DIMENSIONS .region`` is 001003; the plain-string path already rejects this."""
+    with pytest.raises(
+        ValueError, match=r"metrics\[0\] has an empty table or attribute"
+    ):
+        call(fake_session, "V", metrics=[bad])
+    fake_session.sql.assert_not_called()
+
+
+@pytest.mark.parametrize("blank", ["", "   "])
+def test_blank_where_raises_and_sends_no_query(fake_session, blank):
+    with pytest.raises(ValueError, match="where is empty"):
+        call(fake_session, "V", metrics="m", where=blank)
+    fake_session.sql.assert_not_called()
+
+
+def test_empty_clause_is_rejected_not_dropped(fake_session):
+    with pytest.raises(ValueError, match="metrics is an empty list"):
+        call(fake_session, "V", dimensions="customers.region", metrics=[])
+    fake_session.sql.assert_not_called()
+
+
 # --- rejected clause value types ------------------------------------------
 
 
@@ -129,13 +202,32 @@ def test_top_level_tuple_raises_type_error(fake_session):
     fake_session.sql.assert_not_called()
 
 
+@pytest.mark.parametrize("arity", [1, 3])
+def test_top_level_tuple_of_other_arity_does_not_claim_ambiguity(fake_session, arity):
+    with pytest.raises(TypeError) as exc:
+        call(fake_session, "V", metrics=tuple("abc"[:arity]))
+    message = str(exc.value)
+    assert "does not accept a tuple at the top level" in message
+    assert "ambiguous" not in message
+    assert "metrics=[...]" in message
+    fake_session.sql.assert_not_called()
+
+
 @pytest.mark.parametrize("bad", [("a",), ("a", "b", "c")])
 def test_tuple_element_of_wrong_arity_raises_type_error(fake_session, bad):
     with pytest.raises(TypeError) as exc:
         call(fake_session, "V", metrics=["ok", bad])
+    assert re.search(r"metrics\[1\]", str(exc.value))
+    fake_session.sql.assert_not_called()
+
+
+@pytest.mark.parametrize("bad", [("a", 1), (1, "b"), ("a", None)])
+def test_tuple_element_contents_must_be_strings(fake_session, bad):
+    with pytest.raises(TypeError) as exc:
+        call(fake_session, "V", metrics=[bad])
     message = str(exc.value)
-    assert "metrics" in message
-    assert "1" in message  # the offending element's index
+    assert "metrics[0]" in message
+    assert "(table, attribute)" in message
     fake_session.sql.assert_not_called()
 
 
@@ -149,14 +241,21 @@ def test_set_is_rejected(fake_session):
 @pytest.mark.parametrize("bad", [b"revenue", bytearray(b"revenue")])
 def test_bytes_is_rejected(fake_session, bad):
     """bytes is Iterable, so an ``isinstance(x, str)`` guard alone would let it through."""
-    with pytest.raises(TypeError):
+    with pytest.raises(TypeError, match="should be a string, or a list of members"):
         call(fake_session, "V", metrics=bad)
     fake_session.sql.assert_not_called()
 
 
 def test_int_is_rejected(fake_session):
-    with pytest.raises(TypeError):
+    with pytest.raises(TypeError, match="should be a string, or a list of members"):
         call(fake_session, "V", metrics=1)
+    fake_session.sql.assert_not_called()
+
+
+@pytest.mark.parametrize("bad", [123, ["x = 1"], ("x = 1",)])
+def test_non_string_where_is_rejected(fake_session, bad):
+    with pytest.raises(TypeError, match="where should be a string"):
+        call(fake_session, "V", metrics="m", where=bad)
     fake_session.sql.assert_not_called()
 
 
@@ -173,9 +272,31 @@ def test_fully_qualified_name(fake_session):
     assert "SEMANTIC_VIEW(DB.SC.SALES METRICS m)" in emitted(fake_session)
 
 
-def test_iterable_name_is_dot_joined(fake_session):
-    call(fake_session, ["DB", "SC", "SALES"], metrics="m")
+@pytest.mark.parametrize("parts", [["DB", "SC", "SALES"], ("DB", "SC", "SALES")])
+def test_sequence_name_is_dot_joined(fake_session, parts):
+    call(fake_session, parts, metrics="m")
     assert "SEMANTIC_VIEW(DB.SC.SALES METRICS m)" in emitted(fake_session)
+
+
+@pytest.mark.parametrize("bad", [{"DB", "SC", "SALES"}, frozenset({"DB"})])
+def test_set_name_is_rejected(fake_session, bad):
+    """A set would dot-join in an arbitrary order."""
+    with pytest.raises(TypeError, match="name should be a string"):
+        call(fake_session, bad, metrics="m")
+    fake_session.sql.assert_not_called()
+
+
+@pytest.mark.parametrize("bad", [b"DB", bytearray(b"DB"), 1, None])
+def test_non_sequence_name_is_rejected(fake_session, bad):
+    with pytest.raises(TypeError, match="name should be a string"):
+        call(fake_session, bad, metrics="m")
+    fake_session.sql.assert_not_called()
+
+
+def test_non_string_name_part_is_rejected_with_its_index(fake_session):
+    with pytest.raises(TypeError, match=r"name\[1\] should be a string"):
+        call(fake_session, ["DB", 1, "SALES"], metrics="m")
+    fake_session.sql.assert_not_called()
 
 
 def test_quoted_name_is_not_altered(fake_session):
@@ -210,6 +331,21 @@ def test_api_call_source_is_attributed(fake_session):
     df = call(fake_session, "V", metrics="m")
     plan = df._select_statement or df._plan
     assert plan.api_calls == [{"name": "Session.semantic_view"}]
+
+
+@pytest.mark.parametrize("emit", [True, False])
+def test_emit_ast_is_forwarded_to_sql(fake_session, emit):
+    call(fake_session, "V", metrics="m", _emit_ast=emit)
+    assert fake_session.sql.call_args.kwargs["_emit_ast"] is emit
+
+
+def test_publicapi_injects_emit_ast_when_the_caller_omits_it(fake_session):
+    """Fails if ``@publicapi`` is dropped: the parameter default would win instead."""
+    with mock.patch(
+        "snowflake.snowpark._internal.utils.is_ast_enabled", return_value=False
+    ):
+        call(fake_session, "V", metrics="m")
+    assert fake_session.sql.call_args.kwargs["_emit_ast"] is False
 
 
 def test_local_testing_is_rejected(fake_session):

--- a/tests/unit/test_semantic_view.py
+++ b/tests/unit/test_semantic_view.py
@@ -1,0 +1,226 @@
+#
+# Copyright (c) 2012-2025 Snowflake Computing Inc. All rights reserved.
+#
+
+from unittest import mock
+
+import pytest
+
+from snowflake.snowpark.exceptions import SnowparkInvalidObjectNameException
+from snowflake.snowpark.mock._connection import MockServerConnection
+from snowflake.snowpark.session import Session
+
+
+@pytest.fixture
+def fake_session():
+    """A Session stand-in whose ``sql`` is a mock, so the emitted text can be asserted."""
+    session = mock.create_autospec(Session, _session_id=123456)
+    session._conn = mock.MagicMock()
+    return session
+
+
+def call(session, *args, **kwargs):
+    """Invoke the unbound method so no live connection is needed."""
+    return Session.semantic_view(session, *args, **kwargs)
+
+
+def emitted(session):
+    session.sql.assert_called_once()
+    return session.sql.call_args[0][0]
+
+
+# --- clause rendering ------------------------------------------------------
+
+
+def test_metrics_only(fake_session):
+    call(fake_session, "V", metrics=["orders.revenue"])
+    assert (
+        emitted(fake_session) == "SELECT * FROM SEMANTIC_VIEW(V METRICS orders.revenue)"
+    )
+
+
+def test_members_joined_with_comma_space(fake_session):
+    call(fake_session, "V", metrics=["a", "b", "c"])
+    assert emitted(fake_session) == "SELECT * FROM SEMANTIC_VIEW(V METRICS a, b, c)"
+
+
+def test_str_clause_goes_in_verbatim(fake_session):
+    """A string is never comma-split: ``METRICS <text>`` already accepts a list."""
+    call(fake_session, "V", dimensions="NATION.NAME, REGION.NAME AS REGION_NAME")
+    assert emitted(fake_session) == (
+        "SELECT * FROM SEMANTIC_VIEW(V DIMENSIONS NATION.NAME, REGION.NAME AS REGION_NAME)"
+    )
+
+
+def test_str_clause_with_comma_inside_a_function_is_not_split(fake_session):
+    call(fake_session, "V", dimensions="TO_CHAR(orders.order_date,'YY')")
+    assert emitted(fake_session) == (
+        "SELECT * FROM SEMANTIC_VIEW(V DIMENSIONS TO_CHAR(orders.order_date,'YY'))"
+    )
+
+
+def test_tuple_element_is_table_dot_attribute(fake_session):
+    """A 2-tuple element is (table, attribute), as in ``session.table(("db","sc","t"))``."""
+    call(
+        fake_session, "V", dimensions=[("DATE", "CALENDAR_YEAR"), ("PRODUCT", "MARKET")]
+    )
+    assert emitted(fake_session) == (
+        "SELECT * FROM SEMANTIC_VIEW(V DIMENSIONS DATE.CALENDAR_YEAR, PRODUCT.MARKET)"
+    )
+
+
+def test_inline_alias_is_preserved(fake_session):
+    call(fake_session, "V", metrics=["orders.revenue AS REV"])
+    assert emitted(fake_session) == (
+        "SELECT * FROM SEMANTIC_VIEW(V METRICS orders.revenue AS REV)"
+    )
+
+
+# --- emission order --------------------------------------------------------
+
+
+def test_emission_order_is_dimensions_metrics_facts_where(fake_session):
+    """Keyword order cannot express clause order, so one fixed order is emitted.
+
+    ``facts`` with ``metrics`` is rejected by the server (010268) and deliberately
+    not checked here; the client validates form, not semantics.
+    """
+    call(fake_session, "V", where="a = 1", facts="f", metrics="m", dimensions="d")
+    assert emitted(fake_session) == (
+        "SELECT * FROM SEMANTIC_VIEW(V DIMENSIONS d METRICS m FACTS f WHERE a = 1)"
+    )
+
+
+def test_where_comes_last(fake_session):
+    call(fake_session, "V", where="customers.region = 'EMEA'", metrics="orders.revenue")
+    assert emitted(fake_session) == (
+        "SELECT * FROM SEMANTIC_VIEW(V METRICS orders.revenue "
+        "WHERE customers.region = 'EMEA')"
+    )
+
+
+# --- the at-least-one-clause rule -----------------------------------------
+
+
+def test_no_clause_raises_value_error_and_sends_no_query(fake_session):
+    with pytest.raises(ValueError, match="at least one"):
+        call(fake_session, "V")
+    fake_session.sql.assert_not_called()
+
+
+def test_where_alone_does_not_satisfy_the_rule(fake_session):
+    """``SEMANTIC_VIEW(v WHERE x = 'y')`` is 001003 on the server."""
+    with pytest.raises(ValueError, match="at least one"):
+        call(fake_session, "V", where="x = 'y'")
+    fake_session.sql.assert_not_called()
+
+
+# --- rejected clause value types ------------------------------------------
+
+
+def test_top_level_tuple_raises_type_error(fake_session):
+    """Two members and member-with-alias are both plausible, so refuse to guess."""
+    with pytest.raises(TypeError) as exc:
+        call(fake_session, "V", metrics=("a", "b"))
+    message = str(exc.value)
+    assert "metrics" in message
+    assert 'metrics=["a", "b"]' in message
+    assert 'metrics=[("a", "b")]' in message
+    fake_session.sql.assert_not_called()
+
+
+@pytest.mark.parametrize("bad", [("a",), ("a", "b", "c")])
+def test_tuple_element_of_wrong_arity_raises_type_error(fake_session, bad):
+    with pytest.raises(TypeError) as exc:
+        call(fake_session, "V", metrics=["ok", bad])
+    message = str(exc.value)
+    assert "metrics" in message
+    assert "1" in message  # the offending element's index
+    fake_session.sql.assert_not_called()
+
+
+def test_set_is_rejected(fake_session):
+    """Set iteration order is arbitrary and clause order is positional."""
+    with pytest.raises(TypeError):
+        call(fake_session, "V", metrics={"a", "b"})
+    fake_session.sql.assert_not_called()
+
+
+@pytest.mark.parametrize("bad", [b"revenue", bytearray(b"revenue")])
+def test_bytes_is_rejected(fake_session, bad):
+    """bytes is Iterable, so an ``isinstance(x, str)`` guard alone would let it through."""
+    with pytest.raises(TypeError):
+        call(fake_session, "V", metrics=bad)
+    fake_session.sql.assert_not_called()
+
+
+def test_int_is_rejected(fake_session):
+    with pytest.raises(TypeError):
+        call(fake_session, "V", metrics=1)
+    fake_session.sql.assert_not_called()
+
+
+# --- name handling ---------------------------------------------------------
+
+
+def test_plain_name(fake_session):
+    call(fake_session, "SALES", metrics="m")
+    assert "SEMANTIC_VIEW(SALES METRICS m)" in emitted(fake_session)
+
+
+def test_fully_qualified_name(fake_session):
+    call(fake_session, "DB.SC.SALES", metrics="m")
+    assert "SEMANTIC_VIEW(DB.SC.SALES METRICS m)" in emitted(fake_session)
+
+
+def test_iterable_name_is_dot_joined(fake_session):
+    call(fake_session, ["DB", "SC", "SALES"], metrics="m")
+    assert "SEMANTIC_VIEW(DB.SC.SALES METRICS m)" in emitted(fake_session)
+
+
+def test_quoted_name_is_not_altered(fake_session):
+    call(fake_session, 'DB.SC."my view"', metrics="m")
+    assert 'SEMANTIC_VIEW(DB.SC."my view" METRICS m)' in emitted(fake_session)
+
+
+@pytest.mark.parametrize(
+    "bad_name", ["", "a-b", "A.B.C.D", "DB.SC.", ".SALES", "1abc", "sales "]
+)
+def test_invalid_name_raises_and_sends_no_query(fake_session, bad_name):
+    with pytest.raises(SnowparkInvalidObjectNameException):
+        call(fake_session, bad_name, metrics="m")
+    fake_session.sql.assert_not_called()
+
+
+def test_database_and_schema_keywords_are_not_accepted(fake_session):
+    """Qualification lives in the dotted name, as with ``Session.table``."""
+    with pytest.raises(TypeError):
+        call(fake_session, "SALES", metrics="m", database="DB", schema="SC")
+
+
+# --- plumbing --------------------------------------------------------------
+
+
+def test_returns_what_sql_returns(fake_session):
+    df = call(fake_session, "V", metrics="m")
+    assert df is fake_session.sql.return_value
+
+
+def test_api_call_source_is_attributed(fake_session):
+    df = call(fake_session, "V", metrics="m")
+    plan = df._select_statement or df._plan
+    assert plan.api_calls == [{"name": "Session.semantic_view"}]
+
+
+def test_local_testing_is_rejected(fake_session):
+    fake_session._conn = mock.create_autospec(MockServerConnection)
+    fake_session._conn.log_not_supported_error.side_effect = NotImplementedError
+    with pytest.raises(NotImplementedError):
+        call(fake_session, "V", metrics="m")
+    fake_session._conn.log_not_supported_error.assert_called_once()
+    assert (
+        fake_session._conn.log_not_supported_error.call_args.kwargs[
+            "external_feature_name"
+        ]
+        == "Session.semantic_view"
+    )


### PR DESCRIPTION
1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes SNOW-3902758

2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
      - [x] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.
   - [x] I acknowledge that I have ensured my changes to be thread-safe. Follow the link for more information: [Thread-safe Developer Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#thread-safe-development)
   - [x] If adding any arguments to public Snowpark APIs or creating new public Snowpark APIs, I acknowledge that I have ensured my changes include AST support. Follow the link for more information: [AST Support Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#ast-abstract-syntax-tree-support-in-snowpark)

3. Please describe how your code solves the related issue.

   Adds `Session.semantic_view()`, a query-only entry point for Snowflake semantic views. It builds
   `SELECT * FROM SEMANTIC_VIEW(<name> DIMENSIONS ... METRICS ... FACTS ... WHERE ...)` and returns a
   `DataFrame`, so everything outside the closing paren is ordinary DataFrame work.

   ```python
   df = session.semantic_view(
       "my_db.my_schema.sales",
       dimensions="customers.region",
       metrics=["orders.revenue"],
       where="customers.region = 'EMEA'",
   )
   df.filter(col("REVENUE") > 400).sort(col("REGION")).show()
   ```

   Design points:

   **Local Testing:** rejected with `NotImplementedError`, mirroring `Session.catalog` — semantic views
   are a SQL feature with no local-testing implementation, so there is no parity change to make. The
   integration tests are `xfail(run=False)` under `--local-testing-mode`, hence the review request above.
   `tests/mock/test_not_implemented_error.py` covers the rejection through a real local-testing session.

   **AST:** `@publicapi` with `_emit_ast` threaded through to `self.sql`, matching every other
   DataFrame-returning `Session` method, so `_emit_ast=False` works and the call is recorded as a `sql`
   node. There is no dedicated `semantic_view` proto node — happy to add one if reviewers want it.

   **Tests:** 68 unit cases, 8 integration tests (the fixture creates and drops its own semantic view),
   and one local-testing rejection test. Patch coverage is 100%.
