### PR TITLE
SNOW-4081342: pin build/release tooling to exact versions

### DIFF
--- a/.github/scripts/install_protoc.sh
+++ b/.github/scripts/install_protoc.sh
@@ -71,13 +71,17 @@ install() {
 
 install
 
-# mypy-protobuf is used to generated typed Python code from protobuf
+# mypy-protobuf is used to generated typed Python code from protobuf.
+# Exact-version pinned (CWE-829): protoc-gen-mypy is executed while building the
+# officially signed release, so an unpinned resolve would let a newly published
+# mypy-protobuf run arbitrary code in the release job.
+MYPY_PROTOBUF_VERSION="5.1.0"
 if command -v uv &> /dev/null; then
     echo "Using uv to install mypy-protobuf"
-    uv pip install mypy-protobuf --system
+    uv pip install "mypy-protobuf==${MYPY_PROTOBUF_VERSION}" --system
 else
     echo "uv not available, using pip to install mypy-protobuf"
-    pip install mypy-protobuf
+    pip install "mypy-protobuf==${MYPY_PROTOBUF_VERSION}"
 fi
 echo "mypy-protobuf version: $(protoc-gen-mypy --version)"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,13 +1,23 @@
 [build-system]
 requires = [
-    "setuptools",
+    # Bounded rather than exact-pinned: this file ships inside the sdist, so an
+    # exact setuptools pin would break source builds (conda-forge, distros) on
+    # newer Pythons that require a newer setuptools.
+    "setuptools>=40.6.0,<85",
     # py>=3.14: protoc-wheel-0 has no cp314 wheel on PyPI, so it cannot be installed
     # in pip's build isolation venv. setup.py falls back to shutil.which("protoc").
     "protoc-wheel-0==21.1; python_version < '3.14'", # Protocol buffer compiler for Snowpark IR
-    # py>=3.14: pin <=3.6.0 so the build isolation venv does not install mypy-protobuf 5.x,
+    # mypy-protobuf runs its protoc-gen-mypy entry point during the signed release
+    # build, so it must be exact-version pinned (CWE-829): an unpinned resolve lets a
+    # newly published release execute arbitrary code in the release job.
+    # py>=3.14: pin ==3.6.0 so the build isolation venv does not install mypy-protobuf 5.x,
     # whose extensions_pb2.py was generated with protobuf 6.x gencode and fails at import
     # time when the isolated venv resolves protobuf 5.x (Snowflake internal channel).
-    "mypy-protobuf<=3.6.0; python_version >= '3.14'",
-    "mypy-protobuf; python_version < '3.14'", # used in generating typed Python code from protobuf for Snowpark IR
+    "mypy-protobuf==3.6.0; python_version >= '3.14'",
+    # py<3.14: 5.1.0 is the version an unpinned resolve already installs today, so this
+    # pin is status-quo-preserving. Do NOT "align" it with the 3.6.0 pin above: 3.6.0
+    # emits materially different .pyi stubs (non-aliased imports, different
+    # typing_extensions handling, ~900 fewer lines) and would be a silent downgrade.
+    "mypy-protobuf==5.1.0; python_version < '3.14'", # used in generating typed Python code from protobuf for Snowpark IR
 ]
 build-backend = "setuptools.build_meta"

--- a/tests/unit/test_build_dependency_pins.py
+++ b/tests/unit/test_build_dependency_pins.py
@@ -1,0 +1,194 @@
+#!/usr/bin/env python3
+#
+# Copyright (c) 2012-2025 Snowflake Computing Inc. All rights reserved.
+#
+"""Guards against unpinned build/release tooling (SNOW-4081342, CWE-829).
+
+The release pipeline (`.github/workflows/python-publish.yml`) runs
+`.github/scripts/install_protoc.sh`, then `tox -e protoc`, then `python -m build`
+(whose `setup.py` `build_py` invokes `protoc-gen-mypy`), and finally signs and
+publishes the artifacts. Every tool installed along that path executes code inside
+a job holding `contents: write`, `id-token: write` and `PYPI_API_TOKEN`, so each
+one must be resolved at an exact version rather than "whatever is newest on PyPI".
+"""
+
+import configparser
+import re
+import tomllib
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+PYPROJECT = REPO_ROOT / "pyproject.toml"
+TOX_INI = REPO_ROOT / "tox.ini"
+INSTALL_PROTOC = REPO_ROOT / ".github" / "scripts" / "install_protoc.sh"
+
+# The version an unpinned resolve installs today on the release Python (3.11).
+# Pinning below this would silently downgrade the code generator that produces the
+# shipped ast_pb2.pyi stubs.
+EXPECTED_MYPY_PROTOBUF = "5.1.0"
+# py>=3.14 stays on 3.6.0; see the comment in pyproject.toml for why.
+EXPECTED_MYPY_PROTOBUF_PY314 = "3.6.0"
+
+
+def _requirement_names_and_specs(requirements):
+    """Split PEP 508 requirement strings into (name, specifier, marker) triples."""
+    parsed = []
+    for raw in requirements:
+        requirement, _, marker = raw.partition(";")
+        match = re.match(r"^\s*([A-Za-z0-9._-]+)\s*(.*)$", requirement)
+        assert match, f"could not parse requirement {raw!r}"
+        parsed.append((match.group(1).lower(), match.group(2).strip(), marker.strip()))
+    return parsed
+
+
+def _build_system_requires():
+    with open(PYPROJECT, "rb") as f:
+        return tomllib.load(f)["build-system"]["requires"]
+
+
+def _tox_protoc_deps():
+    parser = configparser.ConfigParser()
+    parser.read(TOX_INI)
+    raw = parser["testenv:protoc"]["deps"]
+    return [
+        line.strip()
+        for line in raw.splitlines()
+        if line.strip() and not line.strip().startswith("#")
+    ]
+
+
+# --------------------------------------------------------------------------- #
+# mypy-protobuf: the tool named in the finding. Pinned in all three files.
+# --------------------------------------------------------------------------- #
+
+
+def test_pyproject_pins_mypy_protobuf_exactly():
+    """Both marker branches of the build-system requirement use `==`."""
+    pins = {
+        marker: spec
+        for name, spec, marker in _requirement_names_and_specs(_build_system_requires())
+        if name == "mypy-protobuf"
+    }
+    assert pins, "mypy-protobuf missing from [build-system].requires"
+
+    for marker, spec in pins.items():
+        assert spec.startswith("=="), (
+            f"mypy-protobuf is not exact-version pinned in pyproject.toml "
+            f"(spec={spec!r}, marker={marker!r}). An unpinned or range-pinned build "
+            f"requirement lets a newly published release run arbitrary code during "
+            f"the signed release build (CWE-829)."
+        )
+
+    by_branch = {
+        ("py314" if "3.14" in marker and ">=" in marker else "default"): spec
+        for marker, spec in pins.items()
+    }
+    assert by_branch.get("default") == f"=={EXPECTED_MYPY_PROTOBUF}", (
+        f"the python_version < '3.14' branch must stay at {EXPECTED_MYPY_PROTOBUF}, "
+        f"the version an unpinned resolve installs today; got {by_branch.get('default')!r}. "
+        f"Downgrading it changes the generated ast_pb2.pyi stubs."
+    )
+    assert by_branch.get("py314") == f"=={EXPECTED_MYPY_PROTOBUF_PY314}"
+
+
+def test_tox_protoc_env_pins_mypy_protobuf_exactly():
+    deps = {
+        name: spec for name, spec, _ in _requirement_names_and_specs(_tox_protoc_deps())
+    }
+    assert "mypy-protobuf" in deps, "mypy-protobuf missing from [testenv:protoc] deps"
+    assert deps["mypy-protobuf"] == f"=={EXPECTED_MYPY_PROTOBUF}", (
+        f"[testenv:protoc] must exact-pin mypy-protobuf (got "
+        f"{deps['mypy-protobuf']!r}); this env is invoked by python-publish.yml."
+    )
+
+
+def test_install_protoc_script_pins_mypy_protobuf_exactly():
+    content = INSTALL_PROTOC.read_text()
+
+    # Every install invocation must carry an exact pin, in both the uv and pip branches.
+    install_lines = [
+        line.strip()
+        for line in content.splitlines()
+        if re.search(r"^\s*(uv\s+)?pip install", line)
+    ]
+    assert len(install_lines) >= 2, (
+        f"expected both the uv and pip install branches in {INSTALL_PROTOC.name}, "
+        f"found {install_lines!r}"
+    )
+    for line in install_lines:
+        assert (
+            "mypy-protobuf==" in line or "MYPY_PROTOBUF_VERSION" in line
+        ), f"unpinned mypy-protobuf install in {INSTALL_PROTOC.name}: {line!r}"
+
+    assert re.search(
+        rf'MYPY_PROTOBUF_VERSION="{re.escape(EXPECTED_MYPY_PROTOBUF)}"', content
+    ), (
+        f"{INSTALL_PROTOC.name} must pin mypy-protobuf to {EXPECTED_MYPY_PROTOBUF}, the "
+        f"version an unpinned resolve installs today on the release Python."
+    )
+
+    assert not re.search(r"(uv )?pip install\s+mypy-protobuf(\s|$)", content), (
+        f"{INSTALL_PROTOC.name} still contains a bare, unpinned "
+        f"`pip install mypy-protobuf`"
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Sibling deps installed into the same signed release job. The Mythos draft left
+# these open, so the checks are deliberately broader than the finding's title.
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.parametrize("dep", ["protoc-wheel-0", "mypy-protobuf", "protobuf"])
+def test_all_tox_protoc_deps_are_exact_pinned(dep):
+    """No dependency in the release codegen env may float."""
+    deps = {
+        name: spec for name, spec, _ in _requirement_names_and_specs(_tox_protoc_deps())
+    }
+    assert dep in deps, f"{dep} missing from [testenv:protoc] deps"
+    assert deps[dep].startswith("=="), (
+        f"{dep} is not exact-version pinned in [testenv:protoc] (spec={deps[dep]!r}). "
+        f"This env runs in the signed release job, so a floating dependency is the "
+        f"same CWE-829 sink as an unpinned mypy-protobuf."
+    )
+
+
+def test_pyproject_protoc_wheel_is_exact_pinned():
+    specs = [
+        spec
+        for name, spec, _ in _requirement_names_and_specs(_build_system_requires())
+        if name == "protoc-wheel-0"
+    ]
+    assert specs, "protoc-wheel-0 missing from [build-system].requires"
+    for spec in specs:
+        assert spec.startswith(
+            "=="
+        ), f"protoc-wheel-0 must be exact-version pinned (got {spec!r})"
+
+
+def test_pyproject_setuptools_is_bounded():
+    """setuptools is bounded rather than exact-pinned, but must not float freely.
+
+    pyproject.toml ships inside the sdist, so an exact setuptools pin would break
+    source builds (conda-forge, distros) on newer Pythons that need a newer
+    setuptools. A bounded range still removes the "any future upload is executed"
+    exposure; full hash pinning is tracked as the stronger follow-up.
+    """
+    specs = [
+        spec
+        for name, spec, _ in _requirement_names_and_specs(_build_system_requires())
+        if name == "setuptools"
+    ]
+    assert specs, "setuptools missing from [build-system].requires"
+    for spec in specs:
+        assert spec, "setuptools must not be completely unpinned in pyproject.toml"
+        assert "<" in spec, (
+            f"setuptools must carry an upper bound so an arbitrary future release is "
+            f"not executed during the signed build (got {spec!r})"
+        )
+        assert (
+            ">=" in spec
+        ), f"setuptools must keep its lower bound for PEP 517 support (got {spec!r})"

--- a/tox.ini
+++ b/tox.ini
@@ -231,9 +231,14 @@ commands =
 description = generate python code from protobuf
 allowlist_externals = bash, protoc
 deps =
+    # Exact-version pinned (CWE-829): this env is invoked by python-publish.yml and
+    # runs protoc-gen-mypy while producing the officially signed release artifacts.
     protoc-wheel-0==21.1
-    mypy-protobuf
-    protobuf
+    mypy-protobuf==5.1.0
+    # Only needs to satisfy mypy-protobuf's import; kept within the runtime
+    # protobuf<6.34 ceiling declared in setup.py. Verified byte-identical codegen
+    # output vs. the unpinned resolve.
+    protobuf==6.33.6
 commands =
     protoc --proto_path=src/snowflake/snowpark/_internal/proto/ --python_out=src/snowflake/snowpark/_internal/proto/generated --mypy_out=src/snowflake/snowpark/_internal/proto/generated/ src/snowflake/snowpark/_internal/proto/ast.proto
 


### PR DESCRIPTION
1. Which Jira issue is this PR addressing?

   Fixes SNOW-4081342

2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [x] I am adding a new dependency (no new dependency — existing build-time dependencies are pinned to exact versions)
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.
   - [x] I acknowledge that I have ensured my changes to be thread-safe (no runtime code changed — build tooling and a unit test only).
   - [x] If adding any arguments to public Snowpark APIs or creating new public Snowpark APIs, I acknowledge that I have ensured my changes include AST support (no public API changed).

3. Please describe how your code solves the related issue.

The release/build pipeline resolved the `mypy-protobuf` build tool from PyPI with **no version pin**, then executed its console entry point `protoc-gen-mypy` while producing the officially signed distribution (CWE-829). An attacker publishing a newer `mypy-protobuf` could run arbitrary code in the release job — which holds `contents: write`, `id-token: write`, and `PYPI_API_TOKEN` — and ship a signed, poisoned SDK.

Release path: `install_protoc.sh` → `tox -e protoc` → `python -m build` (whose `setup.py` `build_py` invokes `protoc-gen-mypy` via `--mypy_out`) → `sigstore sign` → publish.

### Changes

- **`.github/scripts/install_protoc.sh`** — `mypy-protobuf==5.1.0` in both the `uv` and `pip` branches.
- **`tox.ini` `[testenv:protoc]`** — `mypy-protobuf==5.1.0`; `protobuf==6.33.6` (was unpinned). Invoked by `python-publish.yml` via `tox -e protoc`.
- **`pyproject.toml` `[build-system] requires`** — `mypy-protobuf==5.1.0` for py<3.14, `==3.6.0` for py>=3.14 (was `<=3.6.0`), `setuptools>=40.6.0,<85`.
- **`tests/unit/test_build_dependency_pins.py`** — asserts exact pinning across all three files.

### Important: 5.1.0, not 3.6.0

An obvious-looking "consistency" fix here is to pin `mypy-protobuf==3.6.0` everywhere, matching the py>=3.14 constraint. **That would be a silent regression.** `mypy-protobuf` latest is 5.1.0; 3.6.0 is from April 2024. The `python_version < '3.14'` branch is what the release job actually uses (`python-publish.yml` sets up Python **3.11**), so it resolves 5.1.0 today — pinning it to 3.6.0 would downgrade the stub generator two major versions.

Measured by running the real `[testenv:protoc]` codegen command in throwaway venvs on Python 3.11:

- **5.1.0 vs 3.6.0** — `ast_pb2.py` byte-identical (emitted by `protoc`, not `mypy-protobuf`), but `ast_pb2.pyi` differs **materially**: ~900 fewer lines and every annotation spelled differently. 3.6.0 emits plain unaliased imports and gates `sys.version_info >= (3, 10)` with `import typing as typing_extensions`; 5.1.0 emits `import builtins as _builtins` / `from collections import abc as _abc` / `import typing as _typing` and gates `>= (3, 11)`.
- **pinned (5.1.0 + protobuf 6.33.6) vs today's unpinned resolve (5.1.0 + protobuf 7.36.1)** — both generated files **byte-identical**. So this PR does not change what ships.

The py>=3.14 pin stays at 3.6.0; the existing comment documents why (mypy-protobuf 5.x's bundled `extensions_pb2.py` was generated with protobuf 6.x gencode and fails to import when the py3.14 build-isolation venv resolves protobuf 5.x). `<=3.6.0` already resolved to 3.6.0, so that branch is unchanged in effect.

### Why `protobuf==6.33.6` and not latest

The unpinned resolve pulls 7.36.1, which is outside the `protobuf>=3.20,<6.34` ceiling `setup.py` declares for the runtime. 6.33.6 is the highest release under that ceiling and codegen output is byte-identical either way, so the pin is free.

### Why `setuptools` is bounded, not exact-pinned

`pyproject.toml` ships inside the sdist, so it binds conda-forge and distro source builds on Pythons that do not exist yet; an exact pin would predictably break those, since new CPython releases generally need newer setuptools. This is an explicit **partial** mitigation — it still admits new `84.x` releases. Flagging rather than claiming closed.

### Verification performed

- Codegen equivalence measured as described above (pinned vs unpinned byte-identical; 3.6.0 materially different).
- `pyproject.toml` parses via `tomllib`; `tox.ini` parses; `bash -n` clean on the script.
- `tests/unit/test_build_dependency_pins.py`: **8 pass on this branch, 6 of 8 fail against `main`.**
- `pre-commit run --files` all hooks pass.

### Limitations

Exact-version pinning does not stop a compromised **re-upload** of an existing version; only full transitive hash pinning (`--require-hashes`) does, which is platform/interpreter-specific and a reasonable follow-up. Transitive deps still float (`types-protobuf` via `mypy-protobuf`). Integrity of the `protoc` download itself is SNOW-4081338.

This PR conflicts textually with SNOW-4081338 on the final block of `install_protoc.sh`. Resolution is trivial (keep that PR's sourcing-guard indentation, keep this PR's version pin); I have verified the merged result runs correctly and all 19 tests across both suites pass.

No CHANGELOG entry: nothing user-visible changes. Codegen output is byte-identical to today's resolve, and existing CHANGELOG precedent for dependency entries covers runtime `install_requires`, not build-time tooling.
