### PR TITLE
Fix FILE type nullable schema expression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 #### Bug Fixes
 
 - Fixed `ai_extract` misrouting FILE-type inputs to the TEXT overload when `scores` or `config` were also supplied.
+- Fixed the nullable `FILE` column schema expression.
 
 ## 1.55.0 (TBD)
 

--- a/src/snowflake/snowpark/_internal/analyzer/datatype_mapper.py
+++ b/src/snowflake/snowpark/_internal/analyzer/datatype_mapper.py
@@ -554,6 +554,8 @@ def schema_expression(data_type: DataType, is_nullable: bool) -> str:
             return "TRY_TO_GEOGRAPHY(NULL)"
         if isinstance(data_type, GeometryType):
             return "TRY_TO_GEOMETRY(NULL)"
+        if isinstance(data_type, FileType):
+            return "TRY_TO_FILE(NULL)"
         if isinstance(data_type, ArrayType) and not data_type.structured:
             return "PARSE_JSON('NULL') :: ARRAY"
         if isinstance(data_type, MapType) and not data_type.structured:

--- a/tests/integ/test_dataframe_reader_file.py
+++ b/tests/integ/test_dataframe_reader_file.py
@@ -11,7 +11,7 @@ import pyarrow.parquet as pq
 import pytest
 
 from snowflake.snowpark._internal.utils import TempObjectType
-from snowflake.snowpark.functions import col, fl_get_file_type
+from snowflake.snowpark.functions import col, flatten, fl_get_file_type, lit
 from snowflake.snowpark.types import FileType, TimestampType
 from tests.utils import Utils, TestFiles
 
@@ -451,3 +451,18 @@ def test_parquet_pattern_infer_with_metadata_files(session):
 
     finally:
         Utils.drop_stage(session, stage_name)
+
+
+def test_nullable_file_column_schema_after_join_table_function(session):
+    """Nullable FILE column must not break schema resolution after join_table_function."""
+    files_df = session.sql("SELECT TRY_TO_FILE(NULL) AS F")
+
+    # join_table_function() causes the schema query to cross a join boundary;
+    # a subsequent with_column forces schema re-resolution on the joined plan.
+    joined = files_df.join_table_function(flatten(lit([1, 2, 3])))
+    extra = joined.with_column("DOUBLE_INDEX", col("INDEX") * 2)
+
+    # Before the fix this raised a server error ("invalid expression NULL :: FILE").
+    columns = extra.columns
+    assert "F" in columns
+    assert "DOUBLE_INDEX" in columns

--- a/tests/unit/test_datatype_mapper.py
+++ b/tests/unit/test_datatype_mapper.py
@@ -31,6 +31,7 @@ from snowflake.snowpark.types import (
     DecFloatType,
     DecimalType,
     DoubleType,
+    FileType,
     FloatType,
     GeographyType,
     GeometryType,
@@ -73,6 +74,7 @@ def test_to_sql():
     assert to_sql(None, StructType([])) == "NULL"
     assert to_sql(None, GeographyType()) == "NULL"
     assert to_sql(None, GeometryType()) == "NULL"
+    assert to_sql(None, FileType()) == "TO_FILE(NULL)"
 
     assert to_sql(None, IntegerType()) == "NULL :: INT"
     assert to_sql(None, ShortType()) == "NULL :: INT"
@@ -420,6 +422,7 @@ def test_to_sql_system_function():
     assert to_sql_no_cast(None, StructType([])) == "NULL"
     assert to_sql_no_cast(None, GeographyType()) == "NULL"
     assert to_sql_no_cast(None, GeometryType()) == "NULL"
+    assert to_sql_no_cast(None, FileType()) == "NULL"
 
     assert to_sql_no_cast(None, IntegerType()) == "NULL"
     assert to_sql_no_cast(None, ShortType()) == "NULL"
@@ -828,7 +831,8 @@ def test_schema_expression():
         schema_expression(DayTimeIntervalType(), True)
         == "NULL :: INTERVAL DAY TO SECOND"
     )
-
+    assert schema_expression(FileType(), True) == "TRY_TO_FILE(NULL)"
+    assert schema_expression(FileType(), False).startswith("TO_FILE(")
     assert (
         schema_expression(GeographyType(), False)
         == "to_geography('POINT(-122.35 37.55)')"


### PR DESCRIPTION
<!---
Please answer these questions before creating your pull request. Thanks!
--->

1. Which Jira issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   <!---
   In this section, please add a Snowflake Jira issue number.

   Note that if a corresponding GitHub issue exists, you should still include
   the Snowflake Jira issue number. For example, for GitHub issue
   https://github.com/snowflakedb/snowpark-python/issues/1400, you should
   add "SNOW-1335071" here.
    --->

   Fixes SNOW-NNNNNNN

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
      - [ ] If this test skips Local Testing mode, I'm requesting review from @snowflakedb/local-testing
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   - [ ] If this is a new feature/behavior, I'm adding the Local Testing parity changes.
   - [x] I acknowledge that I have ensured my changes to be thread-safe. Follow the link for more information: [Thread-safe Developer Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#thread-safe-development)
   - [x] If adding any arguments to public Snowpark APIs or creating new public Snowpark APIs, I acknowledge that I have ensured my changes include AST support. Follow the link for more information: [AST Support Guidelines](https://github.com/snowflakedb/snowpark-python/blob/main/CONTRIBUTING.md#ast-abstract-syntax-tree-support-in-snowpark)

3. Please describe how your code solves the related issue.

   Please write a short description of how your code change solves the related issue.

Fix schema evaluation failures for nullable `FILE` columns
* **The Issue:** `schema_expression()` previously generated a `NULL :: FILE` placeholder for nullable `FILE` columns when computing a describe-only schema query. The server rejects this placeholder when it has to cross a table-function join boundary (e.g., a `FILE` column joined via `join_table_function()`). This breaks `.columns` and `.schema` calls on otherwise-valid DataFrames.
* **The Fix:** Replaces the `NULL :: FILE` placeholder with `TRY_TO_FILE(NULL)`. This matches the same robust pattern already used for `GeographyType` and `GeometryType` within the same function.