### PR TITLE
SNOW-2912540: add IS_V5_DRIVER constant; use it for SecretDetector/TelemetryData/TelemetryClient/ReauthenticationRequest imports and pandas/pyarrow/numpy resolution - universal core transition

### DIFF
--- a/src/snowflake/snowpark/_internal/analyzer/analyzer_utils.py
+++ b/src/snowflake/snowpark/_internal/analyzer/analyzer_utils.py
@@ -13,7 +13,7 @@ from typing import Any, Callable, Dict, List, Optional, Tuple, Union, Literal, S
 
 from snowflake.connector import ProgrammingError
 from snowflake.connector.cursor import SnowflakeCursor
-from snowflake.connector.options import pyarrow
+from snowflake.snowpark._internal.options import pyarrow
 from snowflake.snowpark._internal.analyzer.binary_plan_node import (
     AsOf,
     Except,

--- a/src/snowflake/snowpark/_internal/analyzer/analyzer_utils.py
+++ b/src/snowflake/snowpark/_internal/analyzer/analyzer_utils.py
@@ -7,17 +7,13 @@ import json
 import math
 import os
 import re
+import secrets
 import tempfile
-from typing import Any, Dict, List, Optional, Tuple, Union, Literal, Sequence
+from typing import Any, Callable, Dict, List, Optional, Tuple, Union, Literal, Sequence
 
 from snowflake.connector import ProgrammingError
 from snowflake.connector.cursor import SnowflakeCursor
 from snowflake.connector.options import pyarrow
-from snowflake.connector.pandas_tools import (
-    _create_temp_stage,
-    _create_temp_file_format,
-    build_location_helper,
-)
 from snowflake.snowpark._internal.analyzer.binary_plan_node import (
     AsOf,
     Except,
@@ -2239,6 +2235,136 @@ def cte_statement(queries: List[str], table_names: List[str]) -> str:
     return f"{WITH}{result}"
 
 
+# ---------------------------------------------------------------------------
+# Pandas/Arrow staging helpers
+# (ported from snowflake.connector.pandas_tools so Snowpark owns the impl)
+# ---------------------------------------------------------------------------
+
+_PANDAS_COMPRESSION_MAP: Dict[str, str] = {
+    "gzip": "auto",
+    "snappy": "snappy",
+    "none": "none",
+}
+
+
+def _pandas_quote_identifier(name: str) -> str:
+    return '"' + name.replace('"', '""') + '"'
+
+
+def _qualify_name(
+    database: Optional[str],
+    schema: Optional[str],
+    name: str,
+    quote_identifiers: bool,
+) -> str:
+    parts = [p for p in (database, schema, name) if p is not None]
+    if quote_identifiers:
+        parts = [_pandas_quote_identifier(p) for p in parts]
+    return ".".join(parts)
+
+
+build_location_helper = _qualify_name
+
+
+def _pandas_generate_temp_name(prefix: str) -> str:
+    return f"__WRITE_PANDAS_{prefix}_{secrets.token_hex(8)}"
+
+
+def _pandas_create_temp_object(
+    cursor: SnowflakeCursor,
+    sql_builder: Callable[[str], Tuple[str, tuple]],
+    qualified_name: str,
+    bare_name: str,
+) -> str:
+    sql, params = sql_builder(qualified_name)
+    try:
+        # _force_qmark_paramstyle is only on execute()'s real signature, not its
+        # @overload stubs, so pyright can't match any overload for this call.
+        cursor.execute(sql, params=params, _force_qmark_paramstyle=True)  # type: ignore[call-overload]
+        return qualified_name
+    except ProgrammingError:
+        sql, params = sql_builder(bare_name)
+        cursor.execute(sql, params=params, _force_qmark_paramstyle=True)  # type: ignore[call-overload]
+        return bare_name
+
+
+def _stage_sql(
+    name: str,
+    compression: str,
+    binary_as_text_false: bool,
+    use_scoped: bool = False,
+) -> Tuple[str, tuple]:
+    mapped = _PANDAS_COMPRESSION_MAP[compression]
+    temp_type = "SCOPED TEMPORARY" if use_scoped else "TEMPORARY"
+    fmt_opts = [f"TYPE=PARQUET COMPRESSION={mapped}"]
+    if binary_as_text_false:
+        fmt_opts.append("BINARY_AS_TEXT=FALSE")
+    return (
+        f"CREATE {temp_type} STAGE IDENTIFIER(?) FILE_FORMAT=({' '.join(fmt_opts)})",
+        (name,),
+    )
+
+
+def _file_format_sql(
+    name: str,
+    compression: str,
+    use_logical_type_suffix: str = "",
+    use_scoped: bool = False,
+) -> Tuple[str, tuple]:
+    mapped = _PANDAS_COMPRESSION_MAP[compression]
+    temp_type = "SCOPED TEMPORARY" if use_scoped else "TEMPORARY"
+    return (
+        f"CREATE {temp_type} FILE FORMAT IDENTIFIER(?) TYPE=PARQUET COMPRESSION={mapped}{use_logical_type_suffix}",
+        (name,),
+    )
+
+
+def _create_temp_stage(
+    cursor: SnowflakeCursor,
+    database: Optional[str],
+    schema: Optional[str],
+    quote_identifiers: bool,
+    compression: str,
+    auto_create_table: bool,
+    overwrite: bool,
+    use_scoped_temp_object: bool = False,
+) -> str:
+    name = _pandas_generate_temp_name("STAGE")
+    qualified = _qualify_name(database, schema, name, quote_identifiers)
+    return _pandas_create_temp_object(
+        cursor,
+        lambda n: _stage_sql(
+            n, compression, auto_create_table or overwrite, use_scoped_temp_object
+        ),
+        qualified,
+        name,
+    )
+
+
+def _create_temp_file_format(
+    cursor: SnowflakeCursor,
+    database: Optional[str],
+    schema: Optional[str],
+    quote_identifiers: bool,
+    compression: str,
+    sql_use_logical_type: str,
+    use_scoped_temp_object: bool = False,
+) -> str:
+    name = _pandas_generate_temp_name("FILE_FORMAT")
+    qualified = _qualify_name(database, schema, name, quote_identifiers)
+    return _pandas_create_temp_object(
+        cursor,
+        lambda n: _file_format_sql(
+            n, compression, sql_use_logical_type, use_scoped_temp_object
+        ),
+        qualified,
+        name,
+    )
+
+
+# ---------------------------------------------------------------------------
+
+
 def write_arrow(
     cursor: SnowflakeCursor,
     table: "pyarrow.Table",
@@ -2391,7 +2517,7 @@ def write_arrow(
             database,
             schema,
             quote_identifiers,
-            compression_map[compression],
+            compression,
             sql_use_logical_type,
             use_scoped_temp_object,
         )

--- a/src/snowflake/snowpark/_internal/data_source/datasource_reader.py
+++ b/src/snowflake/snowpark/_internal/data_source/datasource_reader.py
@@ -11,7 +11,7 @@ from snowflake.snowpark._internal.data_source.datasource_typing import Connectio
 from snowflake.snowpark._internal.data_source.drivers.base_driver import BaseDriver
 from snowflake.snowpark.exceptions import SnowparkDataframeReaderException
 from snowflake.snowpark.types import StructType
-from snowflake.connector.options import pandas as pd
+from snowflake.snowpark._internal.options import pandas as pd
 import logging
 
 logger = logging.getLogger(__name__)

--- a/src/snowflake/snowpark/_internal/data_source/drivers/base_driver.py
+++ b/src/snowflake/snowpark/_internal/data_source/drivers/base_driver.py
@@ -4,7 +4,7 @@
 from enum import Enum
 import datetime
 from typing import Dict, List, Callable, Any, Optional, TYPE_CHECKING
-from snowflake.connector.options import pandas as pd
+from snowflake.snowpark._internal.options import pandas as pd
 
 from snowflake.snowpark._internal.analyzer.analyzer_utils import unquote_if_quoted
 from snowflake.snowpark._internal.data_source.datasource_typing import (

--- a/src/snowflake/snowpark/_internal/event_table_telemetry.py
+++ b/src/snowflake/snowpark/_internal/event_table_telemetry.py
@@ -8,10 +8,13 @@ import time
 from abc import ABC
 from logging import getLogger
 from typing import Dict, Optional, Tuple
-from snowflake.connector.options import MissingOptionalDependency, ModuleLikeObject
 import snowflake.snowpark
 import requests
 
+from snowflake.snowpark._internal.options import (
+    MissingOptionalDependency,
+    ModuleLikeObject,
+)
 from snowflake.snowpark._internal.utils import parse_table_name
 
 _logger = getLogger(__name__)

--- a/src/snowflake/snowpark/_internal/options.py
+++ b/src/snowflake/snowpark/_internal/options.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python3
+#
+# Copyright (c) 2012-2025 Snowflake Computing Inc. All rights reserved.
+#
+
+from snowflake.connector.version import VERSION as connector_version
+
+IS_V5_DRIVER: bool = connector_version[0] >= 5
+
+if IS_V5_DRIVER:
+    from snowflake.connector._common.extras import pandas  # noqa: F401
+    from snowflake.connector._common.extras import ModuleLikeObject  # noqa: F401
+    from snowflake.connector._common.extras import installed_pandas  # noqa: F401
+    from snowflake.connector._common.extras import (
+        MissingOptionalDependency,
+        pyarrow,
+        installed_pyarrow,
+    )
+else:
+    from snowflake.connector.options import pandas  # noqa: F401
+    from snowflake.connector.options import ModuleLikeObject  # noqa: F401
+    from snowflake.connector.options import installed_pandas  # noqa: F401
+    from snowflake.connector.options import (
+        MissingOptionalDependency,
+        MissingPandas,
+        pyarrow,
+    )
+
+    # connector.options (v4) never exported installed_pyarrow as its own name.
+    installed_pyarrow: bool = not isinstance(pyarrow, MissingOptionalDependency)
+
+
+def _missing_pandas() -> MissingOptionalDependency:
+    # v4 has no __init__ override (no-arg-subclass only); v5 deleted
+    # MissingPandas in favor of the positional-arg form.
+    if IS_V5_DRIVER:
+        return MissingOptionalDependency("pandas")
+    return MissingPandas()

--- a/src/snowflake/snowpark/_internal/server_connection.py
+++ b/src/snowflake/snowpark/_internal/server_connection.py
@@ -25,7 +25,7 @@ from typing import (
 )
 
 from snowflake.connector import SnowflakeConnection, connect
-from snowflake.connector.constants import ENV_VAR_PARTNER, FIELD_ID_TO_NAME
+from snowflake.connector.constants import FIELD_ID_TO_NAME
 from snowflake.connector.cursor import ResultMetadata, SnowflakeCursor
 from snowflake.connector.errors import Error, NotSupportedError, ProgrammingError
 from snowflake.connector.network import ReauthenticationRequest
@@ -81,6 +81,9 @@ if TYPE_CHECKING:
         ResultMetadataV2 = ResultMetadata
 
 logger = getLogger(__name__)
+
+# backward compatibility constant
+ENV_VAR_PARTNER = "SF_PARTNER"
 
 # parameters needed for usage tracking
 PARAM_APPLICATION = "application"

--- a/src/snowflake/snowpark/_internal/server_connection.py
+++ b/src/snowflake/snowpark/_internal/server_connection.py
@@ -28,8 +28,7 @@ from snowflake.connector import SnowflakeConnection, connect
 from snowflake.connector.constants import FIELD_ID_TO_NAME
 from snowflake.connector.cursor import ResultMetadata, SnowflakeCursor
 from snowflake.connector.errors import Error, NotSupportedError, ProgrammingError
-from snowflake.connector.network import ReauthenticationRequest
-from snowflake.connector.options import pandas
+from snowflake.snowpark._internal.options import pandas
 from snowflake.snowpark._internal.analyzer.analyzer_utils import (
     quote_name_without_upper_casing,
 )
@@ -54,6 +53,7 @@ from snowflake.snowpark._internal.telemetry import (
     get_plan_telemetry_metrics,
 )
 from snowflake.snowpark._internal.utils import (
+    IS_V5_DRIVER,
     create_rlock,
     create_thread_local,
     escape_quotes,
@@ -69,6 +69,11 @@ from snowflake.snowpark._internal.utils import (
     result_set_to_rows,
     unwrap_stage_location_single_quote,
 )
+
+if IS_V5_DRIVER:
+    from snowflake.connector.errors import ReauthenticationRequest
+else:
+    from snowflake.connector.network import ReauthenticationRequest
 from snowflake.snowpark import context
 from snowflake.snowpark.async_job import AsyncJob, _AsyncResultType
 from snowflake.snowpark.query_history import QueryListener, QueryRecord

--- a/src/snowflake/snowpark/_internal/telemetry.py
+++ b/src/snowflake/snowpark/_internal/telemetry.py
@@ -12,11 +12,6 @@ import time
 from typing import Any, Dict, List, Optional
 
 from snowflake.connector import SnowflakeConnection
-from snowflake.connector.telemetry import (
-    TelemetryClient as PCTelemetryClient,
-    TelemetryData as PCTelemetryData,
-    TelemetryField as PCTelemetryField,
-)
 from snowflake.connector.time_util import get_time_millis
 from snowflake.snowpark._internal.analyzer.query_plan_analysis_utils import (
     PlanState,
@@ -30,6 +25,7 @@ from snowflake.snowpark._internal.analyzer.metadata_utils import (
     DescribeQueryTelemetryField,
 )
 from snowflake.snowpark._internal.utils import (
+    IS_V5_DRIVER,
     get_application_name,
     get_os_name,
     get_python_version,
@@ -38,6 +34,19 @@ from snowflake.snowpark._internal.utils import (
     is_interactive,
     generate_random_alphanumeric,
 )
+
+if IS_V5_DRIVER:
+    from snowflake.connector._common.telemetry import (
+        TelemetryClient as PCTelemetryClient,
+        TelemetryData as PCTelemetryData,
+        TelemetryField as PCTelemetryField,
+    )
+else:
+    from snowflake.connector.telemetry import (
+        TelemetryClient as PCTelemetryClient,
+        TelemetryData as PCTelemetryData,
+        TelemetryField as PCTelemetryField,
+    )
 
 try:
     import psutil

--- a/src/snowflake/snowpark/_internal/type_utils.py
+++ b/src/snowflake/snowpark/_internal/type_utils.py
@@ -36,7 +36,7 @@ import snowflake.snowpark.context as context
 import snowflake.snowpark.types  # type: ignore
 from snowflake.connector.constants import FIELD_ID_TO_NAME
 from snowflake.connector.cursor import ResultMetadata
-from snowflake.connector.options import installed_pandas, pandas
+from snowflake.snowpark._internal.options import installed_pandas, pandas
 from snowflake.snowpark._internal.utils import quote_name
 from snowflake.snowpark.row import Row
 from snowflake.snowpark.types import (

--- a/src/snowflake/snowpark/_internal/udf_utils.py
+++ b/src/snowflake/snowpark/_internal/udf_utils.py
@@ -30,7 +30,7 @@ import cloudpickle
 from packaging.requirements import Requirement
 
 import snowflake.snowpark
-from snowflake.connector.options import installed_pandas, pandas
+from snowflake.snowpark._internal.options import installed_pandas, pandas
 from snowflake.snowpark._internal import code_generation, type_utils
 from snowflake.snowpark._internal.analyzer.datatype_mapper import (
     to_sql,

--- a/src/snowflake/snowpark/_internal/utils.py
+++ b/src/snowflake/snowpark/_internal/utils.py
@@ -51,14 +51,23 @@ from typing import (
 )
 
 import snowflake.snowpark
+import snowflake.snowpark._internal.options as snowpark_options
 from snowflake.connector.constants import FIELD_ID_TO_NAME
 from snowflake.connector.cursor import ResultMetadata, SnowflakeCursor
 from snowflake.connector.description import OPERATING_SYSTEM, PLATFORM
-from snowflake.connector.options import MissingOptionalDependency, ModuleLikeObject
 from snowflake.connector.version import VERSION as connector_version
 from snowflake.snowpark._internal.error_message import SnowparkClientExceptionMessages
+from snowflake.snowpark._internal.options import (
+    MissingOptionalDependency,
+    ModuleLikeObject,
+    installed_pandas,
+)
 from snowflake.snowpark.row import Row
 from snowflake.snowpark.version import VERSION as snowpark_version
+
+# Re-exported for MockedSnowflakeConnection and other existing callers.
+IS_V5_DRIVER = snowpark_options.IS_V5_DRIVER
+
 
 if TYPE_CHECKING:
     from snowflake.snowpark._internal.analyzer.snowflake_plan import (
@@ -239,24 +248,6 @@ TEMPORARY_STRING = "TEMPORARY"
 SCOPED_TEMPORARY_STRING = "SCOPED TEMPORARY"
 
 SUPPORTED_TABLE_TYPES = ["temp", "temporary", "transient"]
-
-# TODO: merge fixed pandas importer changes to connector.
-def _pandas_importer():  # noqa: E302
-    """Helper function to lazily import pandas and return MissingPandas if not installed."""
-    from snowflake.connector.options import MissingPandas
-
-    pandas = MissingPandas()
-    try:
-        pandas = importlib.import_module("pandas")
-        # since we enable relative imports without dots this import gives us an issues when ran from test directory
-        from pandas import DataFrame  # NOQA
-    except ImportError:  # pragma: no cover
-        pass  # pragma: no cover
-    return pandas
-
-
-pandas = _pandas_importer()
-installed_pandas = not isinstance(pandas, MissingOptionalDependency)
 
 
 class TempObjectType(Enum):

--- a/src/snowflake/snowpark/async_job.py
+++ b/src/snowflake/snowpark/async_job.py
@@ -7,7 +7,6 @@ from logging import getLogger
 from typing import TYPE_CHECKING, Iterator, List, Literal, Optional, Union
 
 import snowflake.snowpark
-from snowflake.connector.cursor import ASYNC_RETRY_PATTERN
 from snowflake.connector.errors import DatabaseError
 from snowflake.connector.options import pandas
 from snowflake.snowpark._internal.analyzer.analyzer_utils import result_scan_statement
@@ -26,6 +25,8 @@ if TYPE_CHECKING:
     import snowflake.snowpark.session
 
 _logger = getLogger(__name__)
+
+ASYNC_RETRY_PATTERN = [1, 1, 2, 3, 4, 8, 10]
 
 
 class _AsyncResultType(Enum):

--- a/src/snowflake/snowpark/async_job.py
+++ b/src/snowflake/snowpark/async_job.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING, Iterator, List, Literal, Optional, Union
 
 import snowflake.snowpark
 from snowflake.connector.errors import DatabaseError
-from snowflake.connector.options import pandas
+from snowflake.snowpark._internal.options import pandas
 from snowflake.snowpark._internal.analyzer.analyzer_utils import result_scan_statement
 from snowflake.snowpark._internal.analyzer.snowflake_plan import Query
 from snowflake.snowpark._internal.utils import (

--- a/src/snowflake/snowpark/dataframe.py
+++ b/src/snowflake/snowpark/dataframe.py
@@ -32,7 +32,7 @@ from zoneinfo import ZoneInfo
 import snowflake.snowpark
 import snowflake.snowpark.context as context
 import snowflake.snowpark._internal.proto.generated.ast_pb2 as proto
-from snowflake.connector.options import installed_pandas, pandas, pyarrow
+from snowflake.snowpark._internal.options import installed_pandas, pandas, pyarrow
 
 from snowflake.snowpark._internal.analyzer.binary_plan_node import (
     AsOf,

--- a/src/snowflake/snowpark/mock/_options.py
+++ b/src/snowflake/snowpark/mock/_options.py
@@ -4,26 +4,35 @@
 
 import importlib
 
-from snowflake.connector.options import MissingOptionalDependency, MissingPandas
+from snowflake.snowpark._internal.options import (
+    MissingOptionalDependency,
+    _missing_pandas,
+)
+from snowflake.snowpark._internal.utils import IS_V5_DRIVER
 
 try:
     import pandas
 
     installed_pandas = True
 except ImportError:
-    pandas = MissingPandas()
+    pandas = _missing_pandas()
     installed_pandas = False
 
 
-class MissingNumpy(MissingOptionalDependency):
-    """The class is specifically for numpy optional dependency."""
+if IS_V5_DRIVER:
+    from snowflake.connector._common.extras import numpy
 
-    _dep_name = "numpy"
+    installed_numpy = not isinstance(numpy, MissingOptionalDependency)
+else:
 
+    class MissingNumpy(MissingOptionalDependency):
+        """The class is specifically for numpy optional dependency."""
 
-try:
-    numpy = importlib.import_module("numpy")
-    installed_numpy = True
-except ImportError:
-    numpy = MissingNumpy()
-    installed_numpy = False
+        _dep_name = "numpy"
+
+    try:
+        numpy = importlib.import_module("numpy")
+        installed_numpy = True
+    except ImportError:
+        numpy = MissingNumpy()
+        installed_numpy = False

--- a/src/snowflake/snowpark/mock/_secret_detector.py
+++ b/src/snowflake/snowpark/mock/_secret_detector.py
@@ -1,0 +1,216 @@
+#
+# Copyright (c) 2012-2025 Snowflake Computing Inc. All rights reserved.
+#
+"""The secret detector detects sensitive information.
+
+It masks secrets that might be leaked from two potential avenues
+    1. Out of Band Telemetry
+    2. Logging
+
+Ported from snowflake-connector-python's legacy SecretDetector via the
+Universal Driver's backward-compat shim (drivers#598).
+"""
+from __future__ import annotations
+
+import logging
+import os
+import re
+
+from typing import NamedTuple
+
+MIN_TOKEN_LEN = os.getenv("MIN_TOKEN_LEN", 32)
+MIN_PWD_LEN = os.getenv("MIN_PWD_LEN", 8)
+
+
+class MaskedMessageData(NamedTuple):
+    is_masked: bool = False
+    masked_text: str | None = None
+    error_str: str | None = None
+
+
+class SecretDetector(logging.Formatter):
+    AWS_KEY_PATTERN = re.compile(
+        r"(aws_key_id|aws_secret_key|access_key_id|secret_access_key)\s*=\s*'([^']+)'",
+        flags=re.IGNORECASE,
+    )
+    AWS_TOKEN_PATTERN = re.compile(
+        r'(accessToken|tempToken|keySecret)"\s*:\s*"([a-z0-9/+]{32,}={0,2})"',
+        flags=re.IGNORECASE,
+    )
+    # Detects OAuth access/refresh tokens in serialized JSON (e.g. the OAuth
+    # token-exchange response), matching legacy JDBC's OAUTH_JSON_PATTERN.
+    OAUTH_TOKEN_PATTERN = re.compile(
+        r'(access_token|refresh_token)"\s*:\s*"([a-z0-9!"#\$%&\'\(\)\*\+\,\-\./:;<=>\?\@\[\]\^_`\{\|\}~]{3,})"',
+        flags=re.IGNORECASE,
+    )
+    SAS_TOKEN_PATTERN = re.compile(
+        r"(sig|signature|AWSAccessKeyId|password|passcode)=(?P<secret>[a-z0-9%/+]{16,})",
+        flags=re.IGNORECASE,
+    )
+    PRIVATE_KEY_PATTERN = re.compile(
+        r"-{3,}BEGIN [A-Z ]*PRIVATE KEY-{3,}\n([\s\S]*?)\n-{3,}END [A-Z ]*PRIVATE KEY-{3,}",
+        flags=re.MULTILINE | re.IGNORECASE,
+    )
+    PRIVATE_KEY_DATA_PATTERN = re.compile(
+        r'"privateKeyData": "([a-z0-9/+=\\n]{10,})"', flags=re.MULTILINE | re.IGNORECASE
+    )
+    # ':' and '%' are in the value class so a version/hint-prefixed session token
+    # (e.g. "token=ver:1-hint:1036-<value>", Snowflake's actual wire format) masks
+    # in full instead of stopping at the first ':' -- matches legacy Node.js's fix.
+    CONNECTION_TOKEN_PATTERN = re.compile(
+        r"(token|assertion content)" r"([\'\"\s:=]+)" r"([a-z0-9=/_\-\+\.:%]{8,})",
+        flags=re.IGNORECASE,
+    )
+    # Matches legacy Node.js's OAUTH_CLIENT_SECRET_PATTERN.
+    OAUTH_CLIENT_SECRET_PATTERN = re.compile(
+        r"(oauthClientId|oauthClientSecret|clientSecret)"
+        r"([\'\"\s:=]+)"
+        r"([a-z0-9!\"#\$%&\\\'\(\)\*\+\,-\./:;<=>\?\@\[\]\^_`\{\|\}~]{8,})",
+        flags=re.IGNORECASE,
+    )
+    # Matches legacy Node.js's PASSCODE_PATTERN.
+    PASSCODE_PATTERN = re.compile(
+        r"(passcode|otp|pin|otac)\s*([:=])\s*([0-9]{4,6})",
+        flags=re.IGNORECASE,
+    )
+
+    # Value quantifier is {6,} (not {1,}) so short common words after a bare
+    # "password"/"pwd" keyword -- e.g. "...no ID password was not given" -- are
+    # not mistaken for the secret value itself; matches legacy .NET/JDBC's floor.
+    PASSWORD_PATTERN = re.compile(
+        r"(password"
+        r"|pwd)"
+        r"([\'\"\s:=]+)"
+        r"([a-z0-9!\"#\$%&\\\'\(\)\*\+\,-\./:;<=>\?\@\[\]\^_`\{\|\}~]{6,})",
+        flags=re.IGNORECASE,
+    )
+
+    SECRET_STARRED_MASK_STR = "****"
+
+    @classmethod
+    def mask_connection_token(cls, text: str) -> str:
+        return cls.CONNECTION_TOKEN_PATTERN.sub(
+            r"\1\2" + f"{cls.SECRET_STARRED_MASK_STR}", text
+        )
+
+    @classmethod
+    def mask_password(cls, text: str) -> str:
+        return cls.PASSWORD_PATTERN.sub(
+            r"\1\2" + f"{cls.SECRET_STARRED_MASK_STR}", text
+        )
+
+    @classmethod
+    def mask_aws_keys(cls, text: str) -> str:
+        return cls.AWS_KEY_PATTERN.sub(
+            r"\1=" + f"'{cls.SECRET_STARRED_MASK_STR}'", text
+        )
+
+    @classmethod
+    def mask_sas_tokens(cls, text: str) -> str:
+        return cls.SAS_TOKEN_PATTERN.sub(
+            r"\1=" + f"{cls.SECRET_STARRED_MASK_STR}", text
+        )
+
+    @classmethod
+    def mask_aws_tokens(cls, text: str) -> str:
+        return cls.AWS_TOKEN_PATTERN.sub(r'\1":"XXXX"', text)
+
+    @classmethod
+    def mask_oauth_tokens(cls, text: str) -> str:
+        return cls.OAUTH_TOKEN_PATTERN.sub(r'\1":"XXXX"', text)
+
+    @classmethod
+    def mask_oauth_client_secrets(cls, text: str) -> str:
+        return cls.OAUTH_CLIENT_SECRET_PATTERN.sub(
+            r"\1\2" + f"{cls.SECRET_STARRED_MASK_STR}", text
+        )
+
+    @classmethod
+    def mask_passcodes(cls, text: str) -> str:
+        return cls.PASSCODE_PATTERN.sub(
+            r"\1\2" + f"{cls.SECRET_STARRED_MASK_STR}", text
+        )
+
+    @classmethod
+    def mask_private_key(cls, text: str) -> str:
+        return cls.PRIVATE_KEY_PATTERN.sub(
+            "-----BEGIN PRIVATE KEY-----\\\\nXXXX\\\\n-----END PRIVATE KEY-----", text
+        )
+
+    @classmethod
+    def mask_private_key_data(cls, text: str) -> str:
+        return cls.PRIVATE_KEY_DATA_PATTERN.sub('"privateKeyData": "XXXX"', text)
+
+    @classmethod
+    def mask_secrets(cls, text: str | None) -> MaskedMessageData:
+        """Return ``text`` with any detected secrets masked (the public entry point).
+
+        These maskers are ``classmethod``s (not the legacy ``staticmethod``s) so
+        their ``cls.`` self-references resolve even though
+        ``@backward_compatibility`` stashes ``SecretDetector`` out of the module
+        globals; a bare ``SecretDetector.`` reference would raise ``NameError``.
+        """
+        if text is None:
+            return MaskedMessageData()
+
+        masked = False
+        err_str = None
+        try:
+            masked_text = cls.mask_aws_keys(text)
+            masked_text = cls.mask_sas_tokens(masked_text)
+            masked_text = cls.mask_aws_tokens(masked_text)
+            masked_text = cls.mask_oauth_tokens(masked_text)
+            masked_text = cls.mask_private_key(masked_text)
+            masked_text = cls.mask_private_key_data(masked_text)
+            masked_text = cls.mask_oauth_client_secrets(masked_text)
+            masked_text = cls.mask_passcodes(masked_text)
+            masked_text = cls.mask_password(masked_text)
+            masked_text = cls.mask_connection_token(masked_text)
+            if masked_text != text:
+                masked = True
+        except Exception as ex:
+            # We'll assume that the exception was raised during masking
+            # to be safe consider that the log has sensitive information
+            # and do not raise an exception.
+            masked = True
+            masked_text = str(ex)
+            err_str = str(ex)
+
+        return MaskedMessageData(masked, masked_text, err_str)
+
+    @staticmethod
+    def create_formatting_error_log(
+        original_record: logging.LogRecord, error_message: str
+    ) -> str:
+        return "{} - {} {} - {} - {} - {}".format(
+            original_record.asctime,
+            original_record.threadName,
+            "secret_detector.py",
+            "sanitize_log_str",
+            original_record.levelname,
+            error_message,
+        )
+
+    def format(self, record: logging.LogRecord) -> str:
+        """Format ``record`` via ``logging.Formatter``, masking any secrets.
+
+        Ensures the formatted message is free from sensitive credentials before
+        it reaches a log handler.
+        """
+        try:
+            unsanitized_log = super().format(record)
+            masked, optional_sanitized_log, err_str = type(self).mask_secrets(
+                unsanitized_log
+            )
+            # Added to comply with type hints (Optional[str] is not accepted for str)
+            sanitized_log = optional_sanitized_log or ""
+
+            if masked and err_str is not None:
+                sanitized_log = self.create_formatting_error_log(record, err_str)
+
+        except Exception as ex:
+            sanitized_log = self.create_formatting_error_log(
+                record, "EXCEPTION - " + str(ex)
+            )
+
+        return sanitized_log

--- a/src/snowflake/snowpark/mock/_telemetry.py
+++ b/src/snowflake/snowpark/mock/_telemetry.py
@@ -9,9 +9,9 @@ import threading
 import uuid
 from datetime import datetime
 from enum import Enum
+from http.client import OK
 from typing import Optional
 
-from snowflake.connector.compat import OK
 from snowflake.connector.secret_detector import SecretDetector
 from snowflake.connector.telemetry_oob import TelemetryService
 from snowflake.snowpark._internal.utils import (

--- a/src/snowflake/snowpark/mock/_telemetry.py
+++ b/src/snowflake/snowpark/mock/_telemetry.py
@@ -5,6 +5,7 @@ import atexit
 import json
 import logging
 import os
+import queue as _queue
 import threading
 import uuid
 from datetime import datetime
@@ -20,6 +21,7 @@ from snowflake.snowpark._internal.utils import (
     get_version,
 )
 
+from ._secret_detector import SecretDetector
 from .exceptions import SnowparkLocalTestingException
 
 REQUESTS_AVAILABLE = True
@@ -83,17 +85,29 @@ class LocalTestTelemetryEventType(Enum):
     SESSION_CONNECTION = "session"
 
 
-class LocalTestOOBTelemetryService(TelemetryService):
+class LocalTestOOBTelemetryService:
     PROD = "https://client-telemetry.snowflakecomputing.com/enqueue"
 
+    _instance: "LocalTestOOBTelemetryService | None" = None
+    _instance_lock: threading.Lock = threading.Lock()
+
+    @classmethod
+    def get_instance(cls) -> "LocalTestOOBTelemetryService":
+        if cls._instance is None:
+            with cls._instance_lock:
+                if cls._instance is None:
+                    cls._instance = cls()
+        return cls._instance
+
     def __init__(self) -> None:
-        super().__init__()
         self._is_internal_usage = bool(
             os.getenv("SNOWPARK_LOCAL_TESTING_INTERNAL_TELEMETRY", False)
         )
         self._deployment_url = self.PROD
-        self._enable = True
+        self._enabled = True
         self._lock = threading.RLock()
+        self.queue: _queue.Queue = _queue.Queue()
+        self.batch_size: int = 100
 
     def _upload_payload(self, payload) -> None:
         if not REQUESTS_AVAILABLE:
@@ -158,6 +172,10 @@ class LocalTestOOBTelemetryService(TelemetryService):
                     return
                 self._upload_payload(payload)
 
+    def size(self) -> int:
+        """Returns the size of the queue."""
+        return self.queue.qsize()
+
     @property
     def enabled(self) -> bool:
         """Whether the Telemetry service is enabled or not."""
@@ -188,6 +206,9 @@ class LocalTestOOBTelemetryService(TelemetryService):
             payload = None
         _, masked_text, _ = SecretDetector.mask_secrets(payload)
         return masked_text
+
+    def close(self) -> None:
+        self.flush()
 
     def log_session_creation(self, connection_uuid: Optional[str] = None):
         try:

--- a/src/snowflake/snowpark/mock/_telemetry.py
+++ b/src/snowflake/snowpark/mock/_telemetry.py
@@ -13,8 +13,6 @@ from enum import Enum
 from http.client import OK
 from typing import Optional
 
-from snowflake.connector.secret_detector import SecretDetector
-from snowflake.connector.telemetry_oob import TelemetryService
 from snowflake.snowpark._internal.utils import (
     get_os_name,
     get_python_version,

--- a/src/snowflake/snowpark/modin/plugin/_internal/telemetry.py
+++ b/src/snowflake/snowpark/modin/plugin/_internal/telemetry.py
@@ -21,8 +21,13 @@ from snowflake.snowpark.modin.config.envvars import (
     SnowflakeModinTelemetryFlushInterval,
 )
 import snowflake.snowpark.session
-from snowflake.connector.telemetry import TelemetryField as PCTelemetryField
 from snowflake.snowpark._internal.telemetry import TelemetryField, safe_telemetry
+from snowflake.snowpark._internal.utils import IS_V5_DRIVER
+
+if IS_V5_DRIVER:
+    from snowflake.connector._common.telemetry import TelemetryField as PCTelemetryField
+else:
+    from snowflake.connector.telemetry import TelemetryField as PCTelemetryField
 from snowflake.snowpark.exceptions import SnowparkSessionException
 from snowflake.snowpark.modin.plugin._internal.utils import (
     is_snowpark_pandas_dataframe_or_series_type,

--- a/src/snowflake/snowpark/relational_grouped_dataframe.py
+++ b/src/snowflake/snowpark/relational_grouped_dataframe.py
@@ -8,7 +8,7 @@ import inspect
 from snowflake.snowpark._internal.error_message import SnowparkClientExceptionMessages
 import snowflake.snowpark._internal.proto.generated.ast_pb2 as proto
 import snowflake.snowpark.context as context
-from snowflake.connector.options import pandas
+from snowflake.snowpark._internal.options import pandas
 from snowflake.snowpark._internal.analyzer.analyzer_utils import unquote_if_quoted
 from snowflake.snowpark import functions
 from snowflake.snowpark._internal.analyzer.expression import (

--- a/src/snowflake/snowpark/session.py
+++ b/src/snowflake/snowpark/session.py
@@ -42,7 +42,7 @@ from packaging.version import parse as parse_version
 import snowflake.snowpark._internal.proto.generated.ast_pb2 as proto
 import snowflake.snowpark.context as context
 from snowflake.connector import ProgrammingError, SnowflakeConnection
-from snowflake.connector.options import installed_pandas, pandas, pyarrow
+from snowflake.snowpark._internal.options import installed_pandas, pandas, pyarrow
 from snowflake.connector.pandas_tools import write_pandas
 
 from snowflake.snowpark import UDFProfiler

--- a/src/snowflake/snowpark/types.py
+++ b/src/snowflake/snowpark/types.py
@@ -16,11 +16,8 @@ import snowflake.snowpark._internal.analyzer.expression as expression
 import snowflake.snowpark._internal.proto.generated.ast_pb2 as proto
 
 # Use correct version from here:
-from snowflake.snowpark._internal.utils import (
-    installed_pandas,
-    pandas,
-    quote_name,
-)
+from snowflake.snowpark._internal.options import installed_pandas, pandas
+from snowflake.snowpark._internal.utils import quote_name
 
 # TODO: connector installed_pandas is broken. If pyarrow is not installed, but pandas is this function returns the wrong answer.
 # The core issue is that in the connector detection of both pandas/arrow are mixed, which is wrong.

--- a/tests/integ/scala/test_datatype_suite.py
+++ b/tests/integ/scala/test_datatype_suite.py
@@ -12,7 +12,7 @@ import pytest
 from unittest import mock
 
 import snowflake.snowpark.context as context
-from snowflake.connector.options import installed_pandas
+from snowflake.snowpark._internal.options import installed_pandas
 from snowflake.snowpark import Row
 from snowflake.snowpark.dataframe import DataFrame
 from snowflake.snowpark.exceptions import SnowparkSQLException

--- a/tests/integ/scala/test_update_delete_merge_suite.py
+++ b/tests/integ/scala/test_update_delete_merge_suite.py
@@ -8,7 +8,7 @@ import datetime
 
 import pytest
 
-from snowflake.connector.options import installed_pandas
+from snowflake.snowpark._internal.options import installed_pandas
 from snowflake.snowpark import (
     DeleteResult,
     MergeResult,

--- a/tests/integ/test_cte.py
+++ b/tests/integ/test_cte.py
@@ -11,7 +11,7 @@ from unittest import mock
 import pytest
 
 from snowflake.connector.errors import ProgrammingError
-from snowflake.connector.options import installed_pandas
+from snowflake.snowpark._internal.options import installed_pandas
 from snowflake.snowpark import Window
 from snowflake.snowpark._internal.analyzer import analyzer
 from snowflake.snowpark._internal.analyzer.snowflake_plan import PlanQueryType, Query

--- a/tests/integ/test_df_to_arrow.py
+++ b/tests/integ/test_df_to_arrow.py
@@ -334,7 +334,7 @@ def test_misc_settings(
         "" if use_logical_type is None else f" USE_LOGICAL_TYPE = {use_logical_type}"
     )
     queries = [
-        f"^CREATE .*TEMP.* STAGE .* FILE_FORMAT=\\(TYPE=PARQUET COMPRESSION={compression}\\)",
+        f"^CREATE .*TEMP.* STAGE .* FILE_FORMAT=\\(TYPE=PARQUET COMPRESSION={copy_compression}\\)",
         f"PUT.*PARALLEL={parallel}",
         f'COPY INTO "SNOWPARK_PYTHON_MOCKED_ARROW_TABLE" .* FILE_FORMAT=\\(TYPE=PARQUET USE_VECTORIZED_SCANNER={use_vectorized_scanner} COMPRESSION={copy_compression}{sql_use_logical_type.upper()}\\) PURGE=TRUE ON_ERROR={on_error}',
     ]

--- a/tests/integ/test_function.py
+++ b/tests/integ/test_function.py
@@ -165,7 +165,7 @@ from snowflake.snowpark.functions import (
     year,
 )
 import functools
-from snowflake.connector.options import installed_pandas
+from snowflake.snowpark._internal.options import installed_pandas
 from snowflake.snowpark.functions import udf, vectorized
 from snowflake.snowpark.udf import UserDefinedFunction
 from snowflake.snowpark.types import (

--- a/tests/mock/test_secret_detector.py
+++ b/tests/mock/test_secret_detector.py
@@ -1,0 +1,560 @@
+#
+# Copyright (c) 2012-2025 Snowflake Computing Inc. All rights reserved.
+#
+"""Behavioral tests for the ``SecretDetector`` shim, ported from the Universal
+Driver's backward-compat test suite (drivers#598), which itself ports the full
+legacy ``snowflake-connector-python`` masking-behavior suite
+(``test_log_secret_detector.py`` and ``test_oob_secret_detector.py``) verbatim,
+plus cases ported from other legacy drivers for masking gaps that legacy
+Python itself never covered: AWS-token masking (from .NET's ``TestAWSTokens``),
+OAuth-token JSON masking (from JDBC's ``OAUTH_JSON_PATTERN``),
+OAuth-client-secret and passcode/OTP/PIN masking (from Node.js), the
+version/hint-prefixed session-token wire format, and the ``PASSWORD_PATTERN``
+false-positive fix (from .NET/JDBC's ``{6,}`` floor).
+"""
+
+import logging
+import random
+import string
+
+from unittest import mock
+
+import pytest
+
+from snowflake.snowpark.mock._secret_detector import MaskedMessageData, SecretDetector
+
+
+def _assert_not_masked(text):
+    masked, masked_text, err_str = SecretDetector.mask_secrets(text)
+    assert not masked
+    assert err_str is None
+    assert masked_text == text
+
+
+class TestMaskSecrets:
+    def test_clean_text_is_not_masked(self):
+        _assert_not_masked("select 1 from dual")
+
+    def test_none_text_returns_empty_result(self):
+        result = SecretDetector.mask_secrets(None)
+        assert result == MaskedMessageData()
+
+    def test_empty_string_is_not_masked(self):
+        _assert_not_masked("")
+
+    def test_password_is_masked(self):
+        random_password = "Fh[+2J~AcqeqW%?"
+
+        masked, masked_text, err_str = SecretDetector.mask_secrets(
+            "password:" + random_password
+        )
+        assert masked
+        assert err_str is None
+        assert masked_text == "password:****"
+
+        masked, masked_text, err_str = SecretDetector.mask_secrets(
+            "PASSWORD:" + random_password
+        )
+        assert masked
+        assert err_str is None
+        assert masked_text == "PASSWORD:****"
+
+        masked, masked_text, err_str = SecretDetector.mask_secrets(
+            "PassWorD:" + random_password
+        )
+        assert masked
+        assert err_str is None
+        assert masked_text == "PassWorD:****"
+
+        masked, masked_text, err_str = SecretDetector.mask_secrets(
+            "password = " + random_password
+        )
+        assert masked
+        assert err_str is None
+        assert masked_text == "password = ****"
+
+        masked, masked_text, err_str = SecretDetector.mask_secrets(
+            "pwd:" + random_password
+        )
+        assert masked
+        assert err_str is None
+        assert masked_text == "pwd:****"
+
+        masked, masked_text, err_str = SecretDetector.mask_secrets("password=Afs...")
+        assert masked
+        assert err_str is None
+        assert masked_text == "password=****"
+
+    @pytest.mark.parametrize(
+        "text",
+        [
+            "2020-04-30 23:06:04,069 - MainThread auth.py:397"
+            " - write_temporary_credential() - DEBUG - no ID password was not given",
+            "2020-04-30 23:06:04,069 - MainThread auth.py:397"
+            " - write_temporary_credential() - DEBUG - no ID proxyPassword was not given",
+        ],
+    )
+    def test_password_false_positives_are_not_masked(self, text):
+        """``PASSWORD_PATTERN``'s value floor is 6 chars (not 1) so a short common word
+        right after a bare ``password``/``pwd`` keyword isn't mistaken for the secret
+        itself; matches legacy .NET/JDBC's floor and ``TestPasswordFalsePositive``."""
+        _assert_not_masked(text)
+
+    def test_aws_key_is_masked(self):
+        sql = (
+            "copy into 's3://xxxx/test' from \n"
+            "(select seq1(), random()\n"
+            ", random(), random(), random(), random()\n"
+            ", random(), random(), random(), random()\n"
+            ", random() , random(), random(), random()\n"
+            "\tfrom table(generator(rowcount => 10000)))\n"
+            "credentials=(\n"
+            "  aws_key_id='xxdsdfsafds'\n"
+            "  aws_secret_key='safas+asfsad+safasf'\n"
+            "  )\n"
+            "OVERWRITE = TRUE \n"
+            "MAX_FILE_SIZE = 500000000 \n"
+            "HEADER = TRUE \n"
+            "FILE_FORMAT = (TYPE = PARQUET SNAPPY_COMPRESSION = TRUE )\n"
+            ";"
+        )
+        correct = (
+            "copy into 's3://xxxx/test' from \n"
+            "(select seq1(), random()\n"
+            ", random(), random(), random(), random()\n"
+            ", random(), random(), random(), random()\n"
+            ", random() , random(), random(), random()\n"
+            "\tfrom table(generator(rowcount => 10000)))\n"
+            "credentials=(\n"
+            "  aws_key_id='****'\n"
+            "  aws_secret_key='****'\n"
+            "  )\n"
+            "OVERWRITE = TRUE \n"
+            "MAX_FILE_SIZE = 500000000 \n"
+            "HEADER = TRUE \n"
+            "FILE_FORMAT = (TYPE = PARQUET SNAPPY_COMPRESSION = TRUE )\n"
+            ";"
+        )
+        _, masked_text, _ = SecretDetector.mask_secrets(sql)
+        assert masked_text == correct
+
+    @pytest.mark.parametrize(
+        "text,expected",
+        [
+            ('accessToken":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"', 'accessToken":"XXXX"'),
+            ('tempToken":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"', 'tempToken":"XXXX"'),
+            ('keySecret":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"', 'keySecret":"XXXX"'),
+            (
+                'accessToken"  :  "aB1aaaaaaaaaaZaaaaaaaaaaa9aaaaaaa="',
+                'accessToken":"XXXX"',
+            ),
+            (
+                'accessToken"  :  "aB1aaaaaaaaaaZaaaaaaaa56aaaaaaaaaa=="',
+                'accessToken":"XXXX"',
+            ),
+        ],
+    )
+    def test_aws_tokens_are_masked(self, text, expected):
+        """``AWS_TOKEN_PATTERN`` (``accessToken``/``tempToken``/``keySecret``) has no legacy
+        Python test at all; ported from the legacy .NET driver's ``TestAWSTokens``."""
+        masked, masked_text, err_str = SecretDetector.mask_secrets(text)
+        assert masked
+        assert err_str is None
+        assert masked_text == expected
+
+    def test_sas_tokens_are_masked(self):
+        azure_sas_token = (
+            "https://someaccounts.blob.core.windows.net/results/018b90ab-0033-"
+            "5f8e-0000-14f1000bd376_0/main/data_0_0_1?sv=2015-07-08&amp;"
+            "sig=iCvQmdZngZNW%2F4vw43j6%2BVz6fndHF5LI639QJba4r8o%3D&amp;"
+            "spr=https&amp;st=2016-04-12T03%3A24%3A31Z&amp;"
+            "se=2016-04-13T03%3A29%3A31Z&amp;srt=s&amp;ss=bf&amp;sp=rwl"
+        )
+        masked_azure_sas_token = (
+            "https://someaccounts.blob.core.windows.net/results/018b90ab-0033-"
+            "5f8e-0000-14f1000bd376_0/main/data_0_0_1?sv=2015-07-08&amp;"
+            "sig=****&amp;"
+            "spr=https&amp;st=2016-04-12T03%3A24%3A31Z&amp;"
+            "se=2016-04-13T03%3A29%3A31Z&amp;srt=s&amp;ss=bf&amp;sp=rwl"
+        )
+        s3_sas_token = (
+            "https://somebucket.s3.amazonaws.com/vzy1-s-va_demo0/results/018b92f3"
+            "-01c2-02dd-0000-03d5000c8066_0/main/data_0_0_1?"
+            "x-amz-server-side-encryption-customer-algorithm=AES256&"
+            "response-content-encoding=gzip&AWSAccessKeyId=AKIAIOSFODNN7EXAMPLE"
+            "&Expires=1555481960&Signature=zFiRkdB9RtRRYomppVes4fQ%2ByWw%3D"
+        )
+        masked_s3_sas_token = (
+            "https://somebucket.s3.amazonaws.com/vzy1-s-va_demo0/results/018b92f3"
+            "-01c2-02dd-0000-03d5000c8066_0/main/data_0_0_1?"
+            "x-amz-server-side-encryption-customer-algorithm=AES256&"
+            "response-content-encoding=gzip&AWSAccessKeyId=****"
+            "&Expires=1555481960&Signature=****"
+        )
+
+        _, masked_text, _ = SecretDetector.mask_secrets(azure_sas_token)
+        assert masked_text == masked_azure_sas_token
+
+        _, masked_text, _ = SecretDetector.mask_secrets(s3_sas_token)
+        assert masked_text == masked_s3_sas_token
+
+        text = "".join(random.choice(string.ascii_lowercase) for _ in range(200))
+        _, masked_text, _ = SecretDetector.mask_secrets(text)
+        assert masked_text == text
+
+        _, masked_text, _ = SecretDetector.mask_secrets(
+            azure_sas_token + "\n" + azure_sas_token
+        )
+        assert masked_text == masked_azure_sas_token + "\n" + masked_azure_sas_token
+
+        _, masked_text, _ = SecretDetector.mask_secrets(
+            s3_sas_token + "\n" + s3_sas_token
+        )
+        assert masked_text == masked_s3_sas_token + "\n" + masked_s3_sas_token
+
+        _, masked_text, _ = SecretDetector.mask_secrets(
+            azure_sas_token + "\n" + s3_sas_token
+        )
+        assert masked_text == masked_azure_sas_token + "\n" + masked_s3_sas_token
+
+    def test_combined_secrets_in_create_stage_sql(self):
+        sql = (
+            "create stage mystage "
+            "URL = 's3://mybucket/mypath/' "
+            "credentials = (aws_key_id = 'AKIAIOSFODNN7EXAMPLE' "
+            "aws_secret_key = 'frJIUN8DYpKDtOLCwo//yllqDzg='); "
+            "create stage mystage2 "
+            "URL = 'azure//mystorage.blob.core.windows.net/cont' "
+            "credentials = (azure_sas_token = "
+            "'?sv=2016-05-31&ss=b&srt=sco&sp=rwdl&se=2018-06-27T10:05:50Z&"
+            "st=2017-06-27T02:05:50Z&spr=https,http&"
+            "sig=bgqQwoXwxzuD2GJfagRg7VOS8hzNr3QLT7rhS8OFRLQ%3D')"
+        )
+        masked_sql = (
+            "create stage mystage "
+            "URL = 's3://mybucket/mypath/' "
+            "credentials = (aws_key_id='****' "
+            "aws_secret_key='****'); "
+            "create stage mystage2 "
+            "URL = 'azure//mystorage.blob.core.windows.net/cont' "
+            "credentials = (azure_sas_token = "
+            "'?sv=2016-05-31&ss=b&srt=sco&sp=rwdl&se=2018-06-27T10:05:50Z&"
+            "st=2017-06-27T02:05:50Z&spr=https,http&"
+            "sig=****')"
+        )
+        _, masked_text, _ = SecretDetector.mask_secrets(sql)
+        assert masked_text == masked_sql
+
+        text = "".join(random.choice(string.ascii_lowercase) for _ in range(500))
+        _, masked_text, _ = SecretDetector.mask_secrets(text)
+        assert masked_text == text
+
+    def test_connection_token_is_masked(self):
+        long_token = (
+            "_Y1ZNETTn5/qfUWj3Jedby7gipDzQs=U"
+            "KyJH9DS=nFzzWnfZKGV+C7GopWCGD4Lj"
+            "OLLFZKOE26LXHDt3pTi4iI1qwKuSpf/F"
+            "mClCMBSissVsU3Ei590FP0lPQQhcSGcD"
+            "u69ZL_1X6e9h5z62t/iY7ZkII28n2qU="
+            "nrBJUgPRCIbtJQkVJXIuOHjX4G5yUEKj"
+            "ZBAx4w6=_lqtt67bIA=o7D=oUSjfywsR"
+            "FoloNIkBPXCwFTv+1RVUHgVA2g8A9Lw5"
+            "XdJYuI8vhg=f0bKSq7AhQ2Bh"
+        )
+        json_token = (
+            "{'TOKEN': 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFt"
+            "ZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c'}"
+        )
+
+        masked, masked_text, err_str = SecretDetector.mask_secrets(
+            "Token =" + long_token
+        )
+        assert masked
+        assert err_str is None
+        assert masked_text == "Token =****"
+
+        masked, masked_text, err_str = SecretDetector.mask_secrets(
+            "idToken : " + long_token
+        )
+        assert masked
+        assert err_str is None
+        assert masked_text == "idToken : ****"
+
+        masked, masked_text, err_str = SecretDetector.mask_secrets(
+            "sessionToken : " + long_token
+        )
+        assert masked
+        assert err_str is None
+        assert masked_text == "sessionToken : ****"
+
+        masked, masked_text, err_str = SecretDetector.mask_secrets(
+            "masterToken : " + long_token
+        )
+        assert masked
+        assert err_str is None
+        assert masked_text == "masterToken : ****"
+
+        masked, masked_text, err_str = SecretDetector.mask_secrets(
+            "assertion content:" + long_token
+        )
+        assert masked
+        assert err_str is None
+        assert masked_text == "assertion content:****"
+
+        masked, masked_text, err_str = SecretDetector.mask_secrets(json_token)
+        assert masked
+        assert err_str is None
+        assert masked_text == "{'TOKEN': '****'}"
+
+    def test_token_false_positives(self):
+        false_positive_token_str = (
+            "2020-04-30 23:06:04,069 - MainThread auth.py:397"
+            " - write_temporary_credential() - DEBUG - no ID "
+            "token is given when try to store temporary credential"
+        )
+        _assert_not_masked(false_positive_token_str)
+
+    def test_multiple_secrets_are_all_masked(self):
+        long_token = (
+            "_Y1ZNETTn5/qfUWj3Jedby7gipDzQs=U"
+            "KyJH9DS=nFzzWnfZKGV+C7GopWCGD4Lj"
+            "OLLFZKOE26LXHDt3pTi4iI1qwKuSpf/F"
+            "mClCMBSissVsU3Ei590FP0lPQQhcSGcD"
+            "u69ZL_1X6e9h5z62t/iY7ZkII28n2qU="
+            "nrBJUgPRCIbtJQkVJXIuOHjX4G5yUEKj"
+            "ZBAx4w6=_lqtt67bIA=o7D=oUSjfywsR"
+            "FoloNIkBPXCwFTv+1RVUHgVA2g8A9Lw5"
+            "XdJYuI8vhg=f0bKSq7AhQ2Bh"
+        )
+        long_token2 = (
+            "ktL57KJemuq4-M+Q0pdRjCIMcf1mzcr"
+            "MwKteDS5DRE/Pb+5MzvWjDH7LFPV5b_"
+            "/tX/yoLG3b4TuC6Q5qNzsARPPn_zs/j"
+            "BbDOEg1-IfPpdsbwX6ETeEnhxkHIL4H"
+            "sP-V"
+        )
+        random_pwd = "Fh[+2J~AcqeqW%?"
+        random_pwd2 = random_pwd + "vdkav13"
+
+        masked, masked_text, err_str = SecretDetector.mask_secrets(
+            "token=" + long_token + " random giberish " + "password:" + random_pwd
+        )
+        assert masked
+        assert err_str is None
+        assert masked_text == "token=****" + " random giberish " + "password:****"
+
+        # order reversed
+        masked, masked_text, err_str = SecretDetector.mask_secrets(
+            "password:" + random_pwd + " random giberish " + "token=" + long_token
+        )
+        assert masked
+        assert err_str is None
+        assert masked_text == "password:****" + " random giberish " + "token=****"
+
+        # multiple tokens and password
+        masked, masked_text, err_str = SecretDetector.mask_secrets(
+            "token="
+            + long_token
+            + " random giberish "
+            + "password:"
+            + random_pwd
+            + " random giberish "
+            + "idToken:"
+            + long_token2
+        )
+        assert masked
+        assert err_str is None
+        assert (
+            masked_text
+            == "token=****"
+            + " random giberish "
+            + "password:****"
+            + " random giberish "
+            + "idToken:****"
+        )
+
+        # multiple passwords
+        masked, masked_text, err_str = SecretDetector.mask_secrets(
+            "password=" + random_pwd + " random giberish " + "pwd:" + random_pwd2
+        )
+        assert masked
+        assert err_str is None
+        assert masked_text == "password=****" + " random giberish " + "pwd:****"
+
+        masked, masked_text, err_str = SecretDetector.mask_secrets(
+            "password="
+            + random_pwd
+            + " random giberish "
+            + "password="
+            + random_pwd2
+            + " random giberish "
+            + "password="
+            + random_pwd
+        )
+        assert masked
+        assert err_str is None
+        assert (
+            masked_text
+            == "password=****"
+            + " random giberish "
+            + "password=****"
+            + " random giberish "
+            + "password=****"
+        )
+
+    def test_private_key_body_is_masked(self):
+        rsa_key = (
+            "-----BEGIN RSA PRIVATE KEY-----\n"
+            "MIIBVAIBADANBgkqhkiG9w0BAQEFAASCAT4wggE6AgEAAkEA0pCa0rw1n4GBjylx\n"
+            "sBJPVCrsKO7SowkgJ52Lc8K3hMHNKXvYiqwgizbXFBQA27kvpEVSeRQVC3FAPRU5\n"
+            "gjtLRwIDAQABAkBHZbz5o9PS6AjUUEs6VpsLgRpersxBeACtLiBw+h9cJfUerR//\n"
+            "tTmNsQ9LlamMu2lOlfbO3R2J45ybF7z94A+hAiEA8piucvAlo9YJ4VViQGRTVvr+\n"
+            "xZKekSEYRJBn2czeP+kCIQDeMt1PVk/p0NEcNvQMbO0vJ3+U+lITJRwmtJ9Fs1Lj\n"
+            "rwIgJeTdkwyaBI6BepY4w7AoKHUKaNgvNqJBxSv9XNMYgEkCIG2rl1YgWOMkAQI3\n"
+            "EW/Ml6jtiugiQT5X07Q69F33q5LbAiEArZM7htafpt0RVia+nC9aY+73wpW0Be9e\n"
+            "pDz0yVv8s/Q=\n"
+            "-----END RSA PRIVATE KEY-----\n"
+        )
+        masked, masked_text, err_str = SecretDetector.mask_secrets(rsa_key)
+        assert masked
+        assert err_str is None
+        assert (
+            masked_text
+            == "-----BEGIN PRIVATE KEY-----\\nXXXX\\n-----END PRIVATE KEY-----\n"
+        )
+
+    def test_private_key_data_is_masked(self):
+        text = '"privateKeyData": "aslkjdflasjf"'
+        filtered_text = '"privateKeyData": "XXXX"'
+        _, result, _ = SecretDetector.mask_secrets(text)
+        assert result == filtered_text
+
+    def test_session_token_wire_format_is_masked(self):
+        """``CONNECTION_TOKEN_PATTERN``'s value class includes ':' and '%' so a
+        version/hint-prefixed session token -- Snowflake's actual wire format --
+        masks in full instead of stopping at the first ':'; matches legacy
+        Node.js's fix for the same gap."""
+        masked, masked_text, err_str = SecretDetector.mask_secrets(
+            "token=ver:1-hint:1036-abcd1234efgh5678"
+        )
+        assert masked
+        assert err_str is None
+        assert masked_text == "token=****"
+
+    @pytest.mark.parametrize(
+        "text,expected",
+        [
+            ('"access_token" : "some:FAKE_token123"', '"access_token":"XXXX"'),
+            ('"refresh_token" : "some:FAKE_token123"', '"refresh_token":"XXXX"'),
+        ],
+    )
+    def test_oauth_tokens_are_masked(self, text, expected):
+        """``OAUTH_TOKEN_PATTERN`` has no legacy Python equivalent; ported from
+        legacy JDBC's ``OAUTH_JSON_PATTERN`` / ``testMaskOAuthSecrets``."""
+        masked, masked_text, err_str = SecretDetector.mask_secrets(text)
+        assert masked
+        assert err_str is None
+        assert masked_text == expected
+
+    @pytest.mark.parametrize(
+        "text,expected",
+        [
+            ("oauthClientSecret: aVeryLongSecretValue123", "oauthClientSecret: ****"),
+            ("clientSecret=anotherLongSecretValue456", "clientSecret=****"),
+        ],
+    )
+    def test_oauth_client_secrets_are_masked(self, text, expected):
+        """``OAUTH_CLIENT_SECRET_PATTERN`` has no legacy Python equivalent; ported
+        from legacy Node.js's ``OAUTH_CLIENT_SECRET_PATTERN``."""
+        masked, masked_text, err_str = SecretDetector.mask_secrets(text)
+        assert masked
+        assert err_str is None
+        assert masked_text == expected
+
+    @pytest.mark.parametrize(
+        "text,expected",
+        [
+            ("passcode: 123456", "passcode:****"),
+            ("otp=987654", "otp=****"),
+            ("pin = 4321", "pin=****"),
+        ],
+    )
+    def test_passcodes_are_masked(self, text, expected):
+        """``PASSCODE_PATTERN`` has no legacy Python equivalent; ported from legacy
+        Node.js's ``PASSCODE_PATTERN`` (covers passcode/otp/pin/otac, 4-6 digits)."""
+        masked, masked_text, err_str = SecretDetector.mask_secrets(text)
+        assert masked
+        assert err_str is None
+        assert masked_text == expected
+
+
+class TestMaskSecretsExceptionHandling:
+    """Masking failures must fail closed: the original (unmasked) text is never
+    returned, even if a masker raises."""
+
+    @mock.patch.object(
+        SecretDetector,
+        "mask_connection_token",
+        mock.Mock(side_effect=Exception("Test exception")),
+    )
+    def test_exception_in_masking_is_fail_closed(self):
+        test_str = "This string will raise an exception"
+        masked, masked_text, err_str = SecretDetector.mask_secrets(test_str)
+        assert masked
+        assert err_str == "Test exception"
+        assert masked_text == "Test exception"
+
+    @staticmethod
+    def _format_with_masking_exception():
+        test_str = "This string will raise an exception"
+        log_record = logging.LogRecord(
+            SecretDetector.__name__,
+            logging.DEBUG,
+            "test_secret_detector.py",
+            45,
+            test_str,
+            [],
+            None,
+        )
+        log_record.asctime = "2003-07-08 16:49:45,896"
+        sanitized_log = SecretDetector().format(log_record)
+        assert "Test exception" in sanitized_log
+        assert "secret_detector.py" in sanitized_log
+        assert "sanitize_log_str" in sanitized_log
+        assert test_str not in sanitized_log
+
+    @mock.patch.object(
+        SecretDetector,
+        "mask_connection_token",
+        mock.Mock(side_effect=Exception("Test exception")),
+    )
+    def test_exception_in_secret_detector_while_log_masking(self):
+        self._format_with_masking_exception()
+
+    @mock.patch.object(
+        SecretDetector,
+        "mask_secrets",
+        mock.Mock(side_effect=Exception("Test exception")),
+    )
+    def test_exception_while_log_masking(self):
+        self._format_with_masking_exception()
+
+
+class TestFormatter:
+    def test_format_sanitizes_log_record(self):
+        formatter = SecretDetector("%(message)s")
+        record = logging.LogRecord(
+            name="test",
+            level=logging.INFO,
+            pathname=__file__,
+            lineno=1,
+            msg="connecting with password=hunter2",
+            args=None,
+            exc_info=None,
+        )
+        formatted = formatter.format(record)
+        assert "hunter2" not in formatted
+        assert SecretDetector.SECRET_STARRED_MASK_STR in formatted
+
+    def test_is_a_logging_formatter(self):
+        assert issubclass(SecretDetector, logging.Formatter)

--- a/tests/unit/test_internal_utils.py
+++ b/tests/unit/test_internal_utils.py
@@ -4,11 +4,9 @@
 import concurrent.futures
 import random
 import pytest
-from snowflake.connector.options import MissingPandas
 
-from snowflake.snowpark._internal import utils
+from snowflake.snowpark._internal import options, utils
 from snowflake.snowpark._internal.utils import (
-    _pandas_importer,
     generate_random_alphanumeric,
     split_snowflake_identifier_with_dot,
 )
@@ -148,16 +146,6 @@ def test_normalize_path_escapes_backslash_and_quote(raw_path, is_local):
     ), f"decoded={decoded!r} does not end with {expected_tail!r}"
 
 
-def test__pandas_importer():
-    imported_pandas = _pandas_importer()
-    try:
-        import pandas
-
-        assert imported_pandas == pandas
-    except ImportError:
-        assert isinstance(imported_pandas, MissingPandas)
-
-
 def test_generate_random_alphanumeric():
     random.seed(42)
     random_string1 = generate_random_alphanumeric()
@@ -210,3 +198,9 @@ def test_generate_random_alphanumeric():
 )
 def test_split_snowflake_identifier_with_dot(string, expected_result):
     assert split_snowflake_identifier_with_dot(string) == expected_result
+
+
+def test_missing_pandas():
+    result = options._missing_pandas()
+    assert isinstance(result, options.MissingOptionalDependency)
+    assert result._dep_name == "pandas"

--- a/tests/unit/test_server_connection.py
+++ b/tests/unit/test_server_connection.py
@@ -10,9 +10,14 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from snowflake.connector.network import ReauthenticationRequest
 from snowflake.snowpark import Session
 from snowflake.snowpark._internal.analyzer.snowflake_plan import Query, SnowflakePlan
+from snowflake.snowpark._internal.utils import IS_V5_DRIVER
+
+if IS_V5_DRIVER:
+    from snowflake.connector.errors import ReauthenticationRequest
+else:
+    from snowflake.connector.network import ReauthenticationRequest
 from snowflake.snowpark.exceptions import (
     SnowparkFetchDataException,
     SnowparkQueryCancelledException,


### PR DESCRIPTION
> **Re-submitted onto `main`.** The original #4313 was squash-merged into the Graphite stack's synthetic base branch (`graphite-base/4282`) rather than `main`, so its changes never reached `main`. This PR restores the same change, cherry-picked onto current `main` and verified patch-identical to the original merge commit `6d49d2c38`.

## Summary

- Adds a module-level `IS_V5_DRIVER: bool = connector_version[0] >= 5` to `_internal/utils.py` — a single canonical place for code that needs to branch on connector generation (legacy v3/v4 vs Universal Driver v5+). Originally opened as its own PR (#4310); folded in here since every other change in this PR is gated on it.
- `snowflake.connector.secret_detector` does not exist in v5 (UD) — `SecretDetector` lives at `snowflake.connector._common.secret_detector`. Fixed with an `IS_V5_DRIVER`-gated conditional import in `mock/_telemetry.py`.
- `snowflake.connector.options` already provides `MissingOptionalDependency`, `ModuleLikeObject`, and `pyarrow` on both driver generations — no gap to fill. Re-import these from the connector, gated on `IS_V5_DRIVER`, instead of redefining them locally in `_internal/utils.py`. `installed_pyarrow` is now imported directly on v5 (UD PR #1151 fixed it to check `pyarrow` independently instead of mirroring `installed_pandas`) but still derived locally via `isinstance` on v4 (not exported there at all). `MissingPandas` is imported only on v4 (UD PR #1151 deleted it outright on v5 — no replacement, per `BehaviorDifferences.yaml` #66); a `_missing_pandas()` helper builds the sentinel with whichever construction style each driver generation supports, so callers don't need their own `IS_V5_DRIVER` branch.
- Removes `_internal/utils.py`'s pre-existing `_pandas_importer()` (a second, independent pandas-resolution attempt that predates this whole effort) in favor of sourcing `pandas`/`installed_pandas` from the same `IS_V5_DRIVER`-gated import as the rest of these names. Dedups `mock/_options.py`'s numpy handling against `connector._common.extras.numpy` on v5 (confirmed pure duplicate; v4 keeps its own `MissingNumpy` since v4's `options.py` has no numpy handling to delegate to). Originally opened as a separate PR (#4317); folded in here since the diff was small.
- `_internal/telemetry.py`'s `TelemetryClient`/`TelemetryField` import was completely unconditional, pointing at the top-level `snowflake.connector.telemetry` module — a real implementation on v4, but a `"""BACKWARD COMPATIBILITY MODULE ONLY"""` stub on v5. Gated on `IS_V5_DRIVER`: v5 now imports from `_common.telemetry`, matching UD PR #1106's current branch (verified directly — `_internal/telemetry.py` no longer exists there at all, fully moved). This same commit also corrects this file's `TelemetryData` import, which an earlier commit here pointed at `_internal.telemetry` — that class moved to `_common` too on the same #1106 branch since that earlier fix landed, so it was already stale for the identical reason.
- `server_connection.py` imported `ReauthenticationRequest` unconditionally from `snowflake.connector.network` — that module doesn't exist in UD at all (legacy's `errors.py`/`network.py` split is consolidated into `errors.py`). UD PR #1224 (open, stacked on #1133) adds `ReauthenticationRequest(ProgrammingError)` to `errors.py` and removes `network.py` outright, naming Snowpark's import site explicitly as the target. Gated the import (and its unit test mock in `test_server_connection.py`, which had the same unconditional-import bug) on `IS_V5_DRIVER`.
- Added test coverage for `_missing_pandas()` (had zero coverage after `test__pandas_importer()` was deleted alongside `_pandas_importer()` itself).
- Fixed 4 integration test files (`tests/integ/test_function.py`, `tests/integ/test_cte.py`, `tests/integ/scala/test_datatype_suite.py`, `tests/integ/scala/test_update_delete_merge_suite.py`) that unconditionally imported `installed_pandas` from `snowflake.connector.options` — that module is deleted outright in UD PR #1151 (confirmed: `f61156c7a` is an ancestor of `SNOW-2912540-extras-to-common`'s current tip).
- Extracted the whole `IS_V5_DRIVER`-gated options/pandas/pyarrow block out of `_internal/utils.py` into a new, dedicated `_internal/options.py` — mirrors the connector's own `options.py`/`_common.extras` 1:1, and mirrors `mock/_options.py`'s existing role as the scoped equivalent for local testing. Updated all 17 consumers (including `types.py`, whose multi-line import a naive single-line grep initially missed — caught by a regex-based sweep afterward). `options.py` computes its own `IS_V5_DRIVER` rather than importing it from `utils.py`, since `utils.py` itself needs names back from `options.py` (its modin-optional-dependency code) — importing in both directions would be circular.
- Part of the SNOW-2912540 Graphite stack decoupling Snowpark from the connector compat shim.

**Still open**: UD PRs [#1151](https://app.graphite.com/github/pr/snowflake-eng/drivers/1151), [#1152](https://app.graphite.com/github/pr/snowflake-eng/drivers/1152), [#1106](https://app.graphite.com/github/pr/snowflake-eng/drivers/1106), [#1133](https://app.graphite.com/github/pr/snowflake-eng/drivers/1133), and [#1224](https://app.graphite.com/github/pr/snowflake-eng/drivers/1224) are unmerged. This PR's `IS_V5_DRIVER=True` paths are written against their current source but unverifiable end-to-end until they merge.

## Test plan

- [ ] Verify `LocalTestOOBTelemetryService.export_queue_to_string()` still calls `SecretDetector.mask_secrets` correctly with both v4 and v5 connectors
- [x] `grep -rn "_pandas_importer" src/ tests/` → nothing; `grep -rn "MissingNumpy" src/` → only in `mock/_options.py`'s v4 branch; `grep -rn "connector\.network\b" src/ tests/unit/` → only the v4 branch of the gated imports; `grep -rn "connector\.options" tests/integ/` → nothing left; zero remaining imports of the moved names from `_internal.utils` (regex-based multi-line sweep, not just single-line grep)
- [x] `black`/`flake8` clean on all 20 touched files
- [x] Verified pandas/pyarrow/numpy/telemetry/reauth optional-dependency and import handling works as before for v4 (2420 unit tests pass, full package import succeeds end to end)
- [ ] Verify the `IS_V5_DRIVER=True` paths against `connector._common.extras`/`_common.telemetry`/`errors.ReauthenticationRequest` once UD PR #1151/#1152/#1106/#1133/#1224 merge

## Checklist

- [x] If adding any arguments to public Snowpark APIs or creating new public Snowpark APIs, I acknowledge that I have ensured my changes include AST support.
- [x] I acknowledge that I have ensured my changes to be thread-safe
