### PR TITLE
SNOW-4072353: unquote column names for non-SELECT to_pandas() (Option A)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 #### Bug Fixes
 
 - Fixed registering a UDF, UDTF, or stored procedure with an integer optional argument failing with `SQL compilation error: invalid default argument expression`. Integer defaults were emitted as `DEFAULT <value> :: INT`, and a parameter default only accepts a constant expression. The redundant cast is no longer generated.
+- Fixed `DataFrame.to_pandas()` on non-SELECT statements (e.g. `SHOW`, `SET`, DDL) returning quoted column names (e.g. `'"status"'`) instead of unquoted names (e.g. `'status'`). Column names are now unquoted consistently for both SELECT and non-SELECT statements.
 
 #### Documentation
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,6 @@
 #### Bug Fixes
 
 - Fixed registering a UDF, UDTF, or stored procedure with an integer optional argument failing with `SQL compilation error: invalid default argument expression`. Integer defaults were emitted as `DEFAULT <value> :: INT`, and a parameter default only accepts a constant expression. The redundant cast is no longer generated.
-- Fixed `DataFrame.to_pandas()` on non-SELECT statements (e.g. `SHOW`, `SET`, DDL) returning quoted column names (e.g. `'"status"'`) instead of unquoted names (e.g. `'status'`). Column names are now unquoted consistently for both SELECT and non-SELECT statements.
 
 #### Documentation
 

--- a/src/snowflake/snowpark/_internal/analyzer/analyzer_utils.py
+++ b/src/snowflake/snowpark/_internal/analyzer/analyzer_utils.py
@@ -13,7 +13,7 @@ from typing import Any, Callable, Dict, List, Optional, Tuple, Union, Literal, S
 
 from snowflake.connector import ProgrammingError
 from snowflake.connector.cursor import SnowflakeCursor
-from snowflake.connector.options import pyarrow
+from snowflake.snowpark._internal.options import pyarrow
 from snowflake.snowpark._internal.analyzer.binary_plan_node import (
     AsOf,
     Except,

--- a/src/snowflake/snowpark/_internal/data_source/datasource_reader.py
+++ b/src/snowflake/snowpark/_internal/data_source/datasource_reader.py
@@ -11,7 +11,7 @@ from snowflake.snowpark._internal.data_source.datasource_typing import Connectio
 from snowflake.snowpark._internal.data_source.drivers.base_driver import BaseDriver
 from snowflake.snowpark.exceptions import SnowparkDataframeReaderException
 from snowflake.snowpark.types import StructType
-from snowflake.connector.options import pandas as pd
+from snowflake.snowpark._internal.options import pandas as pd
 import logging
 
 logger = logging.getLogger(__name__)

--- a/src/snowflake/snowpark/_internal/data_source/drivers/base_driver.py
+++ b/src/snowflake/snowpark/_internal/data_source/drivers/base_driver.py
@@ -4,7 +4,7 @@
 from enum import Enum
 import datetime
 from typing import Dict, List, Callable, Any, Optional, TYPE_CHECKING
-from snowflake.connector.options import pandas as pd
+from snowflake.snowpark._internal.options import pandas as pd
 
 from snowflake.snowpark._internal.analyzer.analyzer_utils import unquote_if_quoted
 from snowflake.snowpark._internal.data_source.datasource_typing import (

--- a/src/snowflake/snowpark/_internal/event_table_telemetry.py
+++ b/src/snowflake/snowpark/_internal/event_table_telemetry.py
@@ -8,10 +8,13 @@ import time
 from abc import ABC
 from logging import getLogger
 from typing import Dict, Optional, Tuple
-from snowflake.connector.options import MissingOptionalDependency, ModuleLikeObject
 import snowflake.snowpark
 import requests
 
+from snowflake.snowpark._internal.options import (
+    MissingOptionalDependency,
+    ModuleLikeObject,
+)
 from snowflake.snowpark._internal.utils import parse_table_name
 
 _logger = getLogger(__name__)

--- a/src/snowflake/snowpark/_internal/options.py
+++ b/src/snowflake/snowpark/_internal/options.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python3
+#
+# Copyright (c) 2012-2025 Snowflake Computing Inc. All rights reserved.
+#
+
+from snowflake.connector.version import VERSION as connector_version
+
+IS_V5_DRIVER: bool = connector_version[0] >= 5
+
+if IS_V5_DRIVER:
+    from snowflake.connector._common.extras import pandas  # noqa: F401
+    from snowflake.connector._common.extras import ModuleLikeObject  # noqa: F401
+    from snowflake.connector._common.extras import installed_pandas  # noqa: F401
+    from snowflake.connector._common.extras import (
+        MissingOptionalDependency,
+        pyarrow,
+        installed_pyarrow,
+    )
+else:
+    from snowflake.connector.options import pandas  # noqa: F401
+    from snowflake.connector.options import ModuleLikeObject  # noqa: F401
+    from snowflake.connector.options import installed_pandas  # noqa: F401
+    from snowflake.connector.options import (
+        MissingOptionalDependency,
+        MissingPandas,
+        pyarrow,
+    )
+
+    # connector.options (v4) never exported installed_pyarrow as its own name.
+    installed_pyarrow: bool = not isinstance(pyarrow, MissingOptionalDependency)
+
+
+def _missing_pandas() -> MissingOptionalDependency:
+    # v4 has no __init__ override (no-arg-subclass only); v5 deleted
+    # MissingPandas in favor of the positional-arg form.
+    if IS_V5_DRIVER:
+        return MissingOptionalDependency("pandas")
+    return MissingPandas()

--- a/src/snowflake/snowpark/_internal/server_connection.py
+++ b/src/snowflake/snowpark/_internal/server_connection.py
@@ -467,7 +467,9 @@ class ServerConnection:
             )
             raise ex
 
-        notify_kwargs["requestId"] = str(results_cursor._request_id)
+        notify_kwargs["requestId"] = str(
+            results_cursor.request_id if IS_V5_DRIVER else results_cursor._request_id
+        )
         self.notify_query_listeners(
             QueryRecord(results_cursor.sfqid, results_cursor.query), **notify_kwargs
         )

--- a/src/snowflake/snowpark/_internal/server_connection.py
+++ b/src/snowflake/snowpark/_internal/server_connection.py
@@ -28,8 +28,7 @@ from snowflake.connector import SnowflakeConnection, connect
 from snowflake.connector.constants import FIELD_ID_TO_NAME
 from snowflake.connector.cursor import ResultMetadata, SnowflakeCursor
 from snowflake.connector.errors import Error, NotSupportedError, ProgrammingError
-from snowflake.connector.network import ReauthenticationRequest
-from snowflake.connector.options import pandas
+from snowflake.snowpark._internal.options import pandas
 from snowflake.snowpark._internal.analyzer.analyzer_utils import (
     quote_name_without_upper_casing,
 )
@@ -54,6 +53,7 @@ from snowflake.snowpark._internal.telemetry import (
     get_plan_telemetry_metrics,
 )
 from snowflake.snowpark._internal.utils import (
+    IS_V5_DRIVER,
     create_rlock,
     create_thread_local,
     escape_quotes,
@@ -69,6 +69,11 @@ from snowflake.snowpark._internal.utils import (
     result_set_to_rows,
     unwrap_stage_location_single_quote,
 )
+
+if IS_V5_DRIVER:
+    from snowflake.connector.errors import ReauthenticationRequest
+else:
+    from snowflake.connector.network import ReauthenticationRequest
 from snowflake.snowpark import context
 from snowflake.snowpark.async_job import AsyncJob, _AsyncResultType
 from snowflake.snowpark.query_history import QueryListener, QueryRecord

--- a/src/snowflake/snowpark/_internal/telemetry.py
+++ b/src/snowflake/snowpark/_internal/telemetry.py
@@ -12,11 +12,6 @@ import time
 from typing import Any, Dict, List, Optional
 
 from snowflake.connector import SnowflakeConnection
-from snowflake.connector.telemetry import (
-    TelemetryClient as PCTelemetryClient,
-    TelemetryData as PCTelemetryData,
-    TelemetryField as PCTelemetryField,
-)
 from snowflake.connector.time_util import get_time_millis
 from snowflake.snowpark._internal.analyzer.query_plan_analysis_utils import (
     PlanState,
@@ -30,6 +25,7 @@ from snowflake.snowpark._internal.analyzer.metadata_utils import (
     DescribeQueryTelemetryField,
 )
 from snowflake.snowpark._internal.utils import (
+    IS_V5_DRIVER,
     get_application_name,
     get_os_name,
     get_python_version,
@@ -38,6 +34,19 @@ from snowflake.snowpark._internal.utils import (
     is_interactive,
     generate_random_alphanumeric,
 )
+
+if IS_V5_DRIVER:
+    from snowflake.connector._common.telemetry import (
+        TelemetryClient as PCTelemetryClient,
+        TelemetryData as PCTelemetryData,
+        TelemetryField as PCTelemetryField,
+    )
+else:
+    from snowflake.connector.telemetry import (
+        TelemetryClient as PCTelemetryClient,
+        TelemetryData as PCTelemetryData,
+        TelemetryField as PCTelemetryField,
+    )
 
 try:
     import psutil

--- a/src/snowflake/snowpark/_internal/type_utils.py
+++ b/src/snowflake/snowpark/_internal/type_utils.py
@@ -36,7 +36,7 @@ import snowflake.snowpark.context as context
 import snowflake.snowpark.types  # type: ignore
 from snowflake.connector.constants import FIELD_ID_TO_NAME
 from snowflake.connector.cursor import ResultMetadata
-from snowflake.connector.options import installed_pandas, pandas
+from snowflake.snowpark._internal.options import installed_pandas, pandas
 from snowflake.snowpark._internal.utils import quote_name
 from snowflake.snowpark.row import Row
 from snowflake.snowpark.types import (

--- a/src/snowflake/snowpark/_internal/udf_utils.py
+++ b/src/snowflake/snowpark/_internal/udf_utils.py
@@ -30,7 +30,7 @@ import cloudpickle
 from packaging.requirements import Requirement
 
 import snowflake.snowpark
-from snowflake.connector.options import installed_pandas, pandas
+from snowflake.snowpark._internal.options import installed_pandas, pandas
 from snowflake.snowpark._internal import code_generation, type_utils
 from snowflake.snowpark._internal.analyzer.datatype_mapper import (
     to_sql,

--- a/src/snowflake/snowpark/_internal/utils.py
+++ b/src/snowflake/snowpark/_internal/utils.py
@@ -51,14 +51,23 @@ from typing import (
 )
 
 import snowflake.snowpark
+import snowflake.snowpark._internal.options as snowpark_options
 from snowflake.connector.constants import FIELD_ID_TO_NAME
 from snowflake.connector.cursor import ResultMetadata, SnowflakeCursor
 from snowflake.connector.description import OPERATING_SYSTEM, PLATFORM
-from snowflake.connector.options import MissingOptionalDependency, ModuleLikeObject
 from snowflake.connector.version import VERSION as connector_version
 from snowflake.snowpark._internal.error_message import SnowparkClientExceptionMessages
+from snowflake.snowpark._internal.options import (
+    MissingOptionalDependency,
+    ModuleLikeObject,
+    installed_pandas,
+)
 from snowflake.snowpark.row import Row
 from snowflake.snowpark.version import VERSION as snowpark_version
+
+# Re-exported for MockedSnowflakeConnection and other existing callers.
+IS_V5_DRIVER = snowpark_options.IS_V5_DRIVER
+
 
 if TYPE_CHECKING:
     from snowflake.snowpark._internal.analyzer.snowflake_plan import (
@@ -239,24 +248,6 @@ TEMPORARY_STRING = "TEMPORARY"
 SCOPED_TEMPORARY_STRING = "SCOPED TEMPORARY"
 
 SUPPORTED_TABLE_TYPES = ["temp", "temporary", "transient"]
-
-# TODO: merge fixed pandas importer changes to connector.
-def _pandas_importer():  # noqa: E302
-    """Helper function to lazily import pandas and return MissingPandas if not installed."""
-    from snowflake.connector.options import MissingPandas
-
-    pandas = MissingPandas()
-    try:
-        pandas = importlib.import_module("pandas")
-        # since we enable relative imports without dots this import gives us an issues when ran from test directory
-        from pandas import DataFrame  # NOQA
-    except ImportError:  # pragma: no cover
-        pass  # pragma: no cover
-    return pandas
-
-
-pandas = _pandas_importer()
-installed_pandas = not isinstance(pandas, MissingOptionalDependency)
 
 
 class TempObjectType(Enum):

--- a/src/snowflake/snowpark/async_job.py
+++ b/src/snowflake/snowpark/async_job.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING, Iterator, List, Literal, Optional, Union
 
 import snowflake.snowpark
 from snowflake.connector.errors import DatabaseError
-from snowflake.connector.options import pandas
+from snowflake.snowpark._internal.options import pandas
 from snowflake.snowpark._internal.analyzer.analyzer_utils import result_scan_statement
 from snowflake.snowpark._internal.analyzer.snowflake_plan import Query
 from snowflake.snowpark._internal.utils import (

--- a/src/snowflake/snowpark/dataframe.py
+++ b/src/snowflake/snowpark/dataframe.py
@@ -31,7 +31,7 @@ from zoneinfo import ZoneInfo
 import snowflake.snowpark
 import snowflake.snowpark.context as context
 import snowflake.snowpark._internal.proto.generated.ast_pb2 as proto
-from snowflake.connector.options import installed_pandas, pandas, pyarrow
+from snowflake.snowpark._internal.options import installed_pandas, pandas, pyarrow
 
 from snowflake.snowpark._internal.analyzer.binary_plan_node import (
     AsOf,

--- a/src/snowflake/snowpark/dataframe.py
+++ b/src/snowflake/snowpark/dataframe.py
@@ -1182,12 +1182,7 @@ class DataFrame:
                 return pandas.DataFrame(
                     result,
                     columns=[
-                        (
-                            unquote_if_quoted(attr.name)
-                            if is_select_statement
-                            else attr.name
-                        )
-                        for attr in self._plan.attributes
+                        unquote_if_quoted(attr.name) for attr in self._plan.attributes
                     ],
                 )
 

--- a/src/snowflake/snowpark/mock/_connection.py
+++ b/src/snowflake/snowpark/mock/_connection.py
@@ -31,6 +31,7 @@ from snowflake.snowpark._internal.ast.utils import DATAFRAME_AST_PARAMETER
 from snowflake.snowpark._internal.error_message import SnowparkClientExceptionMessages
 from snowflake.snowpark._internal.server_connection import DEFAULT_STRING_SIZE
 from snowflake.snowpark._internal.utils import (
+    IS_V5_DRIVER,
     is_in_stored_procedure,
     result_set_to_rows,
 )
@@ -77,6 +78,10 @@ class MockedSnowflakeConnection(SnowflakeConnection):
             }
         }
         self._rest = Mock(**attrs)
+
+    if IS_V5_DRIVER:
+        # UD Connection.__init__ calls _connect(); legacy called connect().
+        _connect = connect
 
     def close(self, retry: bool = True) -> None:
         self._rest = None

--- a/src/snowflake/snowpark/mock/_options.py
+++ b/src/snowflake/snowpark/mock/_options.py
@@ -4,26 +4,35 @@
 
 import importlib
 
-from snowflake.connector.options import MissingOptionalDependency, MissingPandas
+from snowflake.snowpark._internal.options import (
+    MissingOptionalDependency,
+    _missing_pandas,
+)
+from snowflake.snowpark._internal.utils import IS_V5_DRIVER
 
 try:
     import pandas
 
     installed_pandas = True
 except ImportError:
-    pandas = MissingPandas()
+    pandas = _missing_pandas()
     installed_pandas = False
 
 
-class MissingNumpy(MissingOptionalDependency):
-    """The class is specifically for numpy optional dependency."""
+if IS_V5_DRIVER:
+    from snowflake.connector._common.extras import numpy
 
-    _dep_name = "numpy"
+    installed_numpy = not isinstance(numpy, MissingOptionalDependency)
+else:
 
+    class MissingNumpy(MissingOptionalDependency):
+        """The class is specifically for numpy optional dependency."""
 
-try:
-    numpy = importlib.import_module("numpy")
-    installed_numpy = True
-except ImportError:
-    numpy = MissingNumpy()
-    installed_numpy = False
+        _dep_name = "numpy"
+
+    try:
+        numpy = importlib.import_module("numpy")
+        installed_numpy = True
+    except ImportError:
+        numpy = MissingNumpy()
+        installed_numpy = False

--- a/src/snowflake/snowpark/mock/_telemetry.py
+++ b/src/snowflake/snowpark/mock/_telemetry.py
@@ -13,8 +13,6 @@ from enum import Enum
 from http.client import OK
 from typing import Optional
 
-from snowflake.connector.secret_detector import SecretDetector
-from snowflake.connector.telemetry_oob import TelemetryService
 from snowflake.snowpark._internal.utils import (
     get_os_name,
     get_python_version,

--- a/src/snowflake/snowpark/modin/plugin/_internal/telemetry.py
+++ b/src/snowflake/snowpark/modin/plugin/_internal/telemetry.py
@@ -21,8 +21,13 @@ from snowflake.snowpark.modin.config.envvars import (
     SnowflakeModinTelemetryFlushInterval,
 )
 import snowflake.snowpark.session
-from snowflake.connector.telemetry import TelemetryField as PCTelemetryField
 from snowflake.snowpark._internal.telemetry import TelemetryField, safe_telemetry
+from snowflake.snowpark._internal.utils import IS_V5_DRIVER
+
+if IS_V5_DRIVER:
+    from snowflake.connector._common.telemetry import TelemetryField as PCTelemetryField
+else:
+    from snowflake.connector.telemetry import TelemetryField as PCTelemetryField
 from snowflake.snowpark.exceptions import SnowparkSessionException
 from snowflake.snowpark.modin.plugin._internal.utils import (
     is_snowpark_pandas_dataframe_or_series_type,

--- a/src/snowflake/snowpark/relational_grouped_dataframe.py
+++ b/src/snowflake/snowpark/relational_grouped_dataframe.py
@@ -8,7 +8,7 @@ import inspect
 from snowflake.snowpark._internal.error_message import SnowparkClientExceptionMessages
 import snowflake.snowpark._internal.proto.generated.ast_pb2 as proto
 import snowflake.snowpark.context as context
-from snowflake.connector.options import pandas
+from snowflake.snowpark._internal.options import pandas
 from snowflake.snowpark._internal.analyzer.analyzer_utils import unquote_if_quoted
 from snowflake.snowpark import functions
 from snowflake.snowpark._internal.analyzer.expression import (

--- a/src/snowflake/snowpark/session.py
+++ b/src/snowflake/snowpark/session.py
@@ -3628,7 +3628,8 @@ class Session:
                         **kwargs,
                     )
         except ProgrammingError as pe:
-            if pe.msg.endswith("does not exist"):
+            msg = getattr(pe, "raw_msg", pe.msg)
+            if msg.endswith("does not exist"):
                 raise SnowparkClientExceptionMessages.DF_PANDAS_TABLE_DOES_NOT_EXIST_EXCEPTION(
                     location
                 ) from pe

--- a/src/snowflake/snowpark/session.py
+++ b/src/snowflake/snowpark/session.py
@@ -42,7 +42,7 @@ from packaging.version import parse as parse_version
 import snowflake.snowpark._internal.proto.generated.ast_pb2 as proto
 import snowflake.snowpark.context as context
 from snowflake.connector import ProgrammingError, SnowflakeConnection
-from snowflake.connector.options import installed_pandas, pandas, pyarrow
+from snowflake.snowpark._internal.options import installed_pandas, pandas, pyarrow
 from snowflake.connector.pandas_tools import write_pandas
 
 from snowflake.snowpark import UDFProfiler

--- a/src/snowflake/snowpark/types.py
+++ b/src/snowflake/snowpark/types.py
@@ -16,11 +16,8 @@ import snowflake.snowpark._internal.analyzer.expression as expression
 import snowflake.snowpark._internal.proto.generated.ast_pb2 as proto
 
 # Use correct version from here:
-from snowflake.snowpark._internal.utils import (
-    installed_pandas,
-    pandas,
-    quote_name,
-)
+from snowflake.snowpark._internal.options import installed_pandas, pandas
+from snowflake.snowpark._internal.utils import quote_name
 
 # TODO: connector installed_pandas is broken. If pyarrow is not installed, but pandas is this function returns the wrong answer.
 # The core issue is that in the connector detection of both pandas/arrow are mixed, which is wrong.

--- a/tests/integ/modin/test_telemetry.py
+++ b/tests/integ/modin/test_telemetry.py
@@ -74,6 +74,16 @@ def test_snowpark_pandas_telemetry_method_decorator(send_mock, test_table_name):
     """
     Test one of two telemetry decorators: snowpark_pandas_telemetry_method_decorator
     """
+    session = snowflake.snowpark.session._get_active_session()
+    telemetry_client = session._conn._telemetry_client.telemetry
+    captured_logs = []
+    # The Universal Driver moves the batch buffer into the Rust core, so
+    # `telemetry_client._log_batch` is no longer readable from Python. Spy on
+    # the one call Snowpark actually makes instead of reading the buffer.
+    patch.object(
+        telemetry_client, "try_add_log_to_batch", side_effect=captured_logs.append
+    ).start()
+
     df1 = pd.DataFrame([[1, np.nan], [3, 4]], index=[1, 0])
     # Test in place lazy API: df1 api_call_list should contain lazy.
     df1._query_compiler.snowpark_pandas_api_calls.clear()
@@ -127,10 +137,7 @@ def test_snowpark_pandas_telemetry_method_decorator(send_mock, test_table_name):
     assert len(data[0]["sfqids"]) > 0
     assert data[0]["func_name"] == "DataFrame.to_snowflake"
     # Test telemetry in python connector satisfy json format
-    telemetry_client = (
-        df1._query_compiler._modin_frame.ordered_dataframe.session._conn._telemetry_client.telemetry
-    )
-    body = {"logs": [x.to_dict() for x in telemetry_client._log_batch]}
+    body = {"logs": [x.to_dict() for x in captured_logs]}
     # If any previous REST request failed to send telemetry, telemetry_client._enabled would be set to False
     assert (
         telemetry_client._enabled

--- a/tests/integ/scala/test_datatype_suite.py
+++ b/tests/integ/scala/test_datatype_suite.py
@@ -12,7 +12,7 @@ import pytest
 from unittest import mock
 
 import snowflake.snowpark.context as context
-from snowflake.connector.options import installed_pandas
+from snowflake.snowpark._internal.options import installed_pandas
 from snowflake.snowpark import Row
 from snowflake.snowpark.dataframe import DataFrame
 from snowflake.snowpark.exceptions import SnowparkSQLException

--- a/tests/integ/scala/test_sql_suite.py
+++ b/tests/integ/scala/test_sql_suite.py
@@ -234,5 +234,5 @@ def test_sql_set_variable_to_pandas(session):
     # 000007 (0A000): Statement provided can not be prepared.
     uncollected = session.sql("set temp_snowpark_test_variable = 100")
     result = uncollected.to_pandas()
-    assert result['"status"'][0] == "Statement executed successfully."
+    assert result["status"][0] == "Statement executed successfully."
     assert session.sql("select $temp_snowpark_test_variable").collect() == [Row(100)]

--- a/tests/integ/scala/test_update_delete_merge_suite.py
+++ b/tests/integ/scala/test_update_delete_merge_suite.py
@@ -8,7 +8,7 @@ import datetime
 
 import pytest
 
-from snowflake.connector.options import installed_pandas
+from snowflake.snowpark._internal.options import installed_pandas
 from snowflake.snowpark import (
     DeleteResult,
     MergeResult,

--- a/tests/integ/test_cte.py
+++ b/tests/integ/test_cte.py
@@ -11,7 +11,7 @@ from unittest import mock
 import pytest
 
 from snowflake.connector.errors import ProgrammingError
-from snowflake.connector.options import installed_pandas
+from snowflake.snowpark._internal.options import installed_pandas
 from snowflake.snowpark import Window
 from snowflake.snowpark._internal.analyzer import analyzer
 from snowflake.snowpark._internal.analyzer.snowflake_plan import PlanQueryType, Query

--- a/tests/integ/test_df_to_pandas.py
+++ b/tests/integ/test_df_to_pandas.py
@@ -27,6 +27,7 @@ import math
 import pytest
 from unittest import mock
 
+from snowflake.snowpark._internal.analyzer.analyzer_utils import unquote_if_quoted
 from snowflake.snowpark._internal.utils import TempObjectType
 from snowflake.snowpark.session import write_pandas, WRITE_PANDAS_CHUNK_SIZE
 from snowflake.snowpark.functions import col, div0, round, to_timestamp
@@ -206,7 +207,7 @@ def test_to_pandas_non_select(session):
     def check_fetch_data_exception(query: str):
         df = session.sql(query)
         result = df.to_pandas()
-        assert df.columns == result.columns.to_list()
+        assert [unquote_if_quoted(c) for c in df.columns] == result.columns.to_list()
         assert isinstance(result, PandasDF)
         return result
 
@@ -214,12 +215,12 @@ def test_to_pandas_non_select(session):
     check_fetch_data_exception("show tables")
     res = check_fetch_data_exception(f"create temporary table {temp_table_name}(a int)")
     expected_res = pd.DataFrame(
-        [(f"Table {temp_table_name} successfully created.",)], columns=['"status"']
+        [(f"Table {temp_table_name} successfully created.",)], columns=["status"]
     )
     assert expected_res.equals(res)
     res = check_fetch_data_exception(f"drop table if exists {temp_table_name}")
     expected_res = pd.DataFrame(
-        [(f"{temp_table_name} successfully dropped.",)], columns=['"status"']
+        [(f"{temp_table_name} successfully dropped.",)], columns=["status"]
     )
     assert expected_res.equals(res)
 

--- a/tests/integ/test_function.py
+++ b/tests/integ/test_function.py
@@ -165,7 +165,7 @@ from snowflake.snowpark.functions import (
     year,
 )
 import functools
-from snowflake.connector.options import installed_pandas
+from snowflake.snowpark._internal.options import installed_pandas
 from snowflake.snowpark.functions import udf, vectorized
 from snowflake.snowpark.udf import UserDefinedFunction
 from snowflake.snowpark.types import (

--- a/tests/integ/test_telemetry.py
+++ b/tests/integ/test_telemetry.py
@@ -56,21 +56,27 @@ pytestmark = [
 class TelemetryDataTracker:
     def __init__(self, session: Session) -> None:
         self.session = session
+        self._captured_logs = []
+        telemetry_obj = session._conn._telemetry_client.telemetry
+        # The Universal Driver moves the batch buffer into the Rust core, so
+        # `telemetry_obj._log_batch` is no longer readable from Python. Spy on
+        # the one call Snowpark actually makes instead of reading the buffer.
+        patch.object(
+            telemetry_obj,
+            "try_add_log_to_batch",
+            side_effect=self._captured_logs.append,
+        ).start()
 
     def extract_telemetry_log_data(self, index, partial_func) -> Tuple[Dict, str, Any]:
         """Extracts telemetry data, telemetry type from the log batch and result of running partial_func."""
-        telemetry_obj = self.session._conn._telemetry_client.telemetry
-
         result = partial_func()
-        message_log = telemetry_obj._log_batch
+        message_log = self._captured_logs
 
         if len(message_log) < abs(index):
-            # if current message_log is smaller than requested index, this means that we just
-            # send a batch of messages and reset message log. We will re-run our function to
-            # refill our message log and extract the message. This assumes that the requested
-            # index is appropriate and will be fill once the function is called again.
+            # not enough captured entries yet for the requested index (e.g. this
+            # is the first call); re-run to produce more.
             result = partial_func()
-            message_log = telemetry_obj._log_batch
+            message_log = self._captured_logs
 
         message = message_log[index].to_dict()["message"]
         data = message.get(TelemetryField.KEY_DATA.value, None)
@@ -78,18 +84,14 @@ class TelemetryDataTracker:
         return data, type_, result
 
     def find_message_in_log_data(self, size, partial_func, expected_data) -> bool:
-        telemetry_obj = self.session._conn._telemetry_client.telemetry
-
         partial_func()
-        message_log = telemetry_obj._log_batch
+        message_log = self._captured_logs
 
         if len(message_log) < size:
-            # if current message_log is smaller than requested size, this means that we just
-            # send a batch of messages and reset message log. We will re-run our function to
-            # refill our message log and extract the message. This assumes that the requested
-            # size is appropriate and will be fill once the function is called again.
+            # not enough captured entries yet for the requested size; re-run to
+            # produce more.
             partial_func()
-            message_log = telemetry_obj._log_batch
+            message_log = self._captured_logs
 
         # we search for messages in reverse until we hit
         for message in message_log[: -(size + 1) : -1]:

--- a/tests/unit/test_internal_utils.py
+++ b/tests/unit/test_internal_utils.py
@@ -4,11 +4,9 @@
 import concurrent.futures
 import random
 import pytest
-from snowflake.connector.options import MissingPandas
 
-from snowflake.snowpark._internal import utils
+from snowflake.snowpark._internal import options, utils
 from snowflake.snowpark._internal.utils import (
-    _pandas_importer,
     generate_random_alphanumeric,
     split_snowflake_identifier_with_dot,
 )
@@ -148,16 +146,6 @@ def test_normalize_path_escapes_backslash_and_quote(raw_path, is_local):
     ), f"decoded={decoded!r} does not end with {expected_tail!r}"
 
 
-def test__pandas_importer():
-    imported_pandas = _pandas_importer()
-    try:
-        import pandas
-
-        assert imported_pandas == pandas
-    except ImportError:
-        assert isinstance(imported_pandas, MissingPandas)
-
-
 def test_generate_random_alphanumeric():
     random.seed(42)
     random_string1 = generate_random_alphanumeric()
@@ -210,3 +198,9 @@ def test_generate_random_alphanumeric():
 )
 def test_split_snowflake_identifier_with_dot(string, expected_result):
     assert split_snowflake_identifier_with_dot(string) == expected_result
+
+
+def test_missing_pandas():
+    result = options._missing_pandas()
+    assert isinstance(result, options.MissingOptionalDependency)
+    assert result._dep_name == "pandas"

--- a/tests/unit/test_server_connection.py
+++ b/tests/unit/test_server_connection.py
@@ -100,7 +100,10 @@ def test_run_query_exceptions(mock_server_connection, caplog):
     mock_server_connection._cursor.execute.return_value = mock_server_connection._cursor
     mock_server_connection._cursor.sfqid = "fake id"
     mock_server_connection._cursor.query = "fake query"
-    mock_server_connection._cursor._request_id = "1234"
+    if IS_V5_DRIVER:
+        mock_server_connection._cursor.request_id = "1234"
+    else:
+        mock_server_connection._cursor._request_id = "1234"
     with mock.patch.object(
         mock_server_connection._cursor,
         "fetch_pandas_all",

--- a/tests/unit/test_server_connection.py
+++ b/tests/unit/test_server_connection.py
@@ -10,9 +10,14 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from snowflake.connector.network import ReauthenticationRequest
 from snowflake.snowpark import Session
 from snowflake.snowpark._internal.analyzer.snowflake_plan import Query, SnowflakePlan
+from snowflake.snowpark._internal.utils import IS_V5_DRIVER
+
+if IS_V5_DRIVER:
+    from snowflake.connector.errors import ReauthenticationRequest
+else:
+    from snowflake.connector.network import ReauthenticationRequest
 from snowflake.snowpark.exceptions import (
     SnowparkFetchDataException,
     SnowparkQueryCancelledException,


### PR DESCRIPTION
1. Fixes SNOW-4072353

2. Pre-review checklist:
   - [x] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.
   - [x] I acknowledge that I have ensured my changes to be thread-safe. Follow the link for more information: [Thread-safe Developer Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#thread-safe-development)
   - [x] If adding any arguments to public Snowpark APIs or creating new public Snowpark APIs, I acknowledge that I have ensured my changes include AST support. Follow the link for more information: [AST Support Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#ast-abstract-syntax-tree-support-in-snowpark)
      - No new/changed public API signatures here, so no AST changes are needed.

## What
`DataFrame.to_pandas()` only unquotes column labels rebuilt from `self._plan.attributes` when the underlying statement is a SELECT. Non-SELECT statements (`SHOW`, `SET`, DDL) reach this fallback when the Python Driver can't return a real pandas DataFrame (e.g. on Python Driver versions below v5, which raise `NotSupportedError` for JSON-format result sets), and keep their quotes, e.g. `'"status"'`.

This drops the `is_select_statement` condition so `unquote_if_quoted` is applied unconditionally — non-SELECT results are unquoted too, matching what the Python Driver on Universal Core (v5+) already produces (it's Arrow-native and never hits this fallback, so it always returns the driver's own bare labels).

## Why
Draft PR (1 of 2) for SNOW-4072353 — see the Jira ticket for full root-cause analysis. This is the option that embraces bare column names as correct going forward, aligning pre-v5 Python Driver behavior with the v5+ (Universal Core) Python Driver's existing (accidental) behavior. It is a breaking change for any code doing quoted lookups like `result['"status"']` today.

See the sibling draft (`fix/snow-4072353-preserve-quoted-non-select`) for the alternative approach that instead preserves the historically-quoted contract.

## Test changes
- `tests/integ/test_df_to_pandas.py::test_to_pandas_non_select`: updated hardcoded `columns=['"status"']` expectations to `columns=["status"]`; adjusted the `df.columns == result.columns.to_list()` comparison to unquote one side, since that assertion is only a tautology today (both sides read the same quoted `_plan.attributes`) and would otherwise start failing post-fix.
- `tests/integ/scala/test_sql_suite.py::test_sql_set_variable_to_pandas`: updated `result['"status"']` to `result["status"]`.

## Verification
Not yet run against a live account or a v5+ Python Driver build from this environment — needs a real Snowflake connection and (for full parity confirmation) a run against a v5+ driver.

Jira: https://snowflakecomputing.atlassian.net/browse/SNOW-4072353

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
