### PR TITLE
Prepare release v1.55.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 1.55.0 (2026-09-09)
+## 1.55.0 (2026-09-10)
 
 ### Snowpark Python API Updates
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 1.55.0 (TBD)
+## 1.55.0 (2026-09-09)
 
 ### Snowpark Python API Updates
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 #### New Features
 
+- Added `DataFrame.to_polars()` to convert a Snowpark DataFrame to a Polars DataFrame. Supports an optional `transport="parquet"` mode for large data-transfer-dominated workloads.
 - Added interval type support for Python UDFs and stored procedures. Use `datetime.timedelta` as the type annotation for day-time interval (`DayTimeIntervalType`) parameters and return values, and `YearMonthInterval` (a type annotation sentinel from `snowflake.snowpark.types`) for year-month interval (`YearMonthIntervalType`) parameters and return values.
 - Added support for a `table_properties` key in the `iceberg_config` dictionary of `DataFrameWriter.save_as_table`, which emits a `TABLE_PROPERTIES = ('k'='v', ...)` clause on Iceberg table creation (CREATE / CTAS).
 

--- a/docs/source/snowpark/dataframe.rst
+++ b/docs/source/snowpark/dataframe.rst
@@ -92,6 +92,7 @@ DataFrame
     DataFrame.to_local_iterator
     DataFrame.to_pandas
     DataFrame.to_pandas_batches
+    DataFrame.to_polars
     DataFrame.to_snowpark_pandas
     DataFrame.union
     DataFrame.unionAll

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "snowflake-snowpark-python" %}
-{% set version = "1.54.0" %}
+{% set version = "1.55.0" %}
 {% set noarch_build = (os.environ.get('SNOWFLAKE_SNOWPARK_PYTHON_NOARCH_BUILD', 'false')) == 'true' %}
 {% set build_number = os.environ.get('SNOWFLAKE_SNOWPARK_PYTHON_BUILD_NUMBER', 0) %}
 

--- a/setup.py
+++ b/setup.py
@@ -73,6 +73,7 @@ DEVELOPMENT_REQUIREMENTS = [
     "psutil",  # testing for telemetry
     "lxml",  # used in XML reader unit tests
     "pyarrow",  # used in dataframe reader tests
+    "polars>=1.0",  # used in test_df_to_polars integration tests
 ]
 MODIN_DEVELOPMENT_REQUIREMENTS = [
     # Snowpark pandas 3rd party library testing. Cap the scipy version because

--- a/src/snowflake/snowpark/_internal/polars_backend.py
+++ b/src/snowflake/snowpark/_internal/polars_backend.py
@@ -1,0 +1,135 @@
+#
+# Copyright (c) 2012-2025 Snowflake Computing Inc. All rights reserved.
+#
+from __future__ import annotations
+
+import uuid
+from concurrent.futures import ThreadPoolExecutor
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import polars as pl
+    from snowflake.snowpark.dataframe import DataFrame
+
+
+def _empty_frame_from_schema(
+    df: DataFrame, statement_params: dict[str, str] | None
+) -> pl.DataFrame:
+    """Return an empty polars DataFrame with the DataFrame's schema."""
+    import polars as pl
+
+    return pl.from_arrow(
+        df.limit(0).to_arrow(
+            statement_params=statement_params,
+            _emit_ast=False,
+        )
+    )
+
+
+def _open_stage_files_parallel(
+    session,
+    paths: list[str],
+    is_sproc: bool,
+    max_workers: int | None = None,
+) -> list:
+    """Open stage files concurrently, reading each with ``pl.read_parquet``
+    and returning the resulting ``pl.DataFrame`` (``with`` closes the handle
+    after read).
+
+    Uses ``SnowflakeFile.open`` inside a stored procedure and
+    ``session.file.get_stream`` on the client.
+    """
+    if not paths:
+        return []
+
+    import polars as pl
+
+    if is_sproc:
+        from snowflake.snowpark.files import SnowflakeFile
+
+        def opener(p: str):
+            return SnowflakeFile.open(p, "rb", require_scoped_url=False)
+
+    else:
+        opener = session.file.get_stream
+
+    def _work(p: str):
+        with opener(p) as f:
+            return pl.read_parquet(f)
+
+    with ThreadPoolExecutor(max_workers=max_workers) as ex:
+        return list(ex.map(_work, paths))
+
+
+def _copy_df_to_stage(
+    df: DataFrame,
+    sub_prefix: str,
+    statement_params: dict[str, str] | None = None,
+) -> list[str]:
+    """COPY INTO the session stage as Parquet and return the staged file paths.
+
+    Uses ``DataFrame.write.copy_into_location`` so plan compilation and
+    statement params go through the same path as other write actions. No
+    pre-sort is applied — callers wanting row-group elimination should
+    ``.sort(...)`` before ``to_polars``.
+    """
+    rid = uuid.uuid4().hex[:12]
+    stage = df._session.get_session_stage().rstrip("/")
+    sub = f"{stage}/{sub_prefix}/{rid}/"
+    df.write.copy_into_location(
+        sub,
+        file_format_type="parquet",
+        format_type_options={"COMPRESSION": "SNAPPY"},
+        header=True,
+        overwrite=True,
+        statement_params=statement_params,
+    )
+    rows = df._session.sql(f"LIST '{sub}'").collect(statement_params=statement_params)
+    # `sub` is fully qualified; LIST returns stage-relative names. Construct fully-qualified paths.
+    return [sub + row["name"].rsplit("/", 1)[-1] for row in rows]
+
+
+def arrow_eager(
+    df: DataFrame,
+    statement_params: dict[str, str] | None = None,
+) -> pl.DataFrame:
+    """Fetch the result as Arrow batches and return a polars DataFrame.
+
+    Backs the default ``to_polars()`` path (``transport="arrow"``).
+    Preserves full Snowflake type fidelity.
+    """
+    import polars as pl
+
+    parts = [
+        pl.from_arrow(batch)
+        for batch in df.to_arrow_batches(
+            statement_params=statement_params, _emit_ast=False
+        )
+    ]
+    if not parts:
+        return _empty_frame_from_schema(df, statement_params)
+    return pl.concat(parts) if len(parts) > 1 else parts[0]
+
+
+def parquet_eager(
+    df: DataFrame,
+    is_sproc: bool = False,
+    statement_params: dict[str, str] | None = None,
+    max_workers: int | None = None,
+) -> pl.DataFrame:
+    """COPY INTO Parquet, read the staged files in parallel, return a polars DataFrame.
+
+    Backs ``to_polars(transport="parquet")``. Subject to the Parquet type-fidelity
+    caveats documented on ``DataFrame.to_polars``.
+    """
+    import polars as pl
+
+    paths = _copy_df_to_stage(df, "to_polars_parquet_eager", statement_params)
+    if not paths:
+        return _empty_frame_from_schema(df, statement_params)
+    frames = _open_stage_files_parallel(
+        df._session, paths, is_sproc, max_workers=max_workers
+    )
+    if not frames:
+        return _empty_frame_from_schema(df, statement_params)
+    return pl.concat(frames) if len(frames) > 1 else frames[0]

--- a/src/snowflake/snowpark/dataframe.py
+++ b/src/snowflake/snowpark/dataframe.py
@@ -8,6 +8,7 @@ import datetime
 import itertools
 import random
 import re
+import typing
 from collections import Counter
 from decimal import Decimal
 from functools import cached_property, reduce
@@ -161,6 +162,7 @@ from snowflake.snowpark._internal.utils import (
     experimental,
     generate_random_alphanumeric,
     get_copy_into_table_options,
+    is_in_stored_procedure,
     is_snowflake_quoted_id_case_insensitive,
     is_snowflake_unquoted_suffix_case_insensitive,
     is_sql_select_statement,
@@ -238,6 +240,7 @@ from collections.abc import Iterable
 
 if TYPE_CHECKING:
     import modin.pandas  # pragma: no cover
+    import polars  # pragma: no cover
     from table import Table  # pragma: no cover
 
 _logger = getLogger(__name__)
@@ -1369,6 +1372,117 @@ class DataFrame:
                 ),
             ),
             **kwargs,
+        )
+
+    @experimental(version="1.55.0")
+    @df_collect_api_telemetry
+    @publicapi
+    def to_polars(
+        self,
+        *,
+        transport: typing.Literal["arrow", "parquet"] = "arrow",
+        max_workers: Optional[int] = None,
+        statement_params: Optional[Dict[str, str]] = None,
+    ) -> "polars.DataFrame":
+        """
+        Executes the query representing this DataFrame and returns the result
+        as a `Polars DataFrame <https://docs.pola.rs/py-polars/html/reference/dataframe/index.html>`_.
+
+        The transport is selected by ``transport``:
+
+        ==========  ============================================
+        transport   Description
+        ==========  ============================================
+        "arrow"     Arrow (default; full Snowflake type fidelity)
+        "parquet"   Parquet unload + eager parallel read
+        ==========  ============================================
+
+        Usage Notes:
+            - **Transport selection**:
+                - ``"parquet"``:
+                  Recommended when the result set is large and the type-fidelity
+                  caveats are acceptable. Snowflake's ``COPY INTO`` splits the
+                  result into multiple Parquet files that are opened and read
+                  concurrently. In server-side environments such as stored
+                  procedures, each file open is a parallelizable I/O operation,
+                  so the concurrent access substantially reduces wall-clock time
+                  compared to the Arrow path. On a local client, connection
+                  bandwidth is the primary constraint, and the benefit is more
+                  modest; for small or medium result sets the ``COPY INTO``
+                  setup cost may outweigh the gain, making Arrow the more
+                  efficient choice.
+                - ``"arrow"`` (default):
+                  Streams result batches directly from the cursor without
+                  staging to disk. Preserves full Snowflake type fidelity.
+                  Use when type accuracy is required, or when the result set is
+                  small enough that the Parquet path's ``COPY INTO`` overhead
+                  is not justified.
+            - **Parallelism tuning**: ``max_workers`` controls the thread pool
+              for opening and reading staged Parquet files. Only applies to
+              the ``"parquet"`` transport; ignored for ``"arrow"``. The default
+              (``None``) defers to
+              :class:`~concurrent.futures.ThreadPoolExecutor`.
+
+        Example::
+
+            >>> df = session.create_dataframe([[1, 2], [3, 4]], schema=["a", "b"])
+            >>> df.to_polars().shape  # doctest: +SKIP
+            (2, 2)
+
+        Args:
+            transport: Either ``"arrow"`` (default) or ``"parquet"``. When
+                ``"parquet"``, unload the result to Parquet on the session
+                stage and read the files back in parallel. Can be faster than
+                the ``"arrow"`` transport for large, data-transfer-dominated
+                workloads — especially in a stored procedure — but subject to
+                the type-fidelity limits below.
+            max_workers: Maximum number of threads for parallel stage-file
+                opens and reads. Only applies to the ``"parquet"`` transport
+                (``transport="parquet"``). Defaults to ``None``.
+            statement_params: Dictionary of statement level parameters to be
+                set while executing this action.
+
+        Note:
+            1. Requires ``polars>=1.0``.
+
+            2. The ``"parquet"`` transport
+            does not fully preserve Snowflake types because ``COPY INTO``
+            has restrictions on Parquet unload:
+
+               - ``TIMESTAMP_LTZ`` and ``TIMESTAMP_TZ`` columns cause the
+                 unload to error.
+               - ``TIMESTAMP_NTZ`` values with nanosecond precision are
+                 truncated to milliseconds.
+               - ``FLOAT`` (double) columns are downcast to ``float32``.
+
+            See the `COPY INTO <location> usage notes
+            <https://docs.snowflake.com/en/sql-reference/sql/copy-into-location#usage-notes>`_
+            for the full unload type mapping. Use the Arrow default when
+            full type fidelity is required.
+        """
+        from snowflake.snowpark._internal.polars_backend import (
+            arrow_eager as _arrow_eager,
+            parquet_eager as _parquet_eager,
+        )
+
+        is_sproc = is_in_stored_procedure()
+        normalized_transport = transport.strip().lower()
+
+        if normalized_transport == "parquet":
+            return _parquet_eager(
+                self,
+                is_sproc=is_sproc,
+                statement_params=statement_params,
+                max_workers=max_workers,
+            )
+        elif normalized_transport == "arrow":
+            return _arrow_eager(
+                self,
+                statement_params=statement_params,
+            )
+        raise ValueError(
+            f"Unsupported transport {transport!r} for to_polars(). "
+            'Expected "arrow" or "parquet".'
         )
 
     @df_api_usage

--- a/src/snowflake/snowpark/version.py
+++ b/src/snowflake/snowpark/version.py
@@ -2,4 +2,4 @@
 
 
 # Update this for the versions
-VERSION = (1, 54, 0)
+VERSION = (1, 55, 0)

--- a/tests/ast/data/DataFrame.agg.test
+++ b/tests/ast/data/DataFrame.agg.test
@@ -508,6 +508,6 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 54
+  minor: 55
 }
 id: "\003U\"\366q\366P\346\260\261?\234\303\254\316\353"

--- a/tests/ast/data/DataFrame.ai.test
+++ b/tests/ast/data/DataFrame.ai.test
@@ -2147,6 +2147,6 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 54
+  minor: 55
 }
 id: "\003U\"\366q\366P\346\260\261?\234\303\254\316\353"

--- a/tests/ast/data/DataFrame.col_ilike.test
+++ b/tests/ast/data/DataFrame.col_ilike.test
@@ -239,6 +239,6 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 54
+  minor: 55
 }
 id: "\003U\"\366q\366P\346\260\261?\234\303\254\316\353"

--- a/tests/ast/data/DataFrame.collect.test
+++ b/tests/ast/data/DataFrame.collect.test
@@ -511,6 +511,6 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 54
+  minor: 55
 }
 id: "\003U\"\366q\366P\346\260\261?\234\303\254\316\353"

--- a/tests/ast/data/DataFrame.count.test
+++ b/tests/ast/data/DataFrame.count.test
@@ -228,6 +228,6 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 54
+  minor: 55
 }
 id: "\003U\"\366q\366P\346\260\261?\234\303\254\316\353"

--- a/tests/ast/data/DataFrame.count2.test
+++ b/tests/ast/data/DataFrame.count2.test
@@ -315,6 +315,6 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 54
+  minor: 55
 }
 id: "\003U\"\366q\366P\346\260\261?\234\303\254\316\353"

--- a/tests/ast/data/DataFrame.create_or_replace.test
+++ b/tests/ast/data/DataFrame.create_or_replace.test
@@ -823,6 +823,6 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 54
+  minor: 55
 }
 id: "\003U\"\366q\366P\346\260\261?\234\303\254\316\353"

--- a/tests/ast/data/DataFrame.cross_join.lsuffix.test
+++ b/tests/ast/data/DataFrame.cross_join.lsuffix.test
@@ -171,6 +171,6 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 54
+  minor: 55
 }
 id: "\003U\"\366q\366P\346\260\261?\234\303\254\316\353"

--- a/tests/ast/data/DataFrame.cross_join.rsuffix.test
+++ b/tests/ast/data/DataFrame.cross_join.rsuffix.test
@@ -171,6 +171,6 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 54
+  minor: 55
 }
 id: "\003U\"\366q\366P\346\260\261?\234\303\254\316\353"

--- a/tests/ast/data/DataFrame.cross_join.suffix.test
+++ b/tests/ast/data/DataFrame.cross_join.suffix.test
@@ -174,6 +174,6 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 54
+  minor: 55
 }
 id: "\003U\"\366q\366P\346\260\261?\234\303\254\316\353"

--- a/tests/ast/data/DataFrame.describe.test
+++ b/tests/ast/data/DataFrame.describe.test
@@ -192,6 +192,6 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 54
+  minor: 55
 }
 id: "\003U\"\366q\366P\346\260\261?\234\303\254\316\353"

--- a/tests/ast/data/DataFrame.flatten.test
+++ b/tests/ast/data/DataFrame.flatten.test
@@ -175,6 +175,6 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 54
+  minor: 55
 }
 id: "\003U\"\366q\366P\346\260\261?\234\303\254\316\353"

--- a/tests/ast/data/DataFrame.indexers.test
+++ b/tests/ast/data/DataFrame.indexers.test
@@ -207,6 +207,6 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 54
+  minor: 55
 }
 id: "\003U\"\366q\366P\346\260\261?\234\303\254\316\353"

--- a/tests/ast/data/DataFrame.join.inner.column.test
+++ b/tests/ast/data/DataFrame.join.inner.column.test
@@ -241,6 +241,6 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 54
+  minor: 55
 }
 id: "\003U\"\366q\366P\346\260\261?\234\303\254\316\353"

--- a/tests/ast/data/DataFrame.join.inner.column_list.test
+++ b/tests/ast/data/DataFrame.join.inner.column_list.test
@@ -203,6 +203,6 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 54
+  minor: 55
 }
 id: "\003U\"\366q\366P\346\260\261?\234\303\254\316\353"

--- a/tests/ast/data/DataFrame.join.inner.column_list_predicate.test
+++ b/tests/ast/data/DataFrame.join.inner.column_list_predicate.test
@@ -328,6 +328,6 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 54
+  minor: 55
 }
 id: "\003U\"\366q\366P\346\260\261?\234\303\254\316\353"

--- a/tests/ast/data/DataFrame.join.inner.predicate.test
+++ b/tests/ast/data/DataFrame.join.inner.predicate.test
@@ -289,6 +289,6 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 54
+  minor: 55
 }
 id: "\003U\"\366q\366P\346\260\261?\234\303\254\316\353"

--- a/tests/ast/data/DataFrame.join.inner.predicate_rsuffix.test
+++ b/tests/ast/data/DataFrame.join.inner.predicate_rsuffix.test
@@ -279,6 +279,6 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 54
+  minor: 55
 }
 id: "\003U\"\366q\366P\346\260\261?\234\303\254\316\353"

--- a/tests/ast/data/DataFrame.join.left_outer.column.test
+++ b/tests/ast/data/DataFrame.join.left_outer.column.test
@@ -203,6 +203,6 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 54
+  minor: 55
 }
 id: "\003U\"\366q\366P\346\260\261?\234\303\254\316\353"

--- a/tests/ast/data/DataFrame.join.right_outer.predicate.test
+++ b/tests/ast/data/DataFrame.join.right_outer.predicate.test
@@ -220,6 +220,6 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 54
+  minor: 55
 }
 id: "\003U\"\366q\366P\346\260\261?\234\303\254\316\353"

--- a/tests/ast/data/DataFrame.join_table_function.test
+++ b/tests/ast/data/DataFrame.join_table_function.test
@@ -263,6 +263,6 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 54
+  minor: 55
 }
 id: "\003U\"\366q\366P\346\260\261?\234\303\254\316\353"

--- a/tests/ast/data/DataFrame.lateral_join.test
+++ b/tests/ast/data/DataFrame.lateral_join.test
@@ -666,6 +666,6 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 54
+  minor: 55
 }
 id: "\003U\"\366q\366P\346\260\261?\234\303\254\316\353"

--- a/tests/ast/data/DataFrame.natural_join.test
+++ b/tests/ast/data/DataFrame.natural_join.test
@@ -171,6 +171,6 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 54
+  minor: 55
 }
 id: "\003U\"\366q\366P\346\260\261?\234\303\254\316\353"

--- a/tests/ast/data/DataFrame.pivot.test
+++ b/tests/ast/data/DataFrame.pivot.test
@@ -756,6 +756,6 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 54
+  minor: 55
 }
 id: "\003U\"\366q\366P\346\260\261?\234\303\254\316\353"

--- a/tests/ast/data/DataFrame.select_expr.test
+++ b/tests/ast/data/DataFrame.select_expr.test
@@ -359,6 +359,6 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 54
+  minor: 55
 }
 id: "\003U\"\366q\366P\346\260\261?\234\303\254\316\353"

--- a/tests/ast/data/DataFrame.stat.test
+++ b/tests/ast/data/DataFrame.stat.test
@@ -1647,6 +1647,6 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 54
+  minor: 55
 }
 id: "\003U\"\366q\366P\346\260\261?\234\303\254\316\353"

--- a/tests/ast/data/DataFrame.to_df.test
+++ b/tests/ast/data/DataFrame.to_df.test
@@ -172,6 +172,6 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 54
+  minor: 55
 }
 id: "\003U\"\366q\366P\346\260\261?\234\303\254\316\353"

--- a/tests/ast/data/DataFrame.to_local_iterator.test
+++ b/tests/ast/data/DataFrame.to_local_iterator.test
@@ -539,6 +539,6 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 54
+  minor: 55
 }
 id: "\003U\"\366q\366P\346\260\261?\234\303\254\316\353"

--- a/tests/ast/data/DataFrame.to_pandas.test
+++ b/tests/ast/data/DataFrame.to_pandas.test
@@ -298,6 +298,6 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 54
+  minor: 55
 }
 id: "\003U\"\366q\366P\346\260\261?\234\303\254\316\353"

--- a/tests/ast/data/DataFrame.to_pandas_batch.test
+++ b/tests/ast/data/DataFrame.to_pandas_batch.test
@@ -298,6 +298,6 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 54
+  minor: 55
 }
 id: "\003U\"\366q\366P\346\260\261?\234\303\254\316\353"

--- a/tests/ast/data/DataFrame.unpivot.test
+++ b/tests/ast/data/DataFrame.unpivot.test
@@ -237,6 +237,6 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 54
+  minor: 55
 }
 id: "\003U\"\366q\366P\346\260\261?\234\303\254\316\353"

--- a/tests/ast/data/DataFrame.write.test
+++ b/tests/ast/data/DataFrame.write.test
@@ -6237,6 +6237,6 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 54
+  minor: 55
 }
 id: "\003U\"\366q\366P\346\260\261?\234\303\254\316\353"

--- a/tests/ast/data/Dataframe.cube.test
+++ b/tests/ast/data/Dataframe.cube.test
@@ -520,6 +520,6 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 54
+  minor: 55
 }
 id: "\003U\"\366q\366P\346\260\261?\234\303\254\316\353"

--- a/tests/ast/data/Dataframe.distinct.test
+++ b/tests/ast/data/Dataframe.distinct.test
@@ -89,6 +89,6 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 54
+  minor: 55
 }
 id: "\003U\"\366q\366P\346\260\261?\234\303\254\316\353"

--- a/tests/ast/data/Dataframe.drop_duplicates.test
+++ b/tests/ast/data/Dataframe.drop_duplicates.test
@@ -278,6 +278,6 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 54
+  minor: 55
 }
 id: "\003U\"\366q\366P\346\260\261?\234\303\254\316\353"

--- a/tests/ast/data/Dataframe.drop_duplicates_snow1874622.test
+++ b/tests/ast/data/Dataframe.drop_duplicates_snow1874622.test
@@ -525,6 +525,6 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 54
+  minor: 55
 }
 id: "\003U\"\366q\366P\346\260\261?\234\303\254\316\353"

--- a/tests/ast/data/Dataframe.filter.test
+++ b/tests/ast/data/Dataframe.filter.test
@@ -382,6 +382,6 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 54
+  minor: 55
 }
 id: "\003U\"\366q\366P\346\260\261?\234\303\254\316\353"

--- a/tests/ast/data/Dataframe.getitem.test
+++ b/tests/ast/data/Dataframe.getitem.test
@@ -273,6 +273,6 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 54
+  minor: 55
 }
 id: "\003U\"\366q\366P\346\260\261?\234\303\254\316\353"

--- a/tests/ast/data/Dataframe.group_by.test
+++ b/tests/ast/data/Dataframe.group_by.test
@@ -520,6 +520,6 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 54
+  minor: 55
 }
 id: "\003U\"\366q\366P\346\260\261?\234\303\254\316\353"

--- a/tests/ast/data/Dataframe.group_by_grouping_sets.test
+++ b/tests/ast/data/Dataframe.group_by_grouping_sets.test
@@ -1102,6 +1102,6 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 54
+  minor: 55
 }
 id: "\003U\"\366q\366P\346\260\261?\234\303\254\316\353"

--- a/tests/ast/data/Dataframe.join.asof.test
+++ b/tests/ast/data/Dataframe.join.asof.test
@@ -736,6 +736,6 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 54
+  minor: 55
 }
 id: "\003U\"\366q\366P\346\260\261?\234\303\254\316\353"

--- a/tests/ast/data/Dataframe.join.prefix.test
+++ b/tests/ast/data/Dataframe.join.prefix.test
@@ -819,6 +819,6 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 54
+  minor: 55
 }
 id: "\003U\"\366q\366P\346\260\261?\234\303\254\316\353"

--- a/tests/ast/data/Dataframe.rollup.test
+++ b/tests/ast/data/Dataframe.rollup.test
@@ -520,6 +520,6 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 54
+  minor: 55
 }
 id: "\003U\"\366q\366P\346\260\261?\234\303\254\316\353"

--- a/tests/ast/data/Dataframe.show.test
+++ b/tests/ast/data/Dataframe.show.test
@@ -1132,6 +1132,6 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 54
+  minor: 55
 }
 id: "\003U\"\366q\366P\346\260\261?\234\303\254\316\353"

--- a/tests/ast/data/Dataframe.to_snowpark_pandas.test.DISABLED
+++ b/tests/ast/data/Dataframe.to_snowpark_pandas.test.DISABLED
@@ -183,6 +183,6 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 54
+  minor: 55
 }
 id: "\003U\"\366q\366P\346\260\261?\234\303\254\316\353"

--- a/tests/ast/data/Dataframe.with_col_fns.test
+++ b/tests/ast/data/Dataframe.with_col_fns.test
@@ -928,6 +928,6 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 54
+  minor: 55
 }
 id: "\003U\"\366q\366P\346\260\261?\234\303\254\316\353"

--- a/tests/ast/data/DataframeNaFunctions.test
+++ b/tests/ast/data/DataframeNaFunctions.test
@@ -882,6 +882,6 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 54
+  minor: 55
 }
 id: "\003U\"\366q\366P\346\260\261?\234\303\254\316\353"

--- a/tests/ast/data/RelationalGroupedDataFrame.agg.test
+++ b/tests/ast/data/RelationalGroupedDataFrame.agg.test
@@ -1144,6 +1144,6 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 54
+  minor: 55
 }
 id: "\003U\"\366q\366P\346\260\261?\234\303\254\316\353"

--- a/tests/ast/data/RelationalGroupedDataFrame.ai_agg.test
+++ b/tests/ast/data/RelationalGroupedDataFrame.ai_agg.test
@@ -287,6 +287,6 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 54
+  minor: 55
 }
 id: "\003U\"\366q\366P\346\260\261?\234\303\254\316\353"

--- a/tests/ast/data/RelationalGroupedDataFrame.test
+++ b/tests/ast/data/RelationalGroupedDataFrame.test
@@ -3621,6 +3621,6 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 54
+  minor: 55
 }
 id: "\003U\"\366q\366P\346\260\261?\234\303\254\316\353"

--- a/tests/ast/data/Session.call.test
+++ b/tests/ast/data/Session.call.test
@@ -360,6 +360,6 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 54
+  minor: 55
 }
 id: "\003U\"\366q\366P\346\260\261?\234\303\254\316\353"

--- a/tests/ast/data/Session.create_dataframe.test
+++ b/tests/ast/data/Session.create_dataframe.test
@@ -1272,6 +1272,6 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 54
+  minor: 55
 }
 id: "\003U\"\366q\366P\346\260\261?\234\303\254\316\353"

--- a/tests/ast/data/Session.create_dataframe_from_pandas.test
+++ b/tests/ast/data/Session.create_dataframe_from_pandas.test
@@ -171,6 +171,6 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 54
+  minor: 55
 }
 id: "\003U\"\366q\366P\346\260\261?\234\303\254\316\353"

--- a/tests/ast/data/Session.flatten.test
+++ b/tests/ast/data/Session.flatten.test
@@ -174,6 +174,6 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 54
+  minor: 55
 }
 id: "\003U\"\366q\366P\346\260\261?\234\303\254\316\353"

--- a/tests/ast/data/Session.table_function.test
+++ b/tests/ast/data/Session.table_function.test
@@ -990,6 +990,6 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 54
+  minor: 55
 }
 id: "\003U\"\366q\366P\346\260\261?\234\303\254\316\353"

--- a/tests/ast/data/Table.delete.test
+++ b/tests/ast/data/Table.delete.test
@@ -545,6 +545,6 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 54
+  minor: 55
 }
 id: "\003U\"\366q\366P\346\260\261?\234\303\254\316\353"

--- a/tests/ast/data/Table.drop_table.test
+++ b/tests/ast/data/Table.drop_table.test
@@ -93,6 +93,6 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 54
+  minor: 55
 }
 id: "\003U\"\366q\366P\346\260\261?\234\303\254\316\353"

--- a/tests/ast/data/Table.init.test
+++ b/tests/ast/data/Table.init.test
@@ -423,6 +423,6 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 54
+  minor: 55
 }
 id: "\003U\"\366q\366P\346\260\261?\234\303\254\316\353"

--- a/tests/ast/data/Table.merge.test
+++ b/tests/ast/data/Table.merge.test
@@ -2448,6 +2448,6 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 54
+  minor: 55
 }
 id: "\003U\"\366q\366P\346\260\261?\234\303\254\316\353"

--- a/tests/ast/data/Table.sample.test
+++ b/tests/ast/data/Table.sample.test
@@ -168,6 +168,6 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 54
+  minor: 55
 }
 id: "\003U\"\366q\366P\346\260\261?\234\303\254\316\353"

--- a/tests/ast/data/Table.update.test
+++ b/tests/ast/data/Table.update.test
@@ -1030,6 +1030,6 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 54
+  minor: 55
 }
 id: "\003U\"\366q\366P\346\260\261?\234\303\254\316\353"

--- a/tests/ast/data/case_when.test
+++ b/tests/ast/data/case_when.test
@@ -1913,6 +1913,6 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 54
+  minor: 55
 }
 id: "\003U\"\366q\366P\346\260\261?\234\303\254\316\353"

--- a/tests/ast/data/col_alias.test
+++ b/tests/ast/data/col_alias.test
@@ -409,6 +409,6 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 54
+  minor: 55
 }
 id: "\003U\"\366q\366P\346\260\261?\234\303\254\316\353"

--- a/tests/ast/data/col_asc.test
+++ b/tests/ast/data/col_asc.test
@@ -302,6 +302,6 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 54
+  minor: 55
 }
 id: "\003U\"\366q\366P\346\260\261?\234\303\254\316\353"

--- a/tests/ast/data/col_between.test
+++ b/tests/ast/data/col_between.test
@@ -184,6 +184,6 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 54
+  minor: 55
 }
 id: "\003U\"\366q\366P\346\260\261?\234\303\254\316\353"

--- a/tests/ast/data/col_binops.test
+++ b/tests/ast/data/col_binops.test
@@ -1615,6 +1615,6 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 54
+  minor: 55
 }
 id: "\003U\"\366q\366P\346\260\261?\234\303\254\316\353"

--- a/tests/ast/data/col_bitops.test
+++ b/tests/ast/data/col_bitops.test
@@ -394,6 +394,6 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 54
+  minor: 55
 }
 id: "\003U\"\366q\366P\346\260\261?\234\303\254\316\353"

--- a/tests/ast/data/col_cast.test
+++ b/tests/ast/data/col_cast.test
@@ -2854,6 +2854,6 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 54
+  minor: 55
 }
 id: "\003U\"\366q\366P\346\260\261?\234\303\254\316\353"

--- a/tests/ast/data/col_cast_coll.test
+++ b/tests/ast/data/col_cast_coll.test
@@ -806,6 +806,6 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 54
+  minor: 55
 }
 id: "\003U\"\366q\366P\346\260\261?\234\303\254\316\353"

--- a/tests/ast/data/col_desc.test
+++ b/tests/ast/data/col_desc.test
@@ -300,6 +300,6 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 54
+  minor: 55
 }
 id: "\003U\"\366q\366P\346\260\261?\234\303\254\316\353"

--- a/tests/ast/data/col_getitem.test
+++ b/tests/ast/data/col_getitem.test
@@ -185,6 +185,6 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 54
+  minor: 55
 }
 id: "\003U\"\366q\366P\346\260\261?\234\303\254\316\353"

--- a/tests/ast/data/col_in_.test
+++ b/tests/ast/data/col_in_.test
@@ -358,6 +358,6 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 54
+  minor: 55
 }
 id: "\003U\"\366q\366P\346\260\261?\234\303\254\316\353"

--- a/tests/ast/data/col_lit.test
+++ b/tests/ast/data/col_lit.test
@@ -528,6 +528,6 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 54
+  minor: 55
 }
 id: "\003U\"\366q\366P\346\260\261?\234\303\254\316\353"

--- a/tests/ast/data/col_literal.test
+++ b/tests/ast/data/col_literal.test
@@ -3709,6 +3709,6 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 54
+  minor: 55
 }
 id: "\003U\"\366q\366P\346\260\261?\234\303\254\316\353"

--- a/tests/ast/data/col_null_nan.test
+++ b/tests/ast/data/col_null_nan.test
@@ -403,6 +403,6 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 54
+  minor: 55
 }
 id: "\003U\"\366q\366P\346\260\261?\234\303\254\316\353"

--- a/tests/ast/data/col_rbinops.test
+++ b/tests/ast/data/col_rbinops.test
@@ -773,6 +773,6 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 54
+  minor: 55
 }
 id: "\003U\"\366q\366P\346\260\261?\234\303\254\316\353"

--- a/tests/ast/data/col_star.test
+++ b/tests/ast/data/col_star.test
@@ -127,6 +127,6 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 54
+  minor: 55
 }
 id: "\003U\"\366q\366P\346\260\261?\234\303\254\316\353"

--- a/tests/ast/data/col_string.test
+++ b/tests/ast/data/col_string.test
@@ -740,6 +740,6 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 54
+  minor: 55
 }
 id: "\003U\"\366q\366P\346\260\261?\234\303\254\316\353"

--- a/tests/ast/data/col_try_cast.test
+++ b/tests/ast/data/col_try_cast.test
@@ -2514,6 +2514,6 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 54
+  minor: 55
 }
 id: "\003U\"\366q\366P\346\260\261?\234\303\254\316\353"

--- a/tests/ast/data/col_udf.test
+++ b/tests/ast/data/col_udf.test
@@ -1487,6 +1487,6 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 54
+  minor: 55
 }
 id: "\003U\"\366q\366P\346\260\261?\234\303\254\316\353"

--- a/tests/ast/data/col_unary_ops.test
+++ b/tests/ast/data/col_unary_ops.test
@@ -215,6 +215,6 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 54
+  minor: 55
 }
 id: "\003U\"\366q\366P\346\260\261?\234\303\254\316\353"

--- a/tests/ast/data/col_within_group.test
+++ b/tests/ast/data/col_within_group.test
@@ -431,6 +431,6 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 54
+  minor: 55
 }
 id: "\003U\"\366q\366P\346\260\261?\234\303\254\316\353"

--- a/tests/ast/data/df_alias.test
+++ b/tests/ast/data/df_alias.test
@@ -90,6 +90,6 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 54
+  minor: 55
 }
 id: "\003U\"\366q\366P\346\260\261?\234\303\254\316\353"

--- a/tests/ast/data/df_analytics_functions.test
+++ b/tests/ast/data/df_analytics_functions.test
@@ -950,6 +950,6 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 54
+  minor: 55
 }
 id: "\003U\"\366q\366P\346\260\261?\234\303\254\316\353"

--- a/tests/ast/data/df_col.test
+++ b/tests/ast/data/df_col.test
@@ -144,6 +144,6 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 54
+  minor: 55
 }
 id: "\003U\"\366q\366P\346\260\261?\234\303\254\316\353"

--- a/tests/ast/data/df_copy.test
+++ b/tests/ast/data/df_copy.test
@@ -778,6 +778,6 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 54
+  minor: 55
 }
 id: "\003U\"\366q\366P\346\260\261?\234\303\254\316\353"

--- a/tests/ast/data/df_drop.test
+++ b/tests/ast/data/df_drop.test
@@ -127,6 +127,6 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 54
+  minor: 55
 }
 id: "\003U\"\366q\366P\346\260\261?\234\303\254\316\353"

--- a/tests/ast/data/df_except.test
+++ b/tests/ast/data/df_except.test
@@ -128,6 +128,6 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 54
+  minor: 55
 }
 id: "\003U\"\366q\366P\346\260\261?\234\303\254\316\353"

--- a/tests/ast/data/df_first.test
+++ b/tests/ast/data/df_first.test
@@ -383,6 +383,6 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 54
+  minor: 55
 }
 id: "\003U\"\366q\366P\346\260\261?\234\303\254\316\353"

--- a/tests/ast/data/df_intersect.test
+++ b/tests/ast/data/df_intersect.test
@@ -129,6 +129,6 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 54
+  minor: 55
 }
 id: "\003U\"\366q\366P\346\260\261?\234\303\254\316\353"

--- a/tests/ast/data/df_limit.test
+++ b/tests/ast/data/df_limit.test
@@ -342,6 +342,6 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 54
+  minor: 55
 }
 id: "\003U\"\366q\366P\346\260\261?\234\303\254\316\353"

--- a/tests/ast/data/df_map.test
+++ b/tests/ast/data/df_map.test
@@ -2142,6 +2142,6 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 54
+  minor: 55
 }
 id: "\003U\"\366q\366P\346\260\261?\234\303\254\316\353"

--- a/tests/ast/data/df_random_split.test
+++ b/tests/ast/data/df_random_split.test
@@ -710,6 +710,6 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 54
+  minor: 55
 }
 id: "\003U\"\366q\366P\346\260\261?\234\303\254\316\353"

--- a/tests/ast/data/df_sample.test
+++ b/tests/ast/data/df_sample.test
@@ -124,6 +124,6 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 54
+  minor: 55
 }
 id: "\003U\"\366q\366P\346\260\261?\234\303\254\316\353"

--- a/tests/ast/data/df_sort.test
+++ b/tests/ast/data/df_sort.test
@@ -833,6 +833,6 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 54
+  minor: 55
 }
 id: "\003U\"\366q\366P\346\260\261?\234\303\254\316\353"

--- a/tests/ast/data/df_union.test
+++ b/tests/ast/data/df_union.test
@@ -375,6 +375,6 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 54
+  minor: 55
 }
 id: "\003U\"\366q\366P\346\260\261?\234\303\254\316\353"

--- a/tests/ast/data/functions.table_functions.test
+++ b/tests/ast/data/functions.table_functions.test
@@ -2212,6 +2212,6 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 54
+  minor: 55
 }
 id: "\003U\"\366q\366P\346\260\261?\234\303\254\316\353"

--- a/tests/ast/data/functions1.test
+++ b/tests/ast/data/functions1.test
@@ -18800,6 +18800,6 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 54
+  minor: 55
 }
 id: "\003U\"\366q\366P\346\260\261?\234\303\254\316\353"

--- a/tests/ast/data/functions2.test
+++ b/tests/ast/data/functions2.test
@@ -29678,6 +29678,6 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 54
+  minor: 55
 }
 id: "\003U\"\366q\366P\346\260\261?\234\303\254\316\353"

--- a/tests/ast/data/interval.test
+++ b/tests/ast/data/interval.test
@@ -1069,6 +1069,6 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 54
+  minor: 55
 }
 id: "\003U\"\366q\366P\346\260\261?\234\303\254\316\353"

--- a/tests/ast/data/select.test
+++ b/tests/ast/data/select.test
@@ -139,6 +139,6 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 54
+  minor: 55
 }
 id: "\003U\"\366q\366P\346\260\261?\234\303\254\316\353"

--- a/tests/ast/data/session.read.test
+++ b/tests/ast/data/session.read.test
@@ -1772,6 +1772,6 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 54
+  minor: 55
 }
 id: "\003U\"\366q\366P\346\260\261?\234\303\254\316\353"

--- a/tests/ast/data/session.sql.test
+++ b/tests/ast/data/session.sql.test
@@ -149,6 +149,6 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 54
+  minor: 55
 }
 id: "\003U\"\366q\366P\346\260\261?\234\303\254\316\353"

--- a/tests/ast/data/session_directory.test
+++ b/tests/ast/data/session_directory.test
@@ -101,6 +101,6 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 54
+  minor: 55
 }
 id: "\003U\"\366q\366P\346\260\261?\234\303\254\316\353"

--- a/tests/ast/data/session_generator.test
+++ b/tests/ast/data/session_generator.test
@@ -362,6 +362,6 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 54
+  minor: 55
 }
 id: "\003U\"\366q\366P\346\260\261?\234\303\254\316\353"

--- a/tests/ast/data/session_range.test
+++ b/tests/ast/data/session_range.test
@@ -172,6 +172,6 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 54
+  minor: 55
 }
 id: "\003U\"\366q\366P\346\260\261?\234\303\254\316\353"

--- a/tests/ast/data/session_table_dq_abs_l.test
+++ b/tests/ast/data/session_table_dq_abs_l.test
@@ -105,6 +105,6 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 54
+  minor: 55
 }
 id: "\003U\"\366q\366P\346\260\261?\234\303\254\316\353"

--- a/tests/ast/data/session_table_dq_abs_s.test
+++ b/tests/ast/data/session_table_dq_abs_s.test
@@ -103,6 +103,6 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 54
+  minor: 55
 }
 id: "\003U\"\366q\366P\346\260\261?\234\303\254\316\353"

--- a/tests/ast/data/session_table_dq_rs_l.test
+++ b/tests/ast/data/session_table_dq_rs_l.test
@@ -104,6 +104,6 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 54
+  minor: 55
 }
 id: "\003U\"\366q\366P\346\260\261?\234\303\254\316\353"

--- a/tests/ast/data/session_table_dq_rs_s.test
+++ b/tests/ast/data/session_table_dq_rs_s.test
@@ -103,6 +103,6 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 54
+  minor: 55
 }
 id: "\003U\"\366q\366P\346\260\261?\234\303\254\316\353"

--- a/tests/ast/data/session_table_dq_rt_l.test
+++ b/tests/ast/data/session_table_dq_rt_l.test
@@ -103,6 +103,6 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 54
+  minor: 55
 }
 id: "\003U\"\366q\366P\346\260\261?\234\303\254\316\353"

--- a/tests/ast/data/session_table_dq_rt_s.test
+++ b/tests/ast/data/session_table_dq_rt_s.test
@@ -103,6 +103,6 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 54
+  minor: 55
 }
 id: "\003U\"\366q\366P\346\260\261?\234\303\254\316\353"

--- a/tests/ast/data/session_table_temp_table_cleanup.test
+++ b/tests/ast/data/session_table_temp_table_cleanup.test
@@ -170,6 +170,6 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 54
+  minor: 55
 }
 id: "\003U\"\366q\366P\346\260\261?\234\303\254\316\353"

--- a/tests/ast/data/session_table_uq_abs_l.test
+++ b/tests/ast/data/session_table_uq_abs_l.test
@@ -105,6 +105,6 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 54
+  minor: 55
 }
 id: "\003U\"\366q\366P\346\260\261?\234\303\254\316\353"

--- a/tests/ast/data/session_table_uq_abs_s.test
+++ b/tests/ast/data/session_table_uq_abs_s.test
@@ -103,6 +103,6 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 54
+  minor: 55
 }
 id: "\003U\"\366q\366P\346\260\261?\234\303\254\316\353"

--- a/tests/ast/data/session_table_uq_rs_l.test
+++ b/tests/ast/data/session_table_uq_rs_l.test
@@ -104,6 +104,6 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 54
+  minor: 55
 }
 id: "\003U\"\366q\366P\346\260\261?\234\303\254\316\353"

--- a/tests/ast/data/session_table_uq_rs_s.test
+++ b/tests/ast/data/session_table_uq_rs_s.test
@@ -103,6 +103,6 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 54
+  minor: 55
 }
 id: "\003U\"\366q\366P\346\260\261?\234\303\254\316\353"

--- a/tests/ast/data/session_table_uq_rt_l.test
+++ b/tests/ast/data/session_table_uq_rt_l.test
@@ -103,6 +103,6 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 54
+  minor: 55
 }
 id: "\003U\"\366q\366P\346\260\261?\234\303\254\316\353"

--- a/tests/ast/data/session_table_uq_rt_s.test
+++ b/tests/ast/data/session_table_uq_rt_s.test
@@ -388,6 +388,6 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 54
+  minor: 55
 }
 id: "\003U\"\366q\366P\346\260\261?\234\303\254\316\353"

--- a/tests/ast/data/session_transaction.test
+++ b/tests/ast/data/session_transaction.test
@@ -121,6 +121,6 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 54
+  minor: 55
 }
 id: "\003U\"\366q\366P\346\260\261?\234\303\254\316\353"

--- a/tests/ast/data/session_write_pandas.test
+++ b/tests/ast/data/session_write_pandas.test
@@ -148,6 +148,6 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 54
+  minor: 55
 }
 id: "\003U\"\366q\366P\346\260\261?\234\303\254\316\353"

--- a/tests/ast/data/shadowed_local_name.test
+++ b/tests/ast/data/shadowed_local_name.test
@@ -205,6 +205,6 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 54
+  minor: 55
 }
 id: "\003U\"\366q\366P\346\260\261?\234\303\254\316\353"

--- a/tests/ast/data/smoke1.test
+++ b/tests/ast/data/smoke1.test
@@ -2192,6 +2192,6 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 54
+  minor: 55
 }
 id: "\003U\"\366q\366P\346\260\261?\234\303\254\316\353"

--- a/tests/ast/data/smoke2.test
+++ b/tests/ast/data/smoke2.test
@@ -2356,6 +2356,6 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 54
+  minor: 55
 }
 id: "\003U\"\366q\366P\346\260\261?\234\303\254\316\353"

--- a/tests/ast/data/sproc.test
+++ b/tests/ast/data/sproc.test
@@ -2828,6 +2828,6 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 54
+  minor: 55
 }
 id: "\003U\"\366q\366P\346\260\261?\234\303\254\316\353"

--- a/tests/ast/data/udaf.test
+++ b/tests/ast/data/udaf.test
@@ -1277,6 +1277,6 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 54
+  minor: 55
 }
 id: "\003U\"\366q\366P\346\260\261?\234\303\254\316\353"

--- a/tests/ast/data/udtf.test
+++ b/tests/ast/data/udtf.test
@@ -3580,6 +3580,6 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 54
+  minor: 55
 }
 id: "\003U\"\366q\366P\346\260\261?\234\303\254\316\353"

--- a/tests/ast/data/windows.test
+++ b/tests/ast/data/windows.test
@@ -2091,6 +2091,6 @@ client_language {
 }
 client_version {
   major: 1
-  minor: 54
+  minor: 55
 }
 id: "\003U\"\366q\366P\346\260\261?\234\303\254\316\353"

--- a/tests/integ/test_df_to_polars.py
+++ b/tests/integ/test_df_to_polars.py
@@ -1,0 +1,493 @@
+#!/usr/bin/env python3
+#
+# Copyright (c) 2012-2025 Snowflake Computing Inc. All rights reserved.
+#
+
+import uuid
+from datetime import date, datetime
+from decimal import Decimal
+from unittest import mock
+
+import pytest
+
+from snowflake.snowpark import Session
+from snowflake.snowpark.functions import col
+from snowflake.snowpark.types import DecimalType
+
+from tests.utils import TestData, Utils
+
+try:
+    import polars as pl
+
+    _polars_available = True
+except ImportError:
+    pl = None  # type: ignore[assignment]
+    _polars_available = False
+
+# Shorthand for tests that require a live Snowflake connection + Arrow support.
+_skip_local = pytest.mark.skipif(
+    "config.getoption('local_testing_mode', default=False)",
+    reason="arrow not fully supported by local testing.",
+)
+
+
+@pytest.fixture
+def _no_polars_required():
+    """Request this fixture to opt out of the polars-availability skip."""
+
+
+@pytest.fixture(autouse=True)
+def _require_polars(request):
+    """Skip tests that need polars when it is not installed.
+
+    Tests that mock polars or test the missing-dep path should request
+    the ``_no_polars_required`` fixture to opt out.
+    """
+    if not _polars_available and "_no_polars_required" not in request.fixturenames:
+        pytest.skip("polars not available")
+
+
+def polars_to_pydict(df: "pl.DataFrame") -> dict:
+    return df.to_arrow().to_pydict()
+
+
+# ---------------------------------------------------------------------------
+# Fixtures / helpers
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def local_session():
+    """Local-testing session — no Snowflake connection required."""
+    with Session.builder.config("local_testing", True).create() as s:
+        yield s
+
+
+# ---------------------------------------------------------------------------
+# Type correctness (eager)
+# ---------------------------------------------------------------------------
+
+
+@_skip_local
+@pytest.mark.parametrize(
+    "example,expected",
+    [
+        (TestData.integer1, {"A": [1, 2, 3]}),
+        (
+            TestData.null_data1,
+            {"A": [None, Decimal("2"), Decimal("1"), Decimal("3"), None]},
+        ),
+        (
+            TestData.double1,
+            {"A": [Decimal("1.111"), Decimal("2.222"), Decimal("3.333")]},
+        ),
+        (TestData.string1, {"A": ["test1", "test2", "test3"], "B": ["a", "b", "c"]}),
+        pytest.param(
+            TestData.array1,
+            {
+                "ARR1": ["[\n  1,\n  2,\n  3\n]", "[\n  6,\n  7,\n  8\n]"],
+                "ARR2": ["[\n  3,\n  4,\n  5\n]", "[\n  9,\n  0,\n  1\n]"],
+            },
+            id="semi-structured array",
+        ),
+        pytest.param(
+            TestData.object2,
+            {
+                "OBJ": [
+                    '{\n  "age": 21,\n  "name": "Joe",\n  "zip": 21021\n}',
+                    '{\n  "age": 26,\n  "name": "Jay",\n  "zip": 94021\n}',
+                ],
+                "K": ["age", "key"],
+                "V": [Decimal("0"), Decimal("0")],
+                "FLAG": [True, False],
+            },
+            id="semi-structured object",
+        ),
+        (
+            TestData.datetime_primitives2,
+            {
+                "TIMESTAMP": [
+                    datetime(9999, 12, 31, 0, 0, 0, 123456),
+                    datetime(1583, 1, 1, 23, 59, 59, 567890),
+                ]
+            },
+        ),
+        (
+            TestData.date1,
+            {
+                "A": [date(2020, 8, 1), date(2010, 12, 1)],
+                "B": [Decimal("1"), Decimal("2")],
+            },
+        ),
+    ],
+)
+def test_to_polars_type_correctness(session, example, expected):
+    assert polars_to_pydict(example(session).to_polars()) == expected
+
+
+@_skip_local
+def test_to_polars_decimal_precision(session):
+    data = [
+        [1111111111111111111, 222222222222222222],
+        [3333333333333333333, 444444444444444444],
+        [5555555555555555555, 666666666666666666],
+        [7777777777777777777, 888888888888888888],
+        [9223372036854775807, 111111111111111111],
+        [2222222222222222222, 333333333333333333],
+        [4444444444444444444, 555555555555555555],
+        [6666666666666666666, 777777777777777777],
+        [-9223372036854775808, 999999999999999999],
+    ]
+    df = session.create_dataframe(data, schema=["A", "B"]).select(
+        col("A").cast(DecimalType(38, 0)).alias("A"),
+        col("B").cast(DecimalType(18, 0)).alias("B"),
+    )
+    pa_df = df.to_polars().to_arrow()
+    assert str(pa_df.schema[0].type) == "decimal128(38, 0)"
+    assert str(pa_df.schema[1].type) == "int64"
+    assert [[int(x) for x in row.values()] for row in pa_df.to_pylist()] == data
+
+
+# ---------------------------------------------------------------------------
+# NULL handling
+# ---------------------------------------------------------------------------
+
+
+@_skip_local
+def test_to_polars_null_handling(session):
+    # Nullable integer column
+    col_values = (
+        session.create_dataframe([[0], [1], [None]], schema=["A"])
+        .to_polars()["A"]
+        .to_list()
+    )
+    assert col_values == [0, 1, None]
+
+    # All-null column
+    pl_df = session.create_dataframe([[None], [None], [None]], schema=["A"]).to_polars()
+    assert pl_df.height == 3
+    assert all(v is None for v in pl_df["A"].to_list())
+
+
+# ---------------------------------------------------------------------------
+# Eager path
+# ---------------------------------------------------------------------------
+
+
+@_skip_local
+def test_to_polars_eager_multi_batch(session):
+    """Exercises the pl.concat(parts) path when the result spans multiple Arrow batches."""
+    pl_df = session.range(100_000).to_polars()
+    assert isinstance(pl_df, pl.DataFrame)
+    assert pl_df.height == 100_000
+    assert pl_df.columns == ["ID"]
+
+
+@_skip_local
+def test_to_polars_empty_dataframe(session):
+    pl_df = (
+        session.create_dataframe([[1, 2]], schema=["A", "B"])
+        .filter(col("A") > 100)
+        .to_polars()
+    )
+    assert isinstance(pl_df, pl.DataFrame)
+    assert pl_df.height == 0
+    assert set(pl_df.columns) == {"A", "B"}
+
+
+@_skip_local
+def test_to_polars_timestamp_ltz_and_tz(session):
+    """TIMESTAMP_LTZ and TIMESTAMP_TZ survive the Arrow path as tz-aware datetimes."""
+    pl_df = session.sql(
+        "SELECT TO_TIMESTAMP_LTZ('2024-01-15 12:00:00 -0800') AS ts_ltz,"
+        "       TO_TIMESTAMP_TZ('2024-01-15 20:00:00 +0530')  AS ts_tz"
+    ).to_polars()
+    assert (
+        pl_df["TS_LTZ"][0] is not None and pl_df["TS_LTZ"].dtype.time_zone is not None
+    )
+    assert pl_df["TS_TZ"][0] is not None and pl_df["TS_TZ"].dtype.time_zone is not None
+
+
+@_skip_local
+def test_to_polars_eager_matches_to_arrow(session):
+    df = session.sql(
+        "SELECT 42::INT AS i, 3.14::FLOAT AS f, 'hello'::VARCHAR AS s,"
+        "       TRUE AS b, DATE '2024-01-01' AS d,"
+        "       TO_TIMESTAMP_NTZ('2024-01-01 12:00:00') AS t"
+    )
+    assert polars_to_pydict(df.to_polars()) == df.to_arrow().to_pydict()
+
+
+@_skip_local
+def test_to_polars_statement_params(session):
+    """statement_params must reach Snowflake on every to_polars path,
+    including the raw-cursor Arrow path. Regression guard: earlier the Arrow
+    path forwarded the params only on the (rare) empty-batch fallback and
+    silently dropped them on the main query.
+
+    The ``query_history()`` context manager doubles as a check that the
+    raw-cursor Arrow path still triggers session-level query listeners.
+    """
+    df = session.create_dataframe([[1]], schema=["A"])
+
+    tag = "polars_integ_test_" + uuid.uuid4().hex[:8]
+    with session.query_history() as history:
+        result = df.to_polars(statement_params={"QUERY_TAG": tag})
+    assert isinstance(result, pl.DataFrame)
+    assert history.queries, "no queries captured by the query listener"
+    Utils.assert_executed_with_query_tag(session, tag)
+
+
+# ---------------------------------------------------------------------------
+# transport="parquet" (eager parquet)
+# ---------------------------------------------------------------------------
+
+
+@_skip_local
+def test_to_polars_transport_parquet_basic_types(session):
+    """Common primitive types round-trip through the eager Parquet path."""
+    df = session.sql(
+        "SELECT 42::INT AS i, 'hello'::VARCHAR AS s, TRUE AS b,"
+        "       DATE '2024-01-01' AS d"
+    )
+    pl_df = df.to_polars(transport="parquet")
+    assert isinstance(pl_df, pl.DataFrame)
+    assert pl_df.height == 1
+    row = pl_df.to_dicts()[0]
+    assert row["I"] == 42
+    assert row["S"] == "hello"
+    assert row["B"] is True
+    assert row["D"] == date(2024, 1, 1)
+
+
+@_skip_local
+def test_to_polars_transport_parquet_matches_arrow_shape(session):
+    """Eager Parquet and eager Arrow return the same shape on a non-trivial
+    dataset. Values are compared in a downcast-aware way: FLOAT is compared
+    at float32 precision on both sides."""
+    df = session.create_dataframe(
+        [[i, str(i), i * 1.5] for i in range(500)], schema=["ID", "S", "F"]
+    )
+    pq = df.to_polars(transport="parquet")
+    arrow = df.to_polars()
+    assert pq.height == arrow.height == 500
+    assert set(pq.columns) == set(arrow.columns)
+    # FLOAT is downcast to float32 by the Parquet unload, so cast both sides
+    # before comparing to avoid a precision-driven false negative.
+    assert (
+        pq.sort("ID")["F"]
+        .cast(pl.Float32)
+        .equals(arrow.sort("ID")["F"].cast(pl.Float32))
+    )
+
+
+@_skip_local
+def test_to_polars_transport_parquet_timestamp_ltz_raises(session):
+    """TIMESTAMP_LTZ / TIMESTAMP_TZ can't be unloaded to Parquet — locks in
+    the documented behavior so a future change to the doc or code is caught."""
+    df = session.sql("SELECT TO_TIMESTAMP_LTZ('2024-01-15 12:00:00 -0800') AS ts_ltz")
+    with pytest.raises(Exception, match="(?i)timestamp"):
+        df.to_polars(transport="parquet")
+
+
+@_skip_local
+def test_to_polars_transport_parquet_empty(session):
+    """Empty result from the Parquet path returns a schema-preserving DataFrame."""
+    pl_df = (
+        session.create_dataframe([[1, 2]], schema=["A", "B"])
+        .filter(col("A") > 100)
+        .to_polars(transport="parquet")
+    )
+    assert isinstance(pl_df, pl.DataFrame)
+    assert pl_df.height == 0
+    assert set(pl_df.columns) == {"A", "B"}
+
+
+# ---------------------------------------------------------------------------
+# Column identifier casing (unquoted / quoted lowercase / quoted mixed-case)
+#
+# Snowflake folds unquoted identifiers to UPPERCASE, but preserves the exact
+# case of quoted identifiers. Both the Arrow output names and the Parquet
+# column names emitted by COPY INTO must respect this — Polars is
+# case-sensitive, so any mismatch would surface as ColumnNotFoundError on
+# downstream ops.
+# ---------------------------------------------------------------------------
+
+
+@_skip_local
+@pytest.mark.parametrize(
+    "sql, expected_columns, pushdown_col",
+    [
+        # unquoted → Snowflake folds to uppercase
+        ("SELECT 1 AS revenue, 'US' AS region", ["REVENUE", "REGION"], "REVENUE"),
+        # quoted lowercase → preserved
+        ('SELECT 1 AS "revenue", \'US\' AS "region"', ["revenue", "region"], "revenue"),
+        # quoted mixed-case → preserved
+        (
+            'SELECT 1 AS "myRevenue", \'US\' AS "myRegion"',
+            ["myRevenue", "myRegion"],
+            "myRevenue",
+        ),
+    ],
+    ids=["unquoted_folds_uppercase", "quoted_lowercase", "quoted_mixed_case"],
+)
+def test_to_polars_column_identifier_casing(
+    session, sql, expected_columns, pushdown_col
+):
+    """Casing is preserved end-to-end through eager Arrow and eager Parquet,
+    and column-name-based selection on the Parquet result."""
+    df = session.sql(sql)
+
+    eager = df.to_polars()
+    assert eager.columns == expected_columns
+
+    pq = df.to_polars(transport="parquet")
+    assert pq.columns == expected_columns
+
+    # User selects by the Polars column name they see; that name must resolve
+    # against the Parquet schema COPY INTO produced.
+    projected = pq.select(pushdown_col)
+    assert projected.columns == [pushdown_col] and projected.height == 1
+
+
+# ---------------------------------------------------------------------------
+# Missing dependency
+# ---------------------------------------------------------------------------
+
+
+def test_to_polars_raises_when_polars_missing(local_session, _no_polars_required):
+    df = local_session.create_dataframe([[1]], schema=["A"])
+    with mock.patch.dict("sys.modules", {"polars": None}):
+        with pytest.raises(ModuleNotFoundError, match="polars"):
+            df.to_polars()
+
+
+# ---------------------------------------------------------------------------
+# Unit tests for polars_backend helpers
+#
+# These cover branches that either can't be triggered without a stored proc
+# (SnowflakeFile-based opens), or that only fire on transient error paths
+# (close failures, empty result edge cases). They run with polars installed
+# but do not talk to Snowflake.
+# ---------------------------------------------------------------------------
+
+
+def test_open_stage_files_parallel_empty_paths_returns_empty():
+    from snowflake.snowpark._internal.polars_backend import (
+        _open_stage_files_parallel,
+    )
+
+    for is_sproc in (False, True):
+        assert _open_stage_files_parallel(mock.MagicMock(), [], is_sproc=is_sproc) == []
+
+
+def test_open_stage_files_parallel_eager_sproc_reads_and_closes():
+    """is_sproc=True: reads via pl.read_parquet inside a ``with`` block so the
+    file handle is closed after decode."""
+    from snowflake.snowpark._internal.polars_backend import (
+        _open_stage_files_parallel,
+    )
+
+    fake_file = mock.MagicMock()
+    fake_file.__enter__.return_value = fake_file  # `with f as x: x is f`
+    fake_frame = mock.MagicMock()
+    mock_files_module = mock.MagicMock()
+    mock_files_module.SnowflakeFile.open.return_value = fake_file
+    with mock.patch.dict(
+        "sys.modules", {"snowflake.snowpark.files": mock_files_module}
+    ), mock.patch("polars.read_parquet", return_value=fake_frame) as mock_read:
+        result = _open_stage_files_parallel(None, ["@stg/a.parquet"], is_sproc=True)
+
+    assert result == [fake_frame]
+    mock_read.assert_called_once_with(fake_file)
+    fake_file.__enter__.assert_called_once()
+    fake_file.__exit__.assert_called_once()
+
+
+def test_arrow_eager_empty_result_returns_schema_frame():
+    """When to_arrow_batches yields nothing, we fall back to a schema fetch."""
+    from snowflake.snowpark._internal import polars_backend
+
+    df = mock.MagicMock()
+    df.to_arrow_batches.return_value = iter([])
+    empty = mock.MagicMock(name="empty_pl_df")
+    with mock.patch.object(
+        polars_backend, "_empty_frame_from_schema", return_value=empty
+    ) as m:
+        result = polars_backend.arrow_eager(df, statement_params=None)
+    assert result is empty
+    m.assert_called_once()
+
+
+def test_arrow_eager_uses_to_arrow_batches():
+    """arrow_eager delegates entirely to to_arrow_batches (no raw cursor)."""
+    import pyarrow as pa
+    from snowflake.snowpark._internal import polars_backend
+
+    batch = pa.RecordBatch.from_pydict({"A": [1, 2], "B": [3, 4]})
+    df = mock.MagicMock()
+    df.to_arrow_batches.return_value = iter([batch])
+    result = polars_backend.arrow_eager(df, statement_params=None)
+    df.to_arrow_batches.assert_called_once()
+    assert result.shape == (2, 2)
+
+
+def test_parquet_eager_no_paths_returns_schema_frame():
+    """COPY INTO produced no files → schema-preserving empty frame."""
+    from snowflake.snowpark._internal import polars_backend
+
+    df = mock.MagicMock()
+    empty = mock.MagicMock(name="empty_pl_df")
+    with mock.patch.object(
+        polars_backend, "_copy_df_to_stage", return_value=[]
+    ), mock.patch.object(
+        polars_backend, "_empty_frame_from_schema", return_value=empty
+    ) as m:
+        result = polars_backend.parquet_eager(df)
+    assert result is empty
+    m.assert_called_once()
+
+
+def test_parquet_eager_no_frames_returns_schema_frame():
+    """Paths exist but all reads produce empty list → schema frame."""
+    from snowflake.snowpark._internal import polars_backend
+
+    df = mock.MagicMock()
+    empty = mock.MagicMock(name="empty_pl_df")
+    with mock.patch.object(
+        polars_backend, "_copy_df_to_stage", return_value=["@a.parquet"]
+    ), mock.patch.object(
+        polars_backend, "_open_stage_files_parallel", return_value=[]
+    ), mock.patch.object(
+        polars_backend, "_empty_frame_from_schema", return_value=empty
+    ) as m:
+        result = polars_backend.parquet_eager(df)
+    assert result is empty
+    m.assert_called_once()
+
+
+def test_max_workers_forwarded_to_open_helper():
+    """max_workers passed to parquet_eager reaches _open_stage_files_parallel."""
+    from snowflake.snowpark._internal import polars_backend
+
+    df = mock.MagicMock()
+    fake_frame = mock.MagicMock()
+
+    with mock.patch.object(
+        polars_backend, "_copy_df_to_stage", return_value=["@a.parquet"]
+    ), mock.patch.object(
+        polars_backend,
+        "_open_stage_files_parallel",
+        return_value=[fake_frame],
+    ) as mock_open:
+        polars_backend.parquet_eager(df, max_workers=4)
+    mock_open.assert_called_once()
+    assert mock_open.call_args.kwargs.get("max_workers") == 4
+
+
+@_skip_local
+def test_to_polars_max_workers_param(session):
+    """max_workers is accepted and produces correct results on the parquet path."""
+    df = session.create_dataframe([[1, 2], [3, 4]], schema=["A", "B"])
+    pq = df.to_polars(transport="parquet", max_workers=2)
+    assert isinstance(pq, pl.DataFrame) and pq.height == 2


### PR DESCRIPTION
Automated release cut by `/release-python`. Target version: v1.55.0.

**Note:** this branch also includes a squashed cherry-pick of PR #4343 (SNOW-3472759: support to_polars() eagerFrame interoperability) at the tip, per release owner request.

Review checklist (cut sanity + release-notes approval):
- [ ] Release notes / Changelog Update Approval from Product Manager (Qinyi Ding)
- [ ] Version bump correct (for a hotfix, curate the CHANGELOG entries under the new header)
- [ ] Dependency alignment setup.py <-> recipe/meta.yaml (verify manually)
- [ ] AST goldens: only `client_version` bumped; regenerate with the monorepo Unparser only if AST-generation logic changed (out of scope here)