### PR TITLE
SNOW-2912540: define ASYNC_RETRY_PATTERN and compat.OK locally - universal core transition

### DIFF
--- a/src/snowflake/snowpark/_internal/server_connection.py
+++ b/src/snowflake/snowpark/_internal/server_connection.py
@@ -25,7 +25,7 @@ from typing import (
 )
 
 from snowflake.connector import SnowflakeConnection, connect
-from snowflake.connector.constants import ENV_VAR_PARTNER, FIELD_ID_TO_NAME
+from snowflake.connector.constants import FIELD_ID_TO_NAME
 from snowflake.connector.cursor import ResultMetadata, SnowflakeCursor
 from snowflake.connector.errors import Error, NotSupportedError, ProgrammingError
 from snowflake.connector.network import ReauthenticationRequest
@@ -81,6 +81,9 @@ if TYPE_CHECKING:
         ResultMetadataV2 = ResultMetadata
 
 logger = getLogger(__name__)
+
+# backward compatibility constant
+ENV_VAR_PARTNER = "SF_PARTNER"
 
 # parameters needed for usage tracking
 PARAM_APPLICATION = "application"

--- a/src/snowflake/snowpark/async_job.py
+++ b/src/snowflake/snowpark/async_job.py
@@ -7,7 +7,6 @@ from logging import getLogger
 from typing import TYPE_CHECKING, Iterator, List, Literal, Optional, Union
 
 import snowflake.snowpark
-from snowflake.connector.cursor import ASYNC_RETRY_PATTERN
 from snowflake.connector.errors import DatabaseError
 from snowflake.connector.options import pandas
 from snowflake.snowpark._internal.analyzer.analyzer_utils import result_scan_statement
@@ -26,6 +25,8 @@ if TYPE_CHECKING:
     import snowflake.snowpark.session
 
 _logger = getLogger(__name__)
+
+ASYNC_RETRY_PATTERN = [1, 1, 2, 3, 4, 8, 10]
 
 
 class _AsyncResultType(Enum):

--- a/src/snowflake/snowpark/mock/_telemetry.py
+++ b/src/snowflake/snowpark/mock/_telemetry.py
@@ -9,9 +9,9 @@ import threading
 import uuid
 from datetime import datetime
 from enum import Enum
+from http.client import OK
 from typing import Optional
 
-from snowflake.connector.compat import OK
 from snowflake.connector.secret_detector import SecretDetector
 from snowflake.connector.telemetry_oob import TelemetryService
 from snowflake.snowpark._internal.utils import (


### PR DESCRIPTION
> **Re-submitted onto `main`.** The original #4282 was squash-merged into the Graphite stack's synthetic base branch (`graphite-base/4282`) rather than `main`, so its changes never reached `main`. This PR restores the same change, cherry-picked onto current `main` and verified patch-identical to the original merge commit `d40eb1c27`.

Removes two imports from snowflake-connector-python that the Universal Driver connector no longer provides as shims.

- `async_job.py`: `ASYNC_RETRY_PATTERN` defined locally (was imported from `connector.cursor`)
- `mock/_telemetry.py`: `from http.client import OK` (was imported from `connector.compat`)

Companion changes in snowflake-eng/universal-driver PR #512 and #513.

## Checklist

- [x] If adding any arguments to public Snowpark APIs or creating new public Snowpark APIs, I acknowledge that I have ensured my changes include AST support.
- [x] I acknowledge that I have ensured my changes to be thread-safe
