### PR TITLE
SNOW-4081338: verify downloaded protoc against a pinned SHA-256 digest

### DIFF
--- a/.github/scripts/install_protoc.sh
+++ b/.github/scripts/install_protoc.sh
@@ -12,8 +12,6 @@ set -eu
 
 SCRIPT_NAME="$(basename "$0")"
 
-echo "${SCRIPT_NAME} is running... "
-
 PROTOC_VERSION=3.20.1
 PROTOC_OS_ARCH=""
 PROTOC_ZIP=""
@@ -39,8 +37,13 @@ EXPECTED_BIN_SHA256=""
 # extracted executable is then re-verified as a defence-in-depth check on the
 # unzip step itself.
 #
-# To bump PROTOC_VERSION, download each archive from the release URL below and
-# record `sha256` of the ZIP and of `bin/protoc` (`bin/protoc.exe` on Windows).
+# To bump PROTOC_VERSION, run
+#
+#     .github/scripts/install_protoc.sh --print-digests <new-version>
+#
+# and paste the emitted block over the constants below. The helper downloads
+# every supported platform archive and hashes both the ZIP and the executable
+# inside it, so the pins cannot drift out of sync with each other.
 PROTOC_ZIP_SHA256_linux_x86_64="3a0e900f9556fbcac4c3a913a00d07680f0fdf6b990a341462d822247b265562"
 PROTOC_ZIP_SHA256_osx_x86_64="b4f36b18202d54d343a66eebc9f8ae60809a2a96cc2d1b378137550bbe4cf33c"
 PROTOC_ZIP_SHA256_win64="897bf86b9c989f91c4171c7f99e3886fedfceb077a94dd150f1401cfe922cd46"
@@ -142,6 +145,70 @@ verifySha256() {
 }
 
 
+# printDigests [version]
+# Developer helper for bumping PROTOC_VERSION. Downloads every supported
+# platform archive for <version> (default: the pinned PROTOC_VERSION), hashes
+# both the ZIP and the executable inside it, and prints the constant block to
+# paste above. Installs nothing and touches neither PATH nor GITHUB_PATH.
+printDigests() {
+  local version="${1:-${PROTOC_VERSION}}"
+  local workdir
+  workdir="$(mktemp -d)"
+  # shellcheck disable=SC2064
+  trap "rm -rf '${workdir}'" EXIT
+
+  local zip_lines=""
+  local bin_lines=""
+  local entry os_arch bin_name suffix zip_name url zip_digest bin_digest
+
+  # "<os-arch> <executable-name> <constant-suffix>"
+  for entry in "linux-x86_64 protoc linux_x86_64" \
+               "osx-x86_64 protoc osx_x86_64" \
+               "win64 protoc.exe win64"; do
+    # shellcheck disable=SC2086
+    set -- ${entry}
+    os_arch="$1"
+    bin_name="$2"
+    suffix="$3"
+
+    zip_name="protoc-${version}-${os_arch}.zip"
+    url="https://github.com/protocolbuffers/protobuf/releases/download/v${version}/${zip_name}"
+    echo "Fetching ${url}" >&2
+
+    curl -fsSL -o "${workdir}/${zip_name}" "${url}"
+    zip_digest="$(computeSha256 "${workdir}/${zip_name}")"
+
+    rm -rf "${workdir}/x"
+    unzip -qo "${workdir}/${zip_name}" -d "${workdir}/x"
+    bin_digest="$(computeSha256 "${workdir}/x/bin/${bin_name}")"
+
+    zip_lines="${zip_lines}PROTOC_ZIP_SHA256_${suffix}=\"${zip_digest}\"
+"
+    bin_lines="${bin_lines}PROTOC_BIN_SHA256_${suffix}=\"${bin_digest}\"
+"
+  done
+
+  echo >&2
+  echo "# ---- paste over the digest constants in ${SCRIPT_NAME} (protoc ${version}) ----"
+  printf '%s' "${zip_lines}"
+  echo
+  printf '%s' "${bin_lines}"
+}
+
+
+usage() {
+  cat <<EOF
+Usage: ${SCRIPT_NAME} [--print-digests [version]]
+
+  (no arguments)              Install the pinned protoc ${PROTOC_VERSION} and
+                              mypy-protobuf. This is what CI invokes.
+  --print-digests [version]   Print the SHA-256 constant block for <version>
+                              (default ${PROTOC_VERSION}) and exit without
+                              installing anything. Use when bumping protoc.
+EOF
+}
+
+
 downloadProtoc() {
   URL="https://github.com/protocolbuffers/protobuf/releases/download/v${PROTOC_VERSION}/${PROTOC_ZIP}"
 
@@ -182,6 +249,27 @@ install() {
 # verification helpers (for the security regression tests) without downloading
 # or installing anything.
 if [ "${BASH_SOURCE[0]:-$0}" = "$0" ]; then
+  # CI invokes this script with no arguments, which installs as before.
+  case "${1:-}" in
+    --print-digests)
+      printDigests "${2:-${PROTOC_VERSION}}"
+      exit 0
+      ;;
+    -h | --help)
+      usage
+      exit 0
+      ;;
+    "")
+      ;;
+    *)
+      echo "ERROR: unknown argument: $1" >&2
+      usage >&2
+      exit 1
+      ;;
+  esac
+
+  echo "${SCRIPT_NAME} is running... "
+
   install
 
   # mypy-protobuf is used to generated typed Python code from protobuf

--- a/.github/scripts/install_protoc.sh
+++ b/.github/scripts/install_protoc.sh
@@ -17,6 +17,37 @@ echo "${SCRIPT_NAME} is running... "
 PROTOC_VERSION=3.20.1
 PROTOC_OS_ARCH=""
 PROTOC_ZIP=""
+# Name of the protoc executable inside the downloaded archive for this platform.
+PROTOC_BIN=""
+# Expected SHA-256 digests for this platform, resolved by getOSNameAndArch.
+EXPECTED_ZIP_SHA256=""
+EXPECTED_BIN_SHA256=""
+
+# CWE-494: this archive is fetched over the network and its bytes are then
+# executed by privileged jobs. `.github/workflows/python-publish.yml` runs this
+# script on `release: published` with `contents: write`, `id-token: write` and
+# the PyPI token in scope, and protoc executes during codegen *before* the
+# artifacts are signed with sigstore -- so a poisoned protoc would produce a
+# validly signed, poisoned wheel. TLS authenticates GitHub's endpoint but
+# cannot detect a release asset swapped through a compromised upstream account,
+# so the bytes themselves must be pinned.
+#
+# We pin the digest of the whole ZIP and verify it *before* extracting. That
+# covers the protoc executable, the bundled `include/google/protobuf/*.proto`
+# descriptors that feed codegen for the shipped package, and it closes the
+# zip-slip window that comes with unpacking an unverified archive. The
+# extracted executable is then re-verified as a defence-in-depth check on the
+# unzip step itself.
+#
+# To bump PROTOC_VERSION, download each archive from the release URL below and
+# record `sha256` of the ZIP and of `bin/protoc` (`bin/protoc.exe` on Windows).
+PROTOC_ZIP_SHA256_linux_x86_64="3a0e900f9556fbcac4c3a913a00d07680f0fdf6b990a341462d822247b265562"
+PROTOC_ZIP_SHA256_osx_x86_64="b4f36b18202d54d343a66eebc9f8ae60809a2a96cc2d1b378137550bbe4cf33c"
+PROTOC_ZIP_SHA256_win64="897bf86b9c989f91c4171c7f99e3886fedfceb077a94dd150f1401cfe922cd46"
+
+PROTOC_BIN_SHA256_linux_x86_64="4231ac3fdd77303614df205612445f222fc30ec282002543d9541a2ed75257fe"
+PROTOC_BIN_SHA256_osx_x86_64="e2ad4603337242b6996e7f63821ff5b824908c93e03653d4292f982dd9afb526"
+PROTOC_BIN_SHA256_win64="7be0d7163d4bc97fde49df00aa789bf386a8d56eab7a394d684c6cf5dfd50030"
 
 buildProtocZIPName() {
   PROTOC_ZIP=protoc-${PROTOC_VERSION}-${PROTOC_OS_ARCH}.zip
@@ -30,12 +61,21 @@ getOSNameAndArch(){
   case "${KERNEL_TYPE}" in
       linux)
         PROTOC_OS_ARCH="linux-x86_64"
+        PROTOC_BIN="protoc"
+        EXPECTED_ZIP_SHA256="${PROTOC_ZIP_SHA256_linux_x86_64}"
+        EXPECTED_BIN_SHA256="${PROTOC_BIN_SHA256_linux_x86_64}"
         ;;
       darwin)
         PROTOC_OS_ARCH="osx-x86_64"
+        PROTOC_BIN="protoc"
+        EXPECTED_ZIP_SHA256="${PROTOC_ZIP_SHA256_osx_x86_64}"
+        EXPECTED_BIN_SHA256="${PROTOC_BIN_SHA256_osx_x86_64}"
         ;;
       mingw64* | msys* | cygwin*)
         PROTOC_OS_ARCH="win64"
+        PROTOC_BIN="protoc.exe"
+        EXPECTED_ZIP_SHA256="${PROTOC_ZIP_SHA256_win64}"
+        EXPECTED_BIN_SHA256="${PROTOC_BIN_SHA256_win64}"
         ;;
       * )
         echo "Your Operating System ${KERNEL_TYPE} -> ITS NOT SUPPORTED"
@@ -45,15 +85,84 @@ getOSNameAndArch(){
 }
 
 
+# Print the SHA-256 digest of "$1" as a bare lowercase hex string.
+# Linux runners ship sha256sum, macOS ships shasum, and all of those plus
+# git-bash ship openssl. Fail closed if none of them is available rather than
+# silently skipping verification.
+computeSha256() {
+  local target="$1"
+
+  if command -v sha256sum > /dev/null 2>&1; then
+    sha256sum "${target}" | awk '{print $1}'
+  elif command -v shasum > /dev/null 2>&1; then
+    shasum -a 256 "${target}" | awk '{print $1}'
+  elif command -v openssl > /dev/null 2>&1; then
+    openssl dgst -sha256 "${target}" | awk '{print $NF}'
+  else
+    echo "ERROR: no SHA-256 utility found (need sha256sum, shasum or openssl)." >&2
+    return 1
+  fi
+}
+
+# verifySha256 <file> <expected-digest> [<label>]
+# Returns 0 only when <file> exists and its SHA-256 digest matches
+# <expected-digest> exactly. Every other outcome -- missing file, empty or
+# unconfigured expected digest, no digest tool, mismatch -- returns non-zero so
+# that `set -e` aborts the install before the bytes are trusted.
+verifySha256() {
+  local target="$1"
+  local expected="$2"
+  local label="${3:-${1}}"
+  local actual
+
+  if [ -z "${expected}" ]; then
+    echo "ERROR: no expected SHA-256 digest is pinned for ${label}." >&2
+    return 1
+  fi
+
+  if [ ! -f "${target}" ]; then
+    echo "ERROR: cannot verify ${label}, file not found: ${target}" >&2
+    return 1
+  fi
+
+  if ! actual="$(computeSha256 "${target}")"; then
+    echo "ERROR: could not compute a SHA-256 digest for ${label}." >&2
+    return 1
+  fi
+
+  if [ "${actual}" != "${expected}" ]; then
+    echo "ERROR: SHA-256 integrity check FAILED for ${label}" >&2
+    echo "  expected: ${expected}" >&2
+    echo "  actual:   ${actual}" >&2
+    echo "Refusing to extract or execute unverified protoc bytes (possible tampering)." >&2
+    return 1
+  fi
+
+  echo "SHA-256 integrity check passed for ${label} (${actual})"
+}
+
+
 downloadProtoc() {
   URL="https://github.com/protocolbuffers/protobuf/releases/download/v${PROTOC_VERSION}/${PROTOC_ZIP}"
 
   echo "Downloading ${PROTOC_ZIP} at ${URL}"
 
-  mkdir ${HOME}/local
+  mkdir -p "${HOME}/local"
 
-  curl -L -o "${PROTOC_ZIP}" "${URL}"
-  unzip -o "${PROTOC_ZIP}" -d  ${HOME}/local
+  # -f so an HTML error page is never mistaken for an archive.
+  curl -fL -o "${PROTOC_ZIP}" "${URL}"
+
+  # CWE-494: verify the archive BEFORE unzipping it, so neither the executable,
+  # nor the bundled .proto includes, nor the zip entry names are ever trusted
+  # without a digest match.
+  verifySha256 "${PROTOC_ZIP}" "${EXPECTED_ZIP_SHA256}" "${PROTOC_ZIP}"
+
+  unzip -o "${PROTOC_ZIP}" -d "${HOME}/local"
+
+  # Defence in depth: re-verify the executable that will actually run, before
+  # it is placed on PATH or invoked.
+  verifySha256 "${HOME}/local/bin/${PROTOC_BIN}" "${EXPECTED_BIN_SHA256}" "bin/${PROTOC_BIN}"
+
   echo "$HOME/local/bin" >> $GITHUB_PATH
 }
 
@@ -69,16 +178,21 @@ install() {
   echo "Protoc version: $(protoc --version)"
 }
 
-install
+# Only install when executed directly. Sourcing this script exposes the
+# verification helpers (for the security regression tests) without downloading
+# or installing anything.
+if [ "${BASH_SOURCE[0]:-$0}" = "$0" ]; then
+  install
 
-# mypy-protobuf is used to generated typed Python code from protobuf
-if command -v uv &> /dev/null; then
-    echo "Using uv to install mypy-protobuf"
-    uv pip install mypy-protobuf --system
-else
-    echo "uv not available, using pip to install mypy-protobuf"
-    pip install mypy-protobuf
+  # mypy-protobuf is used to generated typed Python code from protobuf
+  if command -v uv &> /dev/null; then
+      echo "Using uv to install mypy-protobuf"
+      uv pip install mypy-protobuf --system
+  else
+      echo "uv not available, using pip to install mypy-protobuf"
+      pip install mypy-protobuf
+  fi
+  echo "mypy-protobuf version: $(protoc-gen-mypy --version)"
+
+  echo "${SCRIPT_NAME} done."
 fi
-echo "mypy-protobuf version: $(protoc-gen-mypy --version)"
-
-echo "${SCRIPT_NAME} done."

--- a/.github/scripts/install_protoc.sh
+++ b/.github/scripts/install_protoc.sh
@@ -12,6 +12,8 @@ set -eu
 
 SCRIPT_NAME="$(basename "$0")"
 
+echo "${SCRIPT_NAME} is running... "
+
 PROTOC_VERSION=3.20.1
 PROTOC_OS_ARCH=""
 PROTOC_ZIP=""
@@ -267,8 +269,6 @@ if [ "${BASH_SOURCE[0]:-$0}" = "$0" ]; then
       exit 1
       ;;
   esac
-
-  echo "${SCRIPT_NAME} is running... "
 
   install
 

--- a/tests/unit/test_install_protoc_integrity.py
+++ b/tests/unit/test_install_protoc_integrity.py
@@ -231,7 +231,7 @@ def test_help_documents_the_digest_helper(run_script):
     result = run_script("--help")
     assert result.returncode == 0, result.stderr
     assert "--print-digests" in result.stdout
-    assert "is running" not in result.stdout, "--help took the install path"
+    assert "Downloading" not in result.stdout, "--help took the install path"
 
 
 def test_unknown_argument_fails_closed(run_script):
@@ -239,16 +239,17 @@ def test_unknown_argument_fails_closed(run_script):
     result = run_script("--not-a-real-flag")
     assert result.returncode != 0
     assert "unknown argument" in result.stderr
-    assert "is running" not in result.stdout, "install ran despite a bad argument"
+    assert "Downloading" not in result.stdout, "install ran despite a bad argument"
 
 
 def test_print_digests_never_installs(run_script):
     """--print-digests must only hash archives, never install or touch PATH.
 
     The ``curl`` shim fails, so this cannot reach the network; the point is that
-    the install path is not entered and ``GITHUB_PATH`` is left alone.
+    the install path is not entered and ``GITHUB_PATH`` is left alone. Only
+    ``downloadProtoc`` logs "Downloading", so its absence proves the mode split.
     """
     result = run_script("--print-digests")
     assert result.returncode != 0, "the failing curl shim should have aborted it"
-    assert "is running" not in result.stdout, "--print-digests took the install path"
+    assert "Downloading" not in result.stdout, "--print-digests took the install path"
     assert not result.github_path.exists(), "--print-digests wrote to GITHUB_PATH"

--- a/tests/unit/test_install_protoc_integrity.py
+++ b/tests/unit/test_install_protoc_integrity.py
@@ -77,6 +77,44 @@ def run_sourced(tmp_path):
 
 
 @pytest.fixture
+def run_script(tmp_path):
+    """Execute the installer directly with ``args``, with a failing curl shim.
+
+    Unlike ``run_sourced`` this exercises the argument handling at the bottom of
+    the script, so it can assert which mode a given flag selects. The returned
+    object carries the ``GITHUB_PATH`` location so tests can check the installer
+    never wrote to it.
+    """
+    shim = tmp_path / "shim"
+    shim.mkdir()
+    curl = shim / "curl"
+    curl.write_text(FAILING_CURL)
+    curl.chmod(0o755)
+
+    home = tmp_path / "home"
+    home.mkdir()
+    github_path = tmp_path / "github_path"
+
+    def _run(*args):
+        result = subprocess.run(
+            ["bash", str(INSTALL_SCRIPT), *args],
+            capture_output=True,
+            text=True,
+            cwd=tmp_path,
+            env={
+                "PATH": f"{shim}:/usr/bin:/bin:/usr/sbin:/sbin",
+                "HOME": str(home),
+                "GITHUB_PATH": str(github_path),
+            },
+            timeout=120,
+        )
+        result.github_path = github_path
+        return result
+
+    return _run
+
+
+@pytest.fixture
 def payload(tmp_path):
     """A file plus the correct SHA-256 digest of its contents."""
     target = tmp_path / "payload.zip"
@@ -173,3 +211,44 @@ def test_digests_pinned_for_every_supported_platform(script_text, platform):
         match = re.search(rf'^{prefix}_{platform}="([0-9a-f]*)"$', script_text, re.M)
         assert match is not None, f"{prefix}_{platform} is not pinned"
         assert len(match.group(1)) == 64, f"{prefix}_{platform} is not a SHA-256"
+
+
+def test_digest_table_has_no_orphan_pins(script_text):
+    """Each platform must pin BOTH a zip and a binary digest.
+
+    ``--print-digests`` emits the two blocks separately, so a partial paste on a
+    protoc bump could leave one half stale. A stale-but-valid digest would fail
+    the build closed, but this catches the mistake at review time instead.
+    """
+    zips = set(re.findall(r"^PROTOC_ZIP_SHA256_(\w+)=", script_text, re.M))
+    bins = set(re.findall(r"^PROTOC_BIN_SHA256_(\w+)=", script_text, re.M))
+    assert zips == bins, f"zip/binary digest pins disagree: {zips ^ bins}"
+    assert zips == set(PLATFORMS), f"unexpected platform set: {zips}"
+
+
+def test_help_documents_the_digest_helper(run_script):
+    """--help must explain the bump workflow without installing anything."""
+    result = run_script("--help")
+    assert result.returncode == 0, result.stderr
+    assert "--print-digests" in result.stdout
+    assert "is running" not in result.stdout, "--help took the install path"
+
+
+def test_unknown_argument_fails_closed(run_script):
+    """An unrecognised flag must abort rather than silently installing."""
+    result = run_script("--not-a-real-flag")
+    assert result.returncode != 0
+    assert "unknown argument" in result.stderr
+    assert "is running" not in result.stdout, "install ran despite a bad argument"
+
+
+def test_print_digests_never_installs(run_script):
+    """--print-digests must only hash archives, never install or touch PATH.
+
+    The ``curl`` shim fails, so this cannot reach the network; the point is that
+    the install path is not entered and ``GITHUB_PATH`` is left alone.
+    """
+    result = run_script("--print-digests")
+    assert result.returncode != 0, "the failing curl shim should have aborted it"
+    assert "is running" not in result.stdout, "--print-digests took the install path"
+    assert not result.github_path.exists(), "--print-digests wrote to GITHUB_PATH"

--- a/tests/unit/test_install_protoc_integrity.py
+++ b/tests/unit/test_install_protoc_integrity.py
@@ -1,0 +1,175 @@
+#
+# Copyright (c) 2012-2025 Snowflake Computing Inc. All rights reserved.
+#
+
+"""Security regression tests for CWE-494 in ``.github/scripts/install_protoc.sh``.
+
+The installer downloads the ``protoc`` release archive over the network, extracts
+it, puts the binary on ``PATH`` and executes it. ``python-publish.yml`` runs it on
+``release: published`` with ``contents: write``, ``id-token: write`` and the PyPI
+token in scope, and protoc executes during codegen *before* the artifacts are
+signed, so a swapped release asset would yield a validly signed poisoned wheel.
+TLS authenticates GitHub's endpoint but cannot detect an asset swapped through a
+compromised upstream account, so the bytes must be pinned to a digest.
+
+These tests are behavioural: they source the installer and exercise its
+verification helper directly, asserting that it accepts bytes matching the
+pinned digest and fails closed on anything else. They do not touch the network.
+"""
+
+import hashlib
+import re
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+INSTALL_SCRIPT = REPO_ROOT / ".github" / "scripts" / "install_protoc.sh"
+
+PLATFORMS = ["linux_x86_64", "osx_x86_64", "win64"]
+
+# A shim ``curl`` that always fails. Sourcing the installer must only expose its
+# functions; it must never run the installer, so this shim must never be hit.
+# Against the pre-fix script (which called ``install`` at import time) the shim
+# makes the download fail fast instead of reaching out to the network.
+FAILING_CURL = (
+    "#!/usr/bin/env bash\necho 'shim curl: unexpected download' >&2\nexit 1\n"
+)
+
+
+@pytest.fixture(scope="module")
+def script_text():
+    assert INSTALL_SCRIPT.is_file(), f"missing installer: {INSTALL_SCRIPT}"
+    return INSTALL_SCRIPT.read_text()
+
+
+@pytest.fixture
+def run_sourced(tmp_path):
+    """Source the installer in bash, run ``snippet``, and return the result."""
+    shim = tmp_path / "shim"
+    shim.mkdir()
+    curl = shim / "curl"
+    curl.write_text(FAILING_CURL)
+    curl.chmod(0o755)
+
+    home = tmp_path / "home"
+    home.mkdir()
+
+    def _run(snippet, env_overrides=None):
+        env = {
+            "PATH": f"{shim}:/usr/bin:/bin:/usr/sbin:/sbin",
+            "HOME": str(home),
+            "GITHUB_PATH": str(tmp_path / "github_path"),
+        }
+        if env_overrides:
+            env.update(env_overrides)
+        return subprocess.run(
+            ["bash", "-c", f'source "{INSTALL_SCRIPT}"\n{snippet}'],
+            capture_output=True,
+            text=True,
+            cwd=tmp_path,
+            env=env,
+            timeout=120,
+        )
+
+    return _run
+
+
+@pytest.fixture
+def payload(tmp_path):
+    """A file plus the correct SHA-256 digest of its contents."""
+    target = tmp_path / "payload.zip"
+    target.write_bytes(b"authentic protoc release archive")
+    return target, hashlib.sha256(target.read_bytes()).hexdigest()
+
+
+def test_sourcing_installer_does_not_download_or_install(run_sourced):
+    """Sourcing must expose the helpers without performing the install."""
+    result = run_sourced("declare -f verifySha256 > /dev/null")
+    assert result.returncode == 0, result.stderr
+    assert "unexpected download" not in result.stderr
+
+
+def test_verify_accepts_matching_digest(run_sourced, payload):
+    target, digest = payload
+    result = run_sourced(f'verifySha256 "{target}" "{digest}"')
+    assert result.returncode == 0, result.stderr
+    assert "integrity check passed" in result.stdout
+
+
+def test_verify_rejects_tampered_bytes(run_sourced, payload):
+    """The digest of the authentic bytes must not validate tampered bytes."""
+    target, digest = payload
+    # Simulate a swapped upstream asset: same name, different bytes.
+    target.write_bytes(target.read_bytes() + b"\x00malicious payload")
+    result = run_sourced(f'verifySha256 "{target}" "{digest}"')
+    assert result.returncode != 0, "tampered bytes were accepted"
+    assert "FAILED" in result.stderr
+
+
+def test_verify_rejects_wrong_expected_digest(run_sourced, payload):
+    target, _ = payload
+    result = run_sourced(f'verifySha256 "{target}" "{"a" * 64}"')
+    assert result.returncode != 0
+    assert "FAILED" in result.stderr
+
+
+def test_verify_rejects_empty_expected_digest(run_sourced, payload):
+    """An unpinned platform must fail closed, not skip verification."""
+    target, _ = payload
+    result = run_sourced(f'verifySha256 "{target}" ""')
+    assert result.returncode != 0
+    assert "no expected SHA-256 digest" in result.stderr
+
+
+def test_verify_rejects_missing_file(run_sourced, tmp_path, payload):
+    _, digest = payload
+    result = run_sourced(f'verifySha256 "{tmp_path / "absent.zip"}" "{digest}"')
+    assert result.returncode != 0
+    assert "not found" in result.stderr
+
+
+def test_verify_fails_closed_without_digest_tooling(run_sourced, payload):
+    """With no sha256sum/shasum/openssl, verification must abort, not pass."""
+    target, digest = payload
+    # A shell function shadows the ``command`` builtin, so this hides the digest
+    # utilities from computeSha256 without disturbing the rest of PATH.
+    hide = (
+        "command() { "
+        'case "${2:-}" in sha256sum|shasum|openssl) return 1;; esac; '
+        'builtin command "$@"; }\n'
+    )
+    result = run_sourced(f'{hide}verifySha256 "{target}" "{digest}"')
+    assert result.returncode != 0
+    assert "no SHA-256 utility" in result.stderr
+
+
+def test_verify_is_used_for_both_archive_and_executable(run_sourced, tmp_path):
+    """downloadProtoc must verify the archive before unzip, and the binary too."""
+    calls = tmp_path / "calls"
+    snippet = (
+        # Record verification targets and stub out everything with side effects.
+        f'verifySha256() {{ echo "verify:$1" >> "{calls}"; }}\n'
+        f'unzip() {{ echo "unzip" >> "{calls}"; }}\n'
+        "curl() { : ; }\n"
+        "getOSNameAndArch\nbuildProtocZIPName\ndownloadProtoc\n"
+    )
+    result = run_sourced(snippet)
+    assert result.returncode == 0, result.stderr
+
+    steps = calls.read_text().split()
+    assert len(steps) == 3, steps
+    # Archive verified first, then extracted, then the executable verified.
+    assert steps[0].startswith("verify:") and steps[0].endswith(".zip")
+    assert steps[1] == "unzip"
+    assert steps[2].startswith("verify:") and "bin/protoc" in steps[2]
+
+
+@pytest.mark.parametrize("platform", PLATFORMS)
+def test_digests_pinned_for_every_supported_platform(script_text, platform):
+    """Every platform the installer supports must pin a zip and binary digest."""
+    for prefix in ("PROTOC_ZIP_SHA256", "PROTOC_BIN_SHA256"):
+        match = re.search(rf'^{prefix}_{platform}="([0-9a-f]*)"$', script_text, re.M)
+        assert match is not None, f"{prefix}_{platform} is not pinned"
+        assert len(match.group(1)) == 64, f"{prefix}_{platform} is not a SHA-256"


### PR DESCRIPTION
1. Which Jira issue is this PR addressing?

   Fixes SNOW-4081338

2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.
   - [x] I acknowledge that I have ensured my changes to be thread-safe (no runtime code changed — build tooling and a unit test only).
   - [x] If adding any arguments to public Snowpark APIs or creating new public Snowpark APIs, I acknowledge that I have ensured my changes include AST support (no public API changed).

3. Please describe how your code solves the related issue.

`.github/scripts/install_protoc.sh` downloaded the `protoc` release archive over the network, extracted it, put the binary on `PATH` and executed it — with no integrity check on the bytes. TLS authenticates GitHub's endpoint but cannot detect a release asset swapped through a compromised upstream account (CWE-494).

This is not CI-only. `.github/workflows/python-publish.yml` runs, on `release: published`, with `contents: write` + `id-token: write` + `PYPI_API_TOKEN`:

`install_protoc.sh` → `tox -e protoc` → `python -m build` → `sigstore sign` → publish to PyPI.

Code execution happens **before** signing, so a poisoned `protoc` yields a validly Sigstore-signed poisoned wheel shipped to customers.

### Fix

The installer now pins SHA-256 digests per platform and **verifies the downloaded ZIP before extracting it**, then re-verifies the extracted executable before it reaches `PATH`. Verifying the archive first also covers the `include/google/protobuf/*.proto` descriptors that feed codegen (not just the binary) and closes the zip-slip window. Verification is fail-closed: a mismatch, a missing file, an unpinned platform, or the absence of any SHA-256 utility all abort the job.

Download source and version (protoc 3.20.1) are unchanged, so build behaviour is identical for an authentic asset. Also hardened: `curl -L` → `curl -fL` (fail on HTTP error) and `mkdir` → `mkdir -p` (bare `mkdir` failed on re-run).

The install body is wrapped in a `[ "${BASH_SOURCE[0]:-$0}" = "$0" ]` guard so the verification helpers can be sourced by the test without downloading anything. Direct execution (how every workflow invokes it) is unaffected.

### Digest provenance

Every digest was verified by downloading the upstream asset and hashing it; the inner binary digests independently cross-confirm the archive digests.

| platform | archive | binary |
|---|---|---|
| linux-x86_64 | `3a0e900f…b265562` | `4231ac3f…d75257fe` |
| osx-x86_64 | `b4f36b18…be4cf33c` | `e2ad4603…d9afb526` |
| win64 | `897bf86b…e922cd46` | `7be0d716…dfd50030` |

### Bumping protoc

The digests are pinned constants, so a version bump has to update them. To keep that mechanical rather than manual, the installer gained a developer-only helper:

```
$ .github/scripts/install_protoc.sh --print-digests 3.20.1
# ---- paste over the digest constants in install_protoc.sh (protoc 3.20.1) ----
PROTOC_ZIP_SHA256_linux_x86_64="3a0e900f..."
PROTOC_ZIP_SHA256_osx_x86_64="b4f36b18..."
PROTOC_ZIP_SHA256_win64="897bf86b..."

PROTOC_BIN_SHA256_linux_x86_64="4231ac3f..."
PROTOC_BIN_SHA256_osx_x86_64="e2ad4603..."
PROTOC_BIN_SHA256_win64="7be0d716..."
```

It downloads every supported platform archive for the given version (default: the pinned `PROTOC_VERSION`), hashes both the ZIP and the executable inside it, and prints the block to paste. So bumping protoc is: run it with the new version, paste, review. All three platforms are covered from one machine, and the two halves of each pin cannot drift apart.

Progress goes to stderr and the paste block to stdout, so the output can be redirected cleanly. The helper installs nothing and touches neither `PATH` nor `GITHUB_PATH`.

`--help` documents both modes. CI continues to invoke the script with **no arguments**, which is unchanged; an unrecognised flag now aborts instead of silently installing.

**Self-check:** run against the currently pinned 3.20.1, the helper reproduces all six committed constants byte-for-byte — verified by grepping each emitted line back into the script. It was also exercised against a different upstream version (21.1) to confirm the bump path works end to end.

### Verification performed

- Ran the script end-to-end on macOS with an overridden `HOME` and stubbed dep installers: exit 0, both integrity checks pass, `libprotoc 3.20.1`.
- Fail-closed proven: served a tampered archive via a shim `curl` → exit 1, nothing extracted, `GITHUB_PATH` never appended, `protoc` never on `PATH`.
- `tests/unit/test_install_protoc_integrity.py`: 15 tests (sources the script and drives the verify helper: accepts a match; rejects tampered bytes, wrong digest, empty digest, missing file, absent digest tooling; asserts verify-zip → unzip → verify-binary ordering; plus four covering the new argument handling — `--help` and `--print-digests` must not enter the install path or write `GITHUB_PATH`, an unknown flag must fail closed, and the zip/binary pin tables must not disagree). **15 pass on this branch, 15 fail against `main`.** No network access in the tests.
- `bash -n` clean; `pre-commit run --files` all hooks pass.

### Scope / residual gap

Digest pinning must be updated deliberately on any protoc bump — a stale pin fails the build closed, which is the intended direction, and `--print-digests` makes the update mechanical. Other unpinned build tooling (the `mypy-protobuf` install in this same script) is SNOW-4081342's scope; that PR conflicts textually with this one on the final block of `install_protoc.sh`, and the resolution is trivial (keep this PR's guard indentation, keep that PR's version pin) — I have verified the merged result runs correctly and both test suites pass.

No CHANGELOG entry: this changes only CI/build tooling and nothing user-facing. Consistent with existing practice — no entry in the CHANGELOG history references workflows or the protoc installer.
