### PR TITLE
SNOW-4081340: pin release workflow actions to immutable commit SHAs

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -22,9 +22,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
     - name: Set up Python
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@3542bca2639a428e1796aaa6a2ffef0c0f575566 # v3.1.4
       with:
         python-version: '3.11'
     - name: Install dependencies
@@ -73,6 +73,11 @@ jobs:
         done
     - name: List artifacts after sign
       run: ls ./dist
+    - name: Record artifact digests
+      # Snapshot the digests of the signed, verified distributions so that any
+      # substitution of dist/* by a later step can be detected.
+      run: |
+        sha256sum dist/* | tee dist.sha256
     - name: Copy files to release
       run: |
         gh release upload ${{ github.event.release.tag_name }} *.sigstore
@@ -80,8 +85,19 @@ jobs:
         gh release upload ${{ github.event.release.tag_name }} *.crt
       env:
         GITHUB_TOKEN: ${{ github.TOKEN }}
+    - name: Verify artifact digests before publish
+      # Fail the release before anything is uploaded if the signed
+      # distributions no longer match what sigstore verified above.
+      run: |
+        sha256sum --check --strict dist.sha256
     - name: Publish package
-      uses: pypa/gh-action-pypi-publish@release/v1
+      uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
       with:
         user: __token__
         password: ${{ secrets.PYPI_API_TOKEN }}
+    - name: Verify artifact digests after publish
+      # Defence in depth: detect a third-party publish action that swapped a
+      # distribution in the shared workspace before uploading it to PyPI.
+      if: always()
+      run: |
+        sha256sum --check --strict dist.sha256

--- a/tests/unit/test_release_workflow_action_pinning.py
+++ b/tests/unit/test_release_workflow_action_pinning.py
@@ -1,0 +1,68 @@
+#
+# Copyright (c) 2012-2025 Snowflake Computing Inc. All rights reserved.
+#
+"""Guards the release workflow against mutable third-party action references.
+
+``.github/workflows/python-publish.yml`` runs in a privileged job (``contents:
+write``, ``id-token: write``, and the PyPI API token). Referencing an action by
+a mutable tag or branch (for example ``@release/v1``) lets an upstream
+maintainer retarget that ref at arbitrary code, which GitHub would then resolve
+and execute at release time (CWE-829). Every ``uses:`` in that workflow must
+therefore be pinned to a full 40-character commit SHA.
+"""
+
+import re
+from pathlib import Path
+
+import pytest
+
+yaml = pytest.importorskip("yaml")
+
+WORKFLOW_PATH = (
+    Path(__file__).resolve().parents[2] / ".github" / "workflows" / "python-publish.yml"
+)
+
+FULL_SHA_REF = re.compile(r"^[^@\s]+@[0-9a-f]{40}$")
+
+
+def _iter_uses(workflow):
+    """Yield every ``uses:`` value in the workflow, with its step name."""
+    for job_name, job in (workflow.get("jobs") or {}).items():
+        for index, step in enumerate(job.get("steps") or []):
+            uses = step.get("uses")
+            if uses:
+                label = step.get("name") or f"step #{index}"
+                yield f"{job_name} / {label}", uses
+
+
+def test_publish_workflow_actions_are_pinned_to_full_commit_shas():
+    workflow = yaml.safe_load(WORKFLOW_PATH.read_text())
+    references = list(_iter_uses(workflow))
+
+    # Sanity check: if this workflow stops using any action the assertion below
+    # would pass vacuously.
+    assert references, f"no `uses:` references found in {WORKFLOW_PATH}"
+
+    unpinned = [
+        f"{label}: {uses}" for label, uses in references if not FULL_SHA_REF.match(uses)
+    ]
+    assert not unpinned, (
+        "the following actions in .github/workflows/python-publish.yml are not "
+        "pinned to a full 40-character commit SHA: " + ", ".join(unpinned)
+    )
+
+
+def test_publish_workflow_pins_carry_a_version_comment():
+    """Each pin should document the human-readable version it corresponds to."""
+    unannotated = []
+    for line in WORKFLOW_PATH.read_text().splitlines():
+        stripped = line.strip()
+        if not re.match(r"^-?\s*(?:- )?uses:", stripped):
+            continue
+        if not re.search(r"@[0-9a-f]{40}\s+#\s*v?\d", stripped):
+            unannotated.append(stripped)
+    assert (
+        not unannotated
+    ), "pinned actions should carry a trailing `# vX.Y.Z` comment: " + ", ".join(
+        unannotated
+    )


### PR DESCRIPTION
1. Which Jira issue is this PR addressing?

   Fixes SNOW-4081340

2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.
   - [x] I acknowledge that I have ensured my changes to be thread-safe (no runtime code changed — a workflow and a unit test only).
   - [x] If adding any arguments to public Snowpark APIs or creating new public Snowpark APIs, I acknowledge that I have ensured my changes include AST support (no public API changed).

3. Please describe how your code solves the related issue.

`.github/workflows/python-publish.yml` referenced the PyPI publisher as `pypa/gh-action-pypi-publish@release/v1` — a **mutable branch ref** (CWE-829). An attacker with maintainer control of that public action repository can retarget the branch, and GitHub then resolves and executes it at release time inside the privileged `deploy` job (`contents: write`, `id-token: write`, `PYPI_API_TOKEN`).

Two consequences: the action can exfiltrate `PYPI_API_TOKEN` and retain it for future unauthorized uploads until manually revoked; and because the sigstore signing/verification happens at an **earlier** step with no digest re-check afterwards, it can substitute a different distribution in the shared workspace and upload that instead.

### Changes

- All three actions in this workflow pinned to full 40-hex commit SHAs with `# vX.Y.Z` comments. Leaving `checkout`/`setup-python` on mutable tags in the same privileged job would defeat the purpose.
- A digest guard: `Record artifact digests` snapshots `sha256sum dist/*` immediately after signing, then `sha256sum --check --strict` runs before publish and again after publish (`if: always()`).

| action | old ref | pinned SHA | version |
|---|---|---|---|
| `pypa/gh-action-pypi-publish` | `@release/v1` | `dc37677b2e1c63e2034f94d8a5b11f265b73ba33` | v1.14.2 |
| `actions/checkout` | `@v4` | `11d5960a326750d5838078e36cf38b85af677262` | v4.4.0 |
| `actions/setup-python` | `@v3` | `3542bca2639a428e1796aaa6a2ffef0c0f575566` | v3.1.4 |

Every SHA was verified against the GitHub API. `v1.14.2` is an annotated tag object (`a892a5a6…`) which dereferences to `dc37677b…`; that is also the current `release/v1` head, so **pinning is resolution-neutral today**. For `checkout`/`setup-python`, `git/matching-refs/tags` confirms both the major tag and the point release sit on the pinned commit — i.e. each pin equals exactly what the mutable tag resolved to. No major-version bumps were taken, so this is behaviour-preserving.

### On the other two suggested fixes

- **Trusted publishing (OIDC)** is the strongest control since it removes the long-lived token entirely, and this job already has `id-token: write`. It is **deliberately not done here**: it requires registering this repo/workflow as a trusted publisher on PyPI first, and removing the token before that exists breaks the next release. Recommended sequencing: register the trusted publisher on PyPI → merge a follow-up dropping the `with: user/password` block → revoke `PYPI_API_TOKEN`.
- **Splitting build/sign from a digest-checked publish job** would force an artifact round trip and a workflow rewrite. The in-place digest guard achieves the detection goal in three readable steps. Being precise: the post-publish check is **detection, not prevention** — the upload has already happened — but it converts a silent artifact swap into a failed run.

`permissions` are unchanged: `contents: write` is required by the three `gh release upload` steps and `id-token: write` by sigstore. Neither is removable without breaking the release, and there is only one job, so job-scoping would be cosmetic.

### Verification performed

- YAML parses; `bash -n` clean on both new shell bodies.
- `actionlint` 1.7.12: 9 shellcheck info-level findings, **byte-identical in count and location to the same run against `main`** (all pre-existing, on the `Signing` and `Copy files to release` steps). **Zero findings on the new steps.** Pre-existing ones left alone as out of scope.
- Behaviour preservation reviewed line by line: step order, `with:`/`env:` inputs, and the sigstore `--cert-identity …/python-publish.yml@${GITHUB_REF}` assertion all unchanged. `dist.sha256` is written to the repo root and does not match the `*.sigstore`/`*.sig`/`*.crt` upload globs.
- `tests/unit/test_release_workflow_action_pinning.py`: **2 pass on this branch, 2 fail against `main`**, correctly naming all three mutable refs.
- `pre-commit run --files` all hooks pass.

### Not verified / follow-ups

- No real release was executed; the pins and digest steps are statically verified only. Worth watching on the first release: if `pypa/gh-action-pypi-publish` ever writes into `dist/`, the post-publish check would false-positive. It is `if: always()` and runs last, so that would fail the run *after* a successful upload rather than block publishing.
- SHA pinning stops automatic upstream security updates. A `.github/dependabot.yml` entry for `github-actions` should be added so pins are refreshed as reviewable PRs — intentionally not bundled here.
- Whether a PyPI trusted publisher is already registered is not visible to me.

No CHANGELOG entry: this changes only the release workflow and nothing user-facing, consistent with existing practice (no entry in the CHANGELOG history references workflows or GitHub Actions).
