### PR TITLE
SNOW-4081343: pin CLA assistant action to an immutable commit SHA and reduce token scope

### DIFF
--- a/.github/workflows/cla_bot.yml
+++ b/.github/workflows/cla_bot.yml
@@ -9,14 +9,27 @@ jobs:
   CLAssistant:
     runs-on: ubuntu-latest
     permissions:
-      actions: write
-      contents: write
+      # 'read' is sufficient: the action only lists/inspects workflow runs. The
+      # single write call (re-running a stale failed run) is best-effort and its
+      # failure is caught and logged, not fatal. 'write' would also allow
+      # deletion of workflow run records, so it is deliberately not granted.
+      actions: read
+      # 'read' is sufficient because the signature ledger lives in the remote
+      # repository (snowflake-eng/cla-db) and is written with
+      # PERSONAL_ACCESS_TOKEN, not GITHUB_TOKEN.
+      contents: read
+      # Required: the action creates and updates the CLA comment on the PR,
+      # lists comments to detect signatures, and locks merged PRs.
       pull-requests: write
       statuses: write
     steps:
       - name: "CLA Assistant"
         if: (github.event.comment.body == 'recheck' || github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA') || github.event_name == 'pull_request_target'
-        uses: contributor-assistant/github-action/@master
+        # Pinned to an immutable commit SHA. A mutable ref such as @master lets
+        # an upstream compromise run arbitrary code in this repository's
+        # privileged pull_request_target context with both GITHUB_TOKEN and the
+        # CLA_BOT_TOKEN PAT in scope.
+        uses: contributor-assistant/github-action@ca4a40a7d1004f18d9960b404b97e5f30a505a08 # v2.6.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PERSONAL_ACCESS_TOKEN : ${{ secrets.CLA_BOT_TOKEN }}

--- a/tests/unit/test_cla_bot_workflow_security.py
+++ b/tests/unit/test_cla_bot_workflow_security.py
@@ -1,0 +1,129 @@
+#
+# Copyright (c) 2012-2025 Snowflake Computing Inc. All rights reserved.
+#
+
+"""Security regression tests for .github/workflows/cla_bot.yml.
+
+The CLA workflow runs on ``pull_request_target``, which executes in the base
+repository's privileged security context and exposes both ``GITHUB_TOKEN`` and
+the long-lived ``CLA_BOT_TOKEN`` PAT to every step. Two properties therefore
+have to hold:
+
+1. Every third-party action is pinned to an immutable full commit SHA. A mutable
+   ref (``@master``, ``@v2``, a branch name) means an upstream compromise
+   silently gains those tokens on the next ordinary pull request.
+2. The job does not request ``actions: write``, which would permit deletion of
+   workflow run records (anti-forensics) on top of the token theft.
+"""
+
+import re
+from pathlib import Path
+
+import pytest
+
+import yaml
+
+WORKFLOW_PATH = (
+    Path(__file__).parent.parent.parent / ".github" / "workflows" / "cla_bot.yml"
+)
+
+# A full 40-character git object name, the only immutable way to reference an action.
+FULL_SHA = re.compile(r"^[0-9a-f]{40}$")
+
+
+def _load_workflow(path: Path = WORKFLOW_PATH) -> dict:
+    with open(path) as f:
+        return yaml.safe_load(f)
+
+
+def _iter_steps(workflow: dict):
+    for job_name, job in (workflow.get("jobs") or {}).items():
+        for step in job.get("steps") or []:
+            yield job_name, step
+
+
+def _iter_uses(workflow: dict):
+    """Yield (job_name, uses) for every step that references an action."""
+    for job_name, step in _iter_steps(workflow):
+        uses = step.get("uses")
+        if uses:
+            yield job_name, uses
+
+
+def collect_unpinned_actions(workflow: dict) -> list:
+    """Return every ``uses:`` value that is not pinned to a full commit SHA.
+
+    Local (``./path``) and container (``docker://``) references have no mutable
+    upstream ref and are ignored.
+    """
+    unpinned = []
+    for job_name, uses in _iter_uses(workflow):
+        if uses.startswith("./") or uses.startswith("docker://"):
+            continue
+        ref = uses.rpartition("@")[2] if "@" in uses else ""
+        if not FULL_SHA.match(ref):
+            unpinned.append((job_name, uses))
+    return unpinned
+
+
+def collect_actions_write_jobs(workflow: dict) -> list:
+    """Return jobs (and the workflow root) granting ``actions: write``."""
+    offenders = []
+    scopes = [("<workflow>", workflow.get("permissions"))]
+    for job_name, job in (workflow.get("jobs") or {}).items():
+        scopes.append((job_name, job.get("permissions")))
+    for name, permissions in scopes:
+        # A bare `permissions: write-all` grants actions: write implicitly.
+        if permissions == "write-all":
+            offenders.append(name)
+        elif isinstance(permissions, dict) and permissions.get("actions") == "write":
+            offenders.append(name)
+    return offenders
+
+
+def test_workflow_is_valid_yaml_and_has_steps():
+    workflow = _load_workflow()
+    assert workflow.get("jobs"), "cla_bot.yml defines no jobs"
+    assert list(_iter_uses(workflow)), "expected at least one `uses:` step"
+
+
+def test_all_actions_pinned_to_full_commit_sha():
+    unpinned = collect_unpinned_actions(_load_workflow())
+    assert not unpinned, (
+        "cla_bot.yml runs in a privileged pull_request_target context; every "
+        "action must be pinned to a full 40-character commit SHA (with a "
+        f"trailing `# vX.Y.Z` comment). Unpinned: {unpinned}"
+    )
+
+
+def test_pinned_actions_carry_a_version_comment():
+    """A bare SHA is unreviewable; require the `# vX.Y.Z` annotation."""
+    text = WORKFLOW_PATH.read_text()
+    for line in text.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("uses:") or stripped.startswith("- uses:"):
+            assert (
+                "#" in stripped
+            ), f"`uses:` line lacks a version comment: {stripped!r}"
+
+
+def test_actions_write_not_granted():
+    offenders = collect_actions_write_jobs(_load_workflow())
+    assert not offenders, (
+        "`actions: write` allows deletion of workflow run records and must not "
+        f"be granted in cla_bot.yml. Granted by: {offenders}"
+    )
+
+
+def test_privileged_trigger_still_guarded_by_permissions_block():
+    """Any job reachable from pull_request_target must scope its token down."""
+    workflow = _load_workflow()
+    # `on` is parsed as the boolean True by PyYAML unless quoted in the file.
+    triggers = workflow.get("on", workflow.get(True)) or {}
+    if "pull_request_target" not in triggers:
+        pytest.skip("cla_bot.yml no longer uses pull_request_target")
+    for job_name, job in workflow["jobs"].items():
+        assert (
+            workflow.get("permissions") is not None
+            or job.get("permissions") is not None
+        ), f"job {job_name} inherits default token permissions"


### PR DESCRIPTION
1. Which Jira issue is this PR addressing?

   Fixes SNOW-4081343

2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.
   - [x] I acknowledge that I have ensured my changes to be thread-safe (no runtime code changed — a workflow and a unit test only).
   - [x] If adding any arguments to public Snowpark APIs or creating new public Snowpark APIs, I acknowledge that I have ensured my changes include AST support (no public API changed).

3. Please describe how your code solves the related issue.

`.github/workflows/cla_bot.yml` referenced the CLA action as `contributor-assistant/github-action/@master` — a **mutable ref** on a public third-party action (CWE-494). This is the highest-likelihood item in this batch (Mythos: likelihood 6/10) because it fires on *every* routine PR.

An attacker with maintainer control of that repository retargets `master`; any PR being opened or synchronized then fires `pull_request_target`, which runs in the **base repository's** privileged context — the attacker needs no access to anyone's branch or fork. The malicious step receives both `GITHUB_TOKEN` (with `actions`/`contents`/`pull-requests`/`statuses` write) and the long-lived `CLA_BOT_TOKEN` PAT trusted against `snowflake-eng/cla-db`. Consequences: private source disclosure, ref/release/status/PR manipulation, deletion of workflow-run records via `actions: write` (anti-forensics), and durable read/falsification of the shared CLA signature ledger with the stolen PAT — which changes in this repo alone cannot revoke.

### Changes

1. Pinned to `contributor-assistant/github-action@ca4a40a7d1004f18d9960b404b97e5f30a505a08 # v2.6.1`. Verified via four independent `gh api` lookups: `releases/latest` → `v2.6.1`, `git/ref/tags/v2.6.1` → exactly that SHA (`type: commit`), the `tags` listing agrees, and `commits/<sha>` resolves. `master` head is currently ahead of the last release, so the **reviewed release tag** was pinned rather than an unreleased head. Also dropped the stray trailing slash before `@`.
2. `actions: write` → `actions: read` and `contents: write` → `contents: read`.

### Permission analysis — evidence, and one thing worth reviewer attention

I checked both `src/` and the built `dist/index.js`, since `action.yml` declares `main: 'dist/index.js'`. Source alone would have misled me here.

- **`actions: write` → `read`.** `src/pullRerunRunner.ts` is the only `actions` consumer: three reads (`listRepoWorkflows`, `listWorkflowRuns`, `getWorkflowRun`) plus one write (`reRunWorkflow`), all present in the bundle. The write is wrapped in `.catch(core.error)` → non-fatal. The **reads are not guarded**: `getSelfWorkflowId()` throws, which propagates to `setupClaCheck`'s catch → `core.setFailed`. So removing `actions` **entirely would have hard-failed the CLA gate for every contributor** — hence `read` rather than removal. Tradeoff: the best-effort re-run of a stale failed run stops working and logs a non-fatal error. The action's own source comment notes that API needs a PAT anyway, so it likely never worked with `GITHUB_TOKEN` here.
- **`contents: write` → `read`.** The upstream README annotates the scope literally: `contents: write # this can be 'read' if the signatures are in remote repository` — and this workflow *does* set `remote-organization-name`/`remote-repository-name`. `persistence.ts` confirms the mechanism: all three ledger operations route through `getPATOctokit()` when a remote repo is configured, so the ledger is written with the PAT, not `GITHUB_TOKEN`. The one `GITHUB_TOKEN` `contents: write` path, `addEmptyCommit.ts`, is **dead code at v2.6.1** — no caller in `src/`, and its log string `"Adding empty commit for"` has zero occurrences in `dist/index.js`.
- **`pull-requests: write` kept** — clearly required: `issues.createComment`/`updateComment`/`listComments`, `pulls.get`, `issues.lock`.
- **`statuses: write` kept, and flagged.** My evidence says it is *unused* — no `createCommitStatus` or `checks.*` call site in `src/`, and the single `createCommitStatus` hit in `dist/index.js` is just a route-table entry in the bundled `@octokit/plugin-rest-endpoint-methods`. But the upstream README still documents it as required, the security value of dropping it is low, and a wrong call blocks every external contributor — so it was kept deliberately, documented here for a possible follow-up.

### Verification performed

- YAML parses; job `CLAssistant` intact.
- `actionlint` 1.7.12 on the changed workflow: **no findings**.
- Behaviour preservation proven programmatically: `name`, `if`, all `with:` inputs, both `env:` mappings, and the `on:` triggers compare **identical** pre/post. Only `uses:` and `permissions:` differ.
- `tests/unit/test_cla_bot_workflow_security.py`: 5 tests (all `uses:` pinned to 40-hex SHA, each pin carries a version comment, `actions: write` not granted — also catching `permissions: write-all` — and every job under `pull_request_target` has an explicit `permissions` block). **5 pass on this branch, 3 fail against `main`.**
- `pre-commit run --files` all hooks pass.

### Reviewer attention requested

The SHA pin is behaviour-neutral, but **the permission reduction is a deliberate functional change to CI** and is the part worth scrutiny. It cannot be exercised before merge: `pull_request_target` only runs in the base repo, so all verification above is static and API-backed. **Please confirm the CLA gate still functions on the first external PR after merge.** If you would rather land the two independently, the permission changes can be split into a follow-up leaving only the pin here — say so and I will split it.

### Follow-ups (deliberately not in this PR)

The same mutable-ref pattern exists elsewhere in this repo and Mythos filed no tickets for it: `atlassian/gajira-login@master` in `.github/workflows/jira_close.yml` and `.github/workflows/jira_comment.yml`, `atlassian/gajira-comment@master` in `jira_comment.yml` (all three carry `JIRA_API_TOKEN`), and `snowflakedb/gh-actions@jira_v1` — a mutable **branch** ref checked out with `SNOWFLAKE_GITHUB_TOKEN`. A repo-wide SHA-pinning pass plus a Dependabot `github-actions` policy is the durable fix.

Separately, `CLA_BOT_TOKEN` is a classic PAT. It should be replaced with a GitHub App installation token or a fine-grained token scoped to only `snowflake-eng/cla-db`, and the existing PAT revoked after cutover. That is an infrastructure change requiring secret rotation, so it is not attempted here; the secret is left untouched.

No CHANGELOG entry: this changes only CI and nothing user-facing, consistent with existing practice (no entry in the CHANGELOG history references workflows or GitHub Actions).
