### PR TITLE
Fix ai_extract FILE input routing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Release History
 
+## 1.56.0 (TBD)
+
+### Snowpark Python API Updates
+
+#### New Features
+
+#### Bug Fixes
+
+- Fixed `ai_extract` misrouting FILE-type inputs to the TEXT overload when `scores` or `config` were also supplied.
+
 ## 1.55.0 (TBD)
 
 ### Snowpark Python API Updates

--- a/src/snowflake/snowpark/functions.py
+++ b/src/snowflake/snowpark/functions.py
@@ -13173,40 +13173,27 @@ def ai_extract(
     else:
         ast = None
 
-    # Use named-argument form when scores or config is requested
-    if scores is not None or config is not None:
-        response_format_col = sql_expr(
-            _python_obj_to_sql_literal(response_format), is_constant=True
-        )
-        # Detect file vs text input: TO_FILE() calls produce a FunctionExpression named "to_file"
-        is_file = (
-            isinstance(input_col, Column)
-            and isinstance(input_col._expr1, FunctionExpression)
-            and input_col._expr1.name.upper() == "TO_FILE"
-        )
-        input_key = "file" if is_file else "text"
-        call_kwargs: Dict[str, Column] = {
-            input_key: input_col,
-            "responseFormat": response_format_col,
-        }
-        if config is not None:
-            call_kwargs["config"] = sql_expr(
-                _python_obj_to_sql_literal(config), is_constant=True
-            )
-        if scores is not None:
-            call_kwargs["scores"] = lit(scores)
-        return _call_named_arguments_function(
-            sql_func_name, call_kwargs, _ast=ast, _emit_ast=_emit_ast
-        )
-
-    # Default: positional form (backward-compatible)
+    # Keep input and response_format positional so Snowflake's server-side
+    # overload resolution (FILE vs. TEXT) works correctly for all input types.
     response_format_col = sql_expr(
         _python_obj_to_sql_literal(response_format), is_constant=True
     )
+    call_args = [input_col, response_format_col]
+    if scores is not None:
+        call_args.append(
+            sql_expr(
+                f"scores => {_python_obj_to_sql_literal(scores)}", is_constant=True
+            )
+        )
+    if config is not None:
+        call_args.append(
+            sql_expr(
+                f"config => {_python_obj_to_sql_literal(config)}", is_constant=True
+            )
+        )
     return _call_function(
         sql_func_name,
-        input_col,
-        response_format_col,
+        *call_args,
         _ast=ast,
         _emit_ast=_emit_ast,
     )

--- a/tests/integ/test_dataframe_ai.py
+++ b/tests/integ/test_dataframe_ai.py
@@ -1262,6 +1262,45 @@ def test_dataframe_ai_extract_file_column_referenced_from_earlier_step_with_scor
     assert "scoring" in data
 
 
+def test_dataframe_ai_extract_file_column_referenced_from_earlier_step_with_config(
+    session, resources_path
+):
+    """A FILE column from an earlier step must route correctly when config is supplied.
+
+    config forces a named-argument SQL call; the fix keeps input and response_format
+    positional so Snowflake's server-side FILE vs. TEXT overload resolution still works
+    for FILE values that were computed upstream (not inline at the call site).
+    """
+    stage_name = Utils.random_stage_name()
+    _ = session.sql(
+        f"CREATE OR REPLACE TEMP STAGE {stage_name} ENCRYPTION = (TYPE = 'SNOWFLAKE_SSE')"
+    ).collect()
+    file_local = TestFiles(resources_path).test_invoice_pdf
+    _ = session.file.put(file_local, f"@{stage_name}", auto_compress=False)
+
+    df = session.create_dataframe(
+        [[f"@{stage_name}/invoice.pdf"]], schema=["file_path"]
+    )
+    # FILE value computed one step before ai.extract() -- not inline at the call site.
+    file_df = df.select(to_file(col("file_path")).alias("F"))
+
+    result_df = file_df.ai.extract(
+        input_column="F",
+        response_format=[
+            ["date", "What is the invoice date?"],
+            ["amount", "What is the amount?"],
+        ],
+        config={"scale_factor": 1.0},
+        output_column="info",
+    )
+
+    results = result_df.collect(_emit_ast=False)
+    data = json.loads(results[0]["INFO"]) if results[0]["INFO"] else {}
+    assert isinstance(data, dict) and isinstance(data.get("response", {}), dict)
+    assert data["response"]["date"] == "Nov 26, 2016"
+    assert data["response"]["amount"] == "USD $950.00"
+
+
 def test_dataframe_ai_extract_error_handling(session):
     """Test error handling in DataFrame.ai.extract."""
     df = session.create_dataframe([["text"]], schema=["col"])

--- a/tests/integ/test_dataframe_ai.py
+++ b/tests/integ/test_dataframe_ai.py
@@ -1224,6 +1224,44 @@ def test_dataframe_ai_extract_file(session, resources_path):
     assert data["response"]["amount"] == "USD $950.00"
 
 
+def test_dataframe_ai_extract_file_column_referenced_from_earlier_step_with_scores(
+    session, resources_path
+):
+    """A FILE column computed in an earlier step and merely referenced later
+    (by name, not as an inline to_file() call) must still route to AI_EXTRACT's
+    file input, even when scores forces named-argument SQL."""
+    stage_name = Utils.random_stage_name()
+    _ = session.sql(
+        f"CREATE OR REPLACE TEMP STAGE {stage_name} ENCRYPTION = (TYPE = 'SNOWFLAKE_SSE')"
+    ).collect()
+    file_local = TestFiles(resources_path).test_invoice_pdf
+    _ = session.file.put(file_local, f"@{stage_name}", auto_compress=False)
+
+    df = session.create_dataframe(
+        [[f"@{stage_name}/invoice.pdf"]], schema=["file_path"]
+    )
+    # The FILE value is computed here, one step before ai.extract() is called --
+    # not passed as an inline to_file(...) expression at the call site.
+    file_df = df.select(to_file(col("file_path")).alias("F"))
+
+    result_df = file_df.ai.extract(
+        input_column="F",
+        response_format=[
+            ["date", "What is the invoice date?"],
+            ["amount", "What is the amount?"],
+        ],
+        scores=True,
+        output_column="info",
+    )
+
+    results = result_df.collect(_emit_ast=False)
+    data = json.loads(results[0]["INFO"]) if results[0]["INFO"] else {}
+    assert isinstance(data, dict) and isinstance(data.get("response", {}), dict)
+    assert data["response"]["date"] == "Nov 26, 2016"
+    assert data["response"]["amount"] == "USD $950.00"
+    assert "scoring" in data
+
+
 def test_dataframe_ai_extract_error_handling(session):
     """Test error handling in DataFrame.ai.extract."""
     df = session.create_dataframe([["text"]], schema=["col"])

--- a/tests/unit/test_function.py
+++ b/tests/unit/test_function.py
@@ -425,3 +425,51 @@ def test_ai_extract_list_value_special_characters_escaped():
     # Single quotes are doubled and the backslash is doubled inside the literal.
     assert "a''b\\\\c" in sql
     assert sql.count("'") % 2 == 0
+
+
+def _render_ai_extract_sql_with_opts(response_format, scores=None, config=None):
+    """Like _render_ai_extract_sql but also accepts scores/config."""
+    column = ai_extract(
+        "INPUT_TEXT", response_format, scores=scores, config=config, _emit_ast=False
+    )
+    expr = column._expression
+    children = [
+        child.name if hasattr(child, "name") else "<input>" for child in expr.children
+    ]
+    return function_expression(expr.name, children, False)
+
+
+def test_ai_extract_scores_named_arg_sql():
+    # scores=True must appear as a trailing named arg; input and response_format
+    # stay positional so server-side FILE vs. TEXT overload resolution works.
+    sql = _render_ai_extract_sql_with_opts({"city": "What city?"}, scores=True)
+    assert sql.startswith("ai_extract(<input>, ")
+    assert "scores => true" in sql
+    # input (positional) comes before scores (named)
+    assert sql.index("<input>") < sql.index("scores =>")
+
+
+def test_ai_extract_config_named_arg_sql():
+    # config must appear as a trailing named arg; input and response_format
+    # stay positional so server-side FILE vs. TEXT overload resolution works.
+    sql = _render_ai_extract_sql_with_opts(
+        {"city": "What city?"}, config={"scale_factor": 2.0}
+    )
+    assert sql.startswith("ai_extract(<input>, ")
+    assert "config => " in sql
+    assert "scale_factor" in sql
+    # input (positional) comes before config (named)
+    assert sql.index("<input>") < sql.index("config =>")
+
+
+def test_ai_extract_scores_and_config_named_arg_sql():
+    # When both scores and config are provided, both appear as trailing named args.
+    sql = _render_ai_extract_sql_with_opts(
+        {"city": "What city?"}, scores=True, config={"scale_factor": 1.5}
+    )
+    assert sql.startswith("ai_extract(<input>, ")
+    assert "scores => true" in sql
+    assert "config => " in sql
+    assert "scale_factor" in sql
+    assert sql.index("<input>") < sql.index("scores =>")
+    assert sql.index("<input>") < sql.index("config =>")


### PR DESCRIPTION
<!---
Please answer these questions before creating your pull request. Thanks!
--->

1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   <!---
   In this section, please add a Snowflake Jira issue number.

   Note that if a corresponding GitHub issue exists, you should still include
   the Snowflake Jira issue number. For example, for GitHub issue
   https://github.com/snowflakedb/snowpark-python/issues/1400, you should
   add "SNOW-1335071" here.
    --->

   Fixes SNOW-NNNNNNN

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.
   - [x] I acknowledge that I have ensured my changes to be thread-safe. Follow the link for more information: [Thread-safe Developer Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#thread-safe-development)
   - [x] If adding any arguments to public Snowpark APIs or creating new public Snowpark APIs, I acknowledge that I have ensured my changes include AST support. Follow the link for more information: [AST Support Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#ast-abstract-syntax-tree-support-in-snowpark)

3. Please describe how your code solves the related issue.

   Please write a short description of how your code change solves the related issue.

This PR fixes a bug where `ai_extract` misrouted `FILE` columns as text when `scores` or `config` arguments were used.

`ai_extract` previously only recognized a `FILE` input when it was an inline `to_file()` call. A `FILE` column computed in an earlier step and referenced later by name got silently routed as text, failing with the error: `named arguments do not match any signature for function AI_EXTRACT`.
https://docs.snowflake.com/en/sql-reference/functions/ai_extract#syntax
* Keeps `input` and `response_format` as positional arguments. This lets Snowflake resolve `FILE` vs. text type, and appends `scores` and `config` as trailing named arguments if applicable
* Added a regression test with a `FILE` column built in an earlier step and referenced by name -- confirmed the test fails on main and passes with this fix.